### PR TITLE
ENH: Add support for merged binary labelmap segments

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -764,9 +764,7 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
 
   if (segmentation->ContainsRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
   {
-    targetOrientedImageData = vtkSmartPointer<vtkOrientedImageData>::New();
-    targetOrientedImageData->DeepCopy( vtkOrientedImageData::SafeDownCast(
-        segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()) ) );
+    segmentationNode->GetBinaryLabelmapRepresentation(this->TargetSegmentID, targetOrientedImageData);
   }
   else
   {

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.cxx
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.cxx
@@ -40,6 +40,9 @@
 // STD includes
 #include <algorithm>
 
+// SegmentationCore includes
+#include <vtkSegment.h>
+
 // Directions used for dynamic programming table backtracking
 enum BacktrackDirection
 {
@@ -115,16 +118,18 @@ vtkDataObject* vtkPlanarContourToClosedSurfaceConversionRule::ConstructRepresent
 }
 
 //----------------------------------------------------------------------------
-bool vtkPlanarContourToClosedSurfaceConversionRule::Convert(vtkDataObject* sourceRepresentation, vtkDataObject* targetRepresentation)
+bool vtkPlanarContourToClosedSurfaceConversionRule::Convert(vtkSegment* segment)
 {
+  this->CreateTargetRepresentation(segment);
+
   // Check validity of source and target representation objects
-  vtkPolyData* planarContoursPolyData = vtkPolyData::SafeDownCast(sourceRepresentation);
+  vtkPolyData* planarContoursPolyData = vtkPolyData::SafeDownCast(segment->GetRepresentation(this->GetSourceRepresentationName()));
   if (!planarContoursPolyData)
   {
     vtkErrorMacro("Convert: Source representation is not a poly data!");
     return false;
   }
-  vtkPolyData* closedSurfacePolyData = vtkPolyData::SafeDownCast(targetRepresentation);
+  vtkPolyData* closedSurfacePolyData = vtkPolyData::SafeDownCast(segment->GetRepresentation(this->GetTargetRepresentationName()));
   if (!closedSurfacePolyData)
   {
     vtkErrorMacro("Convert: Target representation is not a poly data!");

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.h
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.h
@@ -66,7 +66,7 @@ public:
   vtkDataObject* ConstructRepresentationObjectByClass(std::string className) override;
 
   /// Update the target representation based on the source representation
-  bool Convert(vtkDataObject* sourceRepresentation, vtkDataObject* targetRepresentation) override;
+  bool Convert(vtkSegment* segment) override;
 
   /// Get the cost of the conversion.
   unsigned int GetConversionCost(vtkDataObject* sourceRepresentation = nullptr, vtkDataObject* targetRepresentation = nullptr) override;

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.cxx
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.cxx
@@ -33,6 +33,9 @@
 #include <vtkRibbonFilter.h>
 #include <vtkMath.h>
 
+// SegmentationCore includes
+#include <vtkSegment.h>
+
 //----------------------------------------------------------------------------
 // Utility functions
 namespace
@@ -129,16 +132,18 @@ vtkDataObject* vtkPlanarContourToRibbonModelConversionRule::ConstructRepresentat
 }
 
 //----------------------------------------------------------------------------
-bool vtkPlanarContourToRibbonModelConversionRule::Convert(vtkDataObject* sourceRepresentation, vtkDataObject* targetRepresentation)
+bool vtkPlanarContourToRibbonModelConversionRule::Convert(vtkSegment* segment)
 {
+  this->CreateTargetRepresentation(segment);
+
   // Check validity of source and target representation objects
-  vtkPolyData* planarContourPolyData = vtkPolyData::SafeDownCast(sourceRepresentation);
+  vtkPolyData* planarContourPolyData = vtkPolyData::SafeDownCast(segment->GetRepresentation(this->GetSourceRepresentationName()));
   if (!planarContourPolyData)
   {
     vtkErrorMacro("Convert: Source representation is not a poly data!");
     return false;
   }
-  vtkPolyData* ribbonModelPolyData = vtkPolyData::SafeDownCast(targetRepresentation);
+  vtkPolyData* ribbonModelPolyData = vtkPolyData::SafeDownCast(segment->GetRepresentation(this->GetTargetRepresentationName()));
   if (!ribbonModelPolyData)
   {
     vtkErrorMacro("Convert: Target representation is not a poly data!");

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.h
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.h
@@ -58,7 +58,7 @@ public:
   vtkDataObject* ConstructRepresentationObjectByClass(std::string className) override;
 
   /// Update the target representation based on the source representation
-  bool Convert(vtkDataObject* sourceRepresentation, vtkDataObject* targetRepresentation) override;
+  bool Convert(vtkSegment* segment) override;
 
   /// Get the cost of the conversion.
   unsigned int GetConversionCost(vtkDataObject* sourceRepresentation=nullptr, vtkDataObject* targetRepresentation=nullptr) override;

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -2021,8 +2021,8 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
         vtkSegment* segment = segmentationNode->GetSegmentation()->GetSegment(*segmentIdIt);
 
         // Get binary labelmap representation
-        vtkOrientedImageData* binaryLabelmap = vtkOrientedImageData::SafeDownCast(
-          segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()) );
+        vtkNew<vtkOrientedImageData> binaryLabelmap;
+        segmentationNode->GetBinaryLabelmapRepresentation(segmentID, binaryLabelmap);
         if (!binaryLabelmap)
         {
           error = "Failed to get binary labelmap representation from segment " + segmentID;

--- a/DoseComparison/Logic/vtkSlicerDoseComparisonModuleLogic.cxx
+++ b/DoseComparison/Logic/vtkSlicerDoseComparisonModuleLogic.cxx
@@ -231,8 +231,8 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
       return errorMessage;
     }
     // Get segment binary labelmap
-    vtkOrientedImageData* maskSegmentLabelmap = vtkOrientedImageData::SafeDownCast( segmentationCopy->GetSegment(maskSegmentID)->GetRepresentation(
-      vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() ) );
+    vtkNew<vtkOrientedImageData>  maskSegmentLabelmap;
+    maskSegmentationNode->GetBinaryLabelmapRepresentation(maskSegmentID, maskSegmentLabelmap);
 
     // Apply parent transformation nodes if necessary
     if ( maskSegmentationNode->GetParentTransformNode()

--- a/ExternalBeamPlanning/Widgets/qSlicerMockDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMockDoseEngine.cxx
@@ -86,7 +86,7 @@ QString qSlicerMockDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamN
   vtkPolyData* beamPolyData = vtkPolyData::SafeDownCast(beamSegment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName()));
   vtkSmartPointer<vtkOrientedImageData> beamImageData = vtkSmartPointer<vtkOrientedImageData>::Take(
     vtkSlicerSegmentationsModuleLogic::CreateOrientedImageDataFromVolumeNode(referenceVolumeNode) );
-  converter->Convert(beamPolyData, beamImageData);
+  converter->Convert(beamSegment);
 
   // Create dose image
   vtkSmartPointer<vtkImageData> protonDoseImageData = vtkSmartPointer<vtkImageData>::New();

--- a/SegmentMorphology/Testing/Cxx/vtkSlicerSegmentMorphologyModuleLogicTest1.cxx
+++ b/SegmentMorphology/Testing/Cxx/vtkSlicerSegmentMorphologyModuleLogicTest1.cxx
@@ -409,12 +409,10 @@ int vtkSlicerSegmentMorphologyModuleLogicTest1( int argc, char * argv[] )
   mrmlScene->Commit();
 
   // Compare output to baseline
-  vtkOrientedImageData* baselineImageData = vtkOrientedImageData::SafeDownCast(
-    baselineSegmentationNode->GetSegmentation()->GetSegment(baselineSegmentID)->GetRepresentation(
-      vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() ) );
-  vtkOrientedImageData* outputImageData = vtkOrientedImageData::SafeDownCast(
-    outputSegmentationNode->GetSegmentation()->GetSegment(outputSegmentID)->GetRepresentation(
-      vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() ) );
+  vtkNew<vtkOrientedImageData> baselineImageData;
+  baselineSegmentationNode->GetBinaryLabelmapRepresentation(baselineSegmentID, baselineImageData);
+  vtkNew<vtkOrientedImageData> outputImageData;
+  outputSegmentationNode->GetBinaryLabelmapRepresentation(outputSegmentID, outputImageData);
   if (!baselineImageData || !outputImageData)
   {
     std::cerr << "Failed to retrieve binary labelmap representation from the baseline or the output segmentation!" << std::endl;


### PR DESCRIPTION
Binary labelmap representations can now support multiple segments in the same vtkOrientedImageData.
This commit replaces some instances of segment->GetRepresentation("Binary labelmap") with segmentationNode->GetBinaryLabelmapRepresentation(), or the use of vtkImageThreshold to isolate the binary labelmaps for individual segments.

To be merged once https://github.com/Slicer/Slicer/pull/1221 has been merged.