### PR TITLE
ENH: Modernize build system using ExternalProjectDependency CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SLICERRT_VERSION_PATCH "0")
 set(SLICERRT_VERSION ${SLICERRT_VERSION_MAJOR}.${SLICERRT_VERSION_MINOR}.${SLICERRT_VERSION_PATCH})
 
 #-----------------------------------------------------------------------------
+# Extension meta-information
 set(EXTENSION_HOMEPAGE "http://slicerrt.org")
 set(EXTENSION_CATEGORY "Radiotherapy")
 set(EXTENSION_CONTRIBUTORS "Csaba Pinter (PerkLab, Queen's University), Andras Lasso (PerkLab, Queen's University), Greg Sharp (Massachusetts General Hospital), Kevin Wang (Radiation Medicine Program, Princess Margaret Hospital, University Health Network Toronto)")
@@ -20,7 +21,10 @@ set(EXTENSION_STATUS "Beta")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated list or 'NA' if any
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
 
+set(SUPERBUILD_TOPLEVEL_PROJECT inner)
+
 #-----------------------------------------------------------------------------
+# Extension dependencies
 find_package(Slicer COMPONENTS ConfigurePrerequisites REQUIRED)
 project(SlicerRT)
 find_package(Slicer REQUIRED)
@@ -28,15 +32,17 @@ include(${Slicer_USE_FILE})
 mark_as_superbuild(Slicer_DIR)
 
 #-----------------------------------------------------------------------------
-option(${EXTENSION_NAME}_SUPERBUILD "Build ${EXTENSION_NAME} and the projects it depends on via SuperBuild.cmake." ON)
+option(SLICERRT_ENABLE_EXPERIMENTAL_MODULES "Enable the building of work-in-progress, experimental modules." OFF)
+mark_as_superbuild(SLICERRT_ENABLE_EXPERIMENTAL_MODULES)
+
+#-----------------------------------------------------------------------------
+# SuperBuild setup
+option(${EXTENSION_NAME}_SUPERBUILD "Build ${EXTENSION_NAME} and the projects it depends on." ON)
 mark_as_advanced(${EXTENSION_NAME}_SUPERBUILD)
 if(${EXTENSION_NAME}_SUPERBUILD)
   include("${CMAKE_CURRENT_SOURCE_DIR}/SuperBuild.cmake")
   return()
 endif()
-
-#-----------------------------------------------------------------------------
-OPTION(SLICERRT_ENABLE_EXPERIMENTAL_MODULES "Enable the building of work-in-progress, experimental modules." OFF)
 
 #-----------------------------------------------------------------------------
 # Plastimatch_DIR is only used now by experimental modules. Print the

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -1,86 +1,58 @@
-#-----------------------------------------------------------------------------
-# Enable and setup External project global properties
-#-----------------------------------------------------------------------------
-include(ExternalProject)
-set(ep_base        "${CMAKE_BINARY_DIR}")
-
-# Compute -G arg for configuring external projects with the same CMake generator:
-if(CMAKE_EXTRA_GENERATOR)
-  set(gen "${CMAKE_EXTRA_GENERATOR} - ${CMAKE_GENERATOR}")
-else()
-  set(gen "${CMAKE_GENERATOR}")
-endif()
 
 #-----------------------------------------------------------------------------
-# Build options
+# External project common settings
 #-----------------------------------------------------------------------------
 
-OPTION(SLICERRT_ENABLE_EXPERIMENTAL_MODULES "Enable the building of work-in-progress, experimental modules." OFF)
+set(ep_common_c_flags "${CMAKE_C_FLAGS_INIT} ${ADDITIONAL_C_FLAGS}")
+set(ep_common_cxx_flags "${CMAKE_CXX_FLAGS_INIT} ${ADDITIONAL_CXX_FLAGS}")
 
 #-----------------------------------------------------------------------------
-# Project dependencies
+# Top-level "external" project
 #-----------------------------------------------------------------------------
 
-set(inner_DEPENDENCIES "Plastimatch")
-
-SlicerMacroCheckExternalProjectDependency(inner)
-
-set(ep_cmake_args)
 foreach(dep ${EXTENSION_DEPENDS})
-  list(APPEND ep_cmake_args -D${dep}_DIR:PATH=${${dep}_DIR})
-#  message("--------------dep:${dep}")
+  mark_as_superbuild(${dep}_DIR)
 endforeach()
 
