### PR TITLE
Missing include for QButtonGroup

### DIFF
--- a/SegmentMorphology/qSlicerSegmentMorphologyModuleWidget.cxx
+++ b/SegmentMorphology/qSlicerSegmentMorphologyModuleWidget.cxx
@@ -20,6 +20,7 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QButtonGroup>
 #include <QDebug>
 #include <QMessageBox>
 


### PR DESCRIPTION
Necessary (at least) with Qt 5.11 on macOS 10.12.