-set(proj inner)
+set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
+
+# Project dependencies
+set(${proj}_DEPENDS
+  Plastimatch
+  )
+
+ExternalProject_Include_Dependencies(${proj}
+  PROJECT_VAR proj
+  SUPERBUILD_VAR ${EXTENSION_NAME}_SUPERBUILD
+  )
 
 ExternalProject_Add(${proj}
+  ${${proj}_EP_ARGS}
   DOWNLOAD_COMMAND ""
   INSTALL_COMMAND ""
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
   BINARY_DIR ${EXTENSION_BUILD_SUBDIRECTORY}
-  CMAKE_GENERATOR ${gen}
-  CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+  CMAKE_CACHE_ARGS
+    # Compiler settings
+    -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+    -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+    -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+    -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+    -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+    # Output directories
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-    -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
-    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
-    -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}
-    -DADDITIONAL_C_FLAGS:STRING=${ADDITIONAL_C_FLAGS}
-    -DADDITIONAL_CXX_FLAGS:STRING=${ADDITIONAL_CXX_FLAGS}
+    # Superbuild
     -D${EXTENSION_NAME}_SUPERBUILD:BOOL=OFF
     -DEXTENSION_SUPERBUILD_BINARY_DIR:PATH=${${EXTENSION_NAME}_BINARY_DIR}
-    -DSLICERRT_ENABLE_EXPERIMENTAL_MODULES:BOOL=${SLICERRT_ENABLE_EXPERIMENTAL_MODULES}
-    -DPlastimatch_DIR:PATH=${SLICERRT_PLASTIMATCH_DIR}
-    # Slicer
-    -DSlicer_DIR:PATH=${Slicer_DIR}
+    # Packaging
     -DMIDAS_PACKAGE_EMAIL:STRING=${MIDAS_PACKAGE_EMAIL}
     -DMIDAS_PACKAGE_API_KEY:STRING=${MIDAS_PACKAGE_API_KEY}
-    -DSubversion_SVN_EXECUTABLE:STRING=${Subversion_SVN_EXECUTABLE}
-    -DGIT_EXECUTABLE:STRING=${GIT_EXECUTABLE}
-    ${ep_cmake_args}
   DEPENDS
-    ${${proj}_DEPENDENCIES}
+    ${${proj}_DEPENDS}
   )
 
-# This custom external project step forces the build and later
-# steps to run whenever a top level build is done...
-#
-# BUILD_ALWAYS flag is available in CMake 3.1 that allows force build
-# of external projects without this workaround. Remove this workaround
-# and use the CMake flag instead, when Slicer's required minimum CMake
-# version will be at least 3.1.
-#
-if(CMAKE_CONFIGURATION_TYPES)
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
-else()
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build")
-endif()
-ExternalProject_Add_Step(${proj} forcebuild
-  COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_STAMP_FILE}
-  COMMENT "Forcing build step for '${proj}'"
-  DEPENDEES build
-  ALWAYS 1
-  )
+ExternalProject_AlwaysConfigure(${proj})

--- a/SuperBuild/External_Plastimatch.cmake
+++ b/SuperBuild/External_Plastimatch.cmake
@@ -1,91 +1,91 @@
-#-----------------------------------------------------------------------------
-# External projects
-#-----------------------------------------------------------------------------
 
-if (Plastimatch_DIR)
-  # Plastimatch is built already, so just use that
-  set(SLICERRT_PLASTIMATCH_DIR ${Plastimatch_DIR} CACHE INTERNAL "Path to store Plastimatch binaries.")
-  message(STATUS "Use Plastimatch library at ${SLICERRT_PLASTIMATCH_DIR}")  
-  # Define a "empty" project in case an external one is provided
-  # Doing so allows to keep the external project dependency system happy.
-  ExternalProject_Add(Plastimatch
-    SOURCE_DIR ${CMAKE_BINARY_DIR}/PlastimatchSurrogate
-    BINARY_DIR PlastimatchSurrogate-build
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    DEPENDS ""
+set(proj Plastimatch)
+
+# Set dependency list
+set(${proj}_DEPENDS "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED Plastimatch_DIR AND NOT EXISTS ${Plastimatch_DIR})
+  message(FATAL_ERROR "Plastimatch_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
+    "https://gitlab.com/plastimatch/plastimatch.git" # Gitlab only support https for anonymous checkout
+    QUIET
     )
-  return()
-endif ()
 
-# Download and build Plastimatch
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
+    "a3b76e2779ef2f227d0e2a3a4b981d990e4ed671"
+    QUIET
+    )
 
-SET (DCMTK_DIR "${Slicer_DIR}/../DCMTK-build")
-SET (SLICERRT_PLASTIMATCH_SOURCE_DIR "${CMAKE_BINARY_DIR}/Plastimatch" CACHE INTERNAL "Path to store Plastimatch sources.")
-SET (SLICERRT_PLASTIMATCH_DIR "${CMAKE_BINARY_DIR}/Plastimatch-build" CACHE INTERNAL "Path to store Plastimatch binaries.")
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
-# Choose which Plastimatch components to build
-set (PLASTIMATCH_EXTRA_LIBRARIES 
-  -DPLM_CONFIG_LIBRARY_BUILD:BOOL=ON 
-  -DPLMLIB_CONFIG_ENABLE_REGISTER:BOOL=TRUE
-  -DPLMLIB_CONFIG_ENABLE_DOSE:BOOL=TRUE)
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 
-# Choose which Plastimatch revision to build
-set (PLM_GIT_TAG "a3b76e2779ef2f227d0e2a3a4b981d990e4ed671")
+  if(WIN32)
+    # Disable OpenMP on Windows until a better solution can be found
+    # http://www.na-mic.org/Bug/view.php?id=3823
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      "-DPLM_CONFIG_NOMANIFEST:BOOL=ON"  # Internally set PLM_LINK_FLAGS to build without manifest on windows
+      )
+  endif()
 
-# Figure out whether to use git or https
-if(NOT DEFINED git_protocol)
-  #set(git_protocol "git")
-  set(git_protocol "https")
-endif()
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+      -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+      -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+      # Output directories
+      -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_BIN_DIR}
+      -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_LIB_DIR}
+      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+      # Install directories
+      # NA
+      # Dependencies (satisfied by Slicer)
+     -DDCMTK_DIR:STRING=${DCMTK_DIR}  # XXX What happen is Slicer is built without DICOM support ?
+     -DITK_DIR:STRING=${ITK_DIR}
+     -DVTK_DIR:STRING=${VTK_DIR}
+      # Options
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DBUILD_TESTING:BOOL=OFF
+      -DPLM_CONFIG_DISABLE_CUDA:BOOL=ON  # CUDA build is disabled until ticket #226 can be resolved.
+      -DPLM_CONFIG_LIBRARY_BUILD:BOOL=ON
+      -DPLM_CONFIG_INSTALL_LIBRARIES:BOOL=ON
+      -DPLMLIB_CONFIG_ENABLE_REGISTER:BOOL=TRUE
+      -DPLMLIB_CONFIG_ENABLE_DOSE:BOOL=TRUE
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+  set(${proj}_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
-# With CMake 2.8.9 or later, the UPDATE_COMMAND is required for updates to occur.
-# For earlier versions, we nullify the update state to prevent updates and
-# undesirable rebuild.
-set(Plastimatch_EP_DISABLED_UPDATE UPDATE_COMMAND "")
-if(CMAKE_VERSION VERSION_LESS 2.8.9)
-  set(Plastimatch_EP_UPDATE_IF_CMAKE_LATER_THAN_288 ${${PROJECT_NAME}_EP_DISABLED_UPDATE})
 else()
-  set(Plastimatch_EP_UPDATE_IF_CMAKE_LATER_THAN_288 LOG_UPDATE 1)
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
 endif()
 
-# Disable OpenMP on Windows until a better solution can be found
-# http://www.na-mic.org/Bug/view.php?id=3823
-set (HANDLE_OPENMP_ON_WINDOWS "")
-if (WIN32)
-  #  set (HANDLE_OPENMP_ON_WINDOWS "-DPLM_CONFIG_DISABLE_OPENMP:BOOL=ON")
-  set (HANDLE_OPENMP_ON_WINDOWS "-DPLM_CONFIG_NOMANIFEST:BOOL=ON")
-endif ()
+mark_as_superbuild(${proj}_DIR:PATH)
 
-ExternalProject_Add( Plastimatch
-  SOURCE_DIR "${SLICERRT_PLASTIMATCH_SOURCE_DIR}" 
-  BINARY_DIR "${SLICERRT_PLASTIMATCH_DIR}"
-  #--Download step--------------
-  GIT_REPOSITORY "${git_protocol}://gitlab.com/plastimatch/plastimatch.git"
-  GIT_TAG "${PLM_GIT_TAG}"
-  #--Configure step-------------
-  CMAKE_ARGS 
-    # If Plastimatch is build in library mode (PLM_CONFIG_LIBRARY_BUILD) then does not use Slicer libraries
-    # -DSlicer_DIR:STRING=${Slicer_DIR}
-    -DBUILD_SHARED_LIBS:BOOL=OFF 
-    -DBUILD_TESTING:BOOL=OFF 
-    -DPLM_CONFIG_INSTALL_LIBRARIES:BOOL=ON 
-    # CUDA build is disabled until ticket #226 can be resolved.
-    -DPLM_CONFIG_DISABLE_CUDA:BOOL=ON
-    # Set PLM_LINK_FLAGS to build without manifest on windows 
-    ${HANDLE_OPENMP_ON_WINDOWS}
-    ${PLASTIMATCH_EXTRA_LIBRARIES}
-    -DDCMTK_DIR:STRING=${DCMTK_DIR}
-    -DITK_DIR:STRING=${ITK_DIR}
-    -DVTK_DIR:STRING=${VTK_DIR}
-    -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
-    -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
-    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
-    -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}
-  #--Build step-----------------
-  #--Install step-----------------
-  # Don't perform installation at the end of the build
-  INSTALL_COMMAND ""
-  ) 


### PR DESCRIPTION
This commit simplifies and update the build system based on the
SuperBuild extension template available in Slicer.

It also removes the use of the obsolete module "SlicerMacroCheckExternalProjectDependency"

Reported-by: Csaba Pinter <csaba.pinter@queensu.ca>