### PR TITLE
ENH: Initial RTIonPlan and multiple control points support

### DIFF
--- a/Beams/MRML/CMakeLists.txt
+++ b/Beams/MRML/CMakeLists.txt
@@ -19,6 +19,8 @@ set(${KIT}_SRCS
   vtkMRMLRTPlanNode.h
   vtkMRMLRTBeamNode.cxx
   vtkMRMLRTBeamNode.h
+  vtkMRMLRTIonBeamNode.cxx
+  vtkMRMLRTIonBeamNode.h
   )
 
 SET (${KIT}_INCLUDE_DIRS

--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -46,6 +46,7 @@
 #include <vtkDoubleArray.h>
 #include <vtkTable.h>
 #include <vtkCellArray.h>
+#include <vtkAppendPolyData.h>
 
 //------------------------------------------------------------------------------
 const char* vtkMRMLRTBeamNode::NEW_BEAM_NODE_NAME_PREFIX = "NewBeam_";
@@ -56,6 +57,155 @@ static const char* MLCBOUNDARY_REFERENCE_ROLE = "MLCBoundaryRef";
 static const char* MLCPOSITION_REFERENCE_ROLE = "MLCPositionRef";
 static const char* DRR_REFERENCE_ROLE = "DRRRef";
 static const char* CONTOUR_BEV_REFERENCE_ROLE = "contourBEVRef";
+
+//------------------------------------------------------------------------------
+namespace
+{
+
+typedef std::vector< std::pair< double, double > > PointVector;
+typedef std::vector< std::array< double, 4 > > LeafDataVector;
+typedef std::vector< std::pair< LeafDataVector::iterator, LeafDataVector::iterator > > SectionVector;
+typedef std::array< double, 6 > JawsParameters;
+typedef std::pair< bool, bool > MLCType;
+
+bool(*AreEqual)( double, double) = vtkSlicerRtCommon::AreEqualWithTolerance;
+
+void
+CreateMLCPointsFromSectionBorders( const JawsParameters& jawsParameters,
+  const MLCType& mlcType, const SectionVector::value_type& sectionBorder, 
+  PointVector& side12)
+{
+  const double& jawBegin = jawsParameters[0];
+  const double& jawEnd = jawsParameters[1];
+  const double& X1Jaw = jawsParameters[2];
+  const double& X2Jaw = jawsParameters[3];
+  const double& Y1Jaw = jawsParameters[4];
+  const double& Y2Jaw = jawsParameters[5];
+
+  bool typeMLCX = mlcType.first;
+  bool typeMLCY = mlcType.second;
+
+  PointVector side1, side2; // temporary vectors to save visible points
+
+  LeafDataVector::iterator firstLeafIterator = sectionBorder.first;
+  LeafDataVector::iterator lastLeafIterator = sectionBorder.second;
+  LeafDataVector::iterator firstLeafIteratorJaws = firstLeafIterator;
+  LeafDataVector::iterator lastLeafIteratorJaws = lastLeafIterator;
+
+  // find first and last visible leaves using Jaws data
+  for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
+  {
+    double& bound1 = (*it)[0]; // leaf begin boundary
+    double& bound2 = (*it)[1]; // leaf end boundary
+    if (bound1 <= jawBegin && bound2 > jawBegin)
+    {
+      firstLeafIteratorJaws = it;
+    }
+    else if (bound1 <= jawEnd && bound2 > jawEnd)
+    {
+      lastLeafIteratorJaws = it;
+    }
+  }
+
+  // find opened MLC leaves into Jaws opening (logical AND)
+  if (firstLeafIteratorJaws != firstLeafIterator)
+  {
+    firstLeafIterator = std::max( firstLeafIteratorJaws, firstLeafIterator);
+  }
+  if (lastLeafIteratorJaws != lastLeafIterator)
+  {
+    lastLeafIterator = std::min( lastLeafIteratorJaws, lastLeafIterator);
+  }
+
+  // add points for the visible leaves of side "1" and "2"
+  // into side1 and side2 points vectors
+  for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
+  {
+    double& bound1 = (*it)[0]; // leaf begin boundary
+    double& bound2 = (*it)[1]; // leaf end boundary
+    double& pos1 = (*it)[2]; // leaf position "1"
+    double& pos2 = (*it)[3]; // leaf position "2"
+    if (typeMLCX)
+    {
+      side1.push_back({ std::max( pos1, X1Jaw), bound1});
+      side1.push_back({ std::max( pos1, X1Jaw), bound2});
+      side2.push_back({ std::min( pos2, X2Jaw), bound1});
+      side2.push_back({ std::min( pos2, X2Jaw), bound2});
+    }
+    else if (typeMLCY)
+    {
+      side1.push_back({ bound1, std::max( pos1, Y1Jaw)});
+      side1.push_back({ bound2, std::max( pos1, Y1Jaw)});
+      side2.push_back({ bound1, std::min( pos2, Y2Jaw)});
+      side2.push_back({ bound2, std::min( pos2, Y2Jaw)});
+    }
+  }
+
+  // intersection between Jaws and MLC boundary (logical AND) lambda
+  auto intersectJawsMLC = [ jawBegin, jawEnd, typeMLCX, typeMLCY](PointVector::value_type& point)
+  {
+    double& leafBoundary = point.second;
+    if (typeMLCX) // JawsY and MLCX
+    {
+      leafBoundary = point.second;
+    }
+    else if (typeMLCY) // JawsX and MLCY
+    {
+      leafBoundary = point.first;
+    }
+
+    if (leafBoundary <= jawBegin)
+    {
+      leafBoundary = jawBegin;
+    }
+    else if (leafBoundary >= jawEnd)
+    {
+      leafBoundary = jawEnd;
+    }
+  };
+
+  // apply lambda to side "1"
+  std::for_each( side1.begin(), side1.end(), intersectJawsMLC);
+  // apply lambda to side "2"
+  std::for_each( side2.begin(), side2.end(), intersectJawsMLC);
+
+  // reverse side "2"
+  std::reverse( side2.begin(), side2.end());
+
+  // fill real points vector side12 without excessive points from side1 vector
+  PointVector::value_type& p = side1.front(); // start point
+  double& px = p.first; // x coordinate of p point
+  double& py = p.second; // y coordinate of p point
+  side12.push_back(p);
+  for ( size_t i = 1; i < side1.size() - 1; ++i)
+  {
+    double& pxNext = side1[i + 1].first; // x coordinate of next point
+    double& pyNext = side1[i + 1].second; // y coordinate of next point
+    if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
+    {
+      p = side1[i];
+      side12.push_back(p);
+    }
+  }
+  side12.push_back(side1.back()); // end point
+
+  // same for the side2 vector
+  p = side2.front();
+  side12.push_back(p);
+  for ( size_t i = 1; i < side2.size() - 1; ++i)
+  {
+    double& pxNext = side2[i + 1].first;
+    double& pyNext = side2[i + 1].second;
+    if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
+    {
+      p = side2[i];
+      side12.push_back(p);
+    }
+  }
+  side12.push_back(side2.back());
+}
+
+} // namespace
 
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLRTBeamNode);
@@ -77,6 +227,10 @@ vtkMRMLRTBeamNode::vtkMRMLRTBeamNode()
   this->CouchAngle = 0.0;
 
   this->SAD = 2000.0;
+
+  this->SourceToJawsDistanceX = 500.;
+  this->SourceToJawsDistanceY = 500.;
+  this->SourceToMultiLeafCollimatorDistance = 400.;
 }
 
 //----------------------------------------------------------------------------
@@ -100,6 +254,10 @@ void vtkMRMLRTBeamNode::WriteXML(ostream& of, int nIndent)
   of << " Y1Jaw=\"" << this->Y1Jaw << "\"";
   of << " Y2Jaw=\"" << this->Y2Jaw << "\"";
   of << " SAD=\"" << this->SAD << "\"";
+
+  of << " SourceToJawsDistanceX=\"" << this->SourceToJawsDistanceX << "\"";
+  of << " SourceToJawsDistanceY=\"" << this->SourceToJawsDistanceY << "\"";
+  of << " SourceToMultiLeafCollimatorDistance=\"" << this->SourceToMultiLeafCollimatorDistance << "\"";
 
   of << " GantryAngle=\"" << this->GantryAngle << "\"";
   of << " CollimatorAngle=\"" << this->CollimatorAngle << "\"";
@@ -151,6 +309,18 @@ void vtkMRMLRTBeamNode::ReadXMLAttributes(const char** atts)
     else if (!strcmp(attName, "SAD"))
     {
       this->SAD = vtkVariant(attValue).ToDouble();
+    }
+    else if (!strcmp(attName, "SourceToJawsDistanceX"))
+    {
+      this->SourceToJawsDistanceX = vtkVariant(attValue).ToDouble();
+    }
+    else if (!strcmp(attName, "SourceToJawsDistanceY"))
+    {
+      this->SourceToJawsDistanceY = vtkVariant(attValue).ToDouble();
+    }
+    else if (!strcmp(attName, "SourceToMultiLeafCollimatorDistance"))
+    {
+      this->SourceToMultiLeafCollimatorDistance = vtkVariant(attValue).ToDouble();
     }
     else if (!strcmp(attName, "GantryAngle"))
     {
@@ -204,6 +374,10 @@ void vtkMRMLRTBeamNode::Copy(vtkMRMLNode *anode)
   this->SetY1Jaw(node->GetY1Jaw());
   this->SetY2Jaw(node->GetY2Jaw());
 
+  this->SetSourceToJawsDistanceX(node->GetSourceToJawsDistanceX());
+  this->SetSourceToJawsDistanceY(node->GetSourceToJawsDistanceY());
+  this->SetSourceToMultiLeafCollimatorDistance(node->GetSourceToMultiLeafCollimatorDistance());
+
   this->SetGantryAngle(node->GetGantryAngle());
   this->SetCollimatorAngle(node->GetCollimatorAngle());
   this->SetCouchAngle(node->GetCouchAngle());
@@ -246,6 +420,10 @@ void vtkMRMLRTBeamNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << " Y1Jaw:   " << this->Y1Jaw << "\n";
   os << indent << " Y2Jaw:   " << this->Y2Jaw << "\n";
   os << indent << " SAD:   " << this->SAD << "\n";
+
+  os << indent << " SourceToJawsDistanceX:   " << this->SourceToJawsDistanceX << "\n";
+  os << indent << " SourceToJawsDistanceY:   " << this->SourceToJawsDistanceY << "\n";
+  os << indent << " SourceToMultiLeafCollimatorDistance:   " << this->SourceToMultiLeafCollimatorDistance << "\n";
 
   os << indent << " GantryAngle:   " << this->GantryAngle << "\n";
   os << indent << " CollimatorAngle:   " << this->CollimatorAngle << "\n";
@@ -309,10 +487,10 @@ vtkMRMLDoubleArrayNode* vtkMRMLRTBeamNode::GetMLCBoundaryDoubleArrayNode()
 void vtkMRMLRTBeamNode::SetAndObserveMLCBoundaryDoubleArrayNode(vtkMRMLDoubleArrayNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(MLCBOUNDARY_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 
@@ -329,10 +507,10 @@ vtkMRMLTableNode* vtkMRMLRTBeamNode::GetMLCPositionTableNode()
 void vtkMRMLRTBeamNode::SetAndObserveMLCPositionTableNode(vtkMRMLTableNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(MLCPOSITION_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 
@@ -349,10 +527,10 @@ vtkMRMLScalarVolumeNode* vtkMRMLRTBeamNode::GetDRRVolumeNode()
 void vtkMRMLRTBeamNode::SetAndObserveDRRVolumeNode(vtkMRMLScalarVolumeNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(DRR_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -367,10 +545,10 @@ vtkMRMLScalarVolumeNode* vtkMRMLRTBeamNode::GetContourBEVVolumeNode()
 void vtkMRMLRTBeamNode::SetAndObserveContourBEVVolumeNode(vtkMRMLScalarVolumeNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(CONTOUR_BEV_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -450,6 +628,30 @@ void vtkMRMLRTBeamNode::SetY2Jaw(double y2Jaw)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLRTBeamNode::SetSourceToJawsDistanceX(double distance)
+{
+  this->SourceToJawsDistanceX = distance;
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTBeamNode::SetSourceToJawsDistanceY(double distance)
+{
+  this->SourceToJawsDistanceY = distance;
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTBeamNode::SetSourceToMultiLeafCollimatorDistance(double distance)
+{
+  this->SourceToMultiLeafCollimatorDistance = distance;
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLRTBeamNode::SetGantryAngle(double angle)
 {
   this->GantryAngle = angle;
@@ -503,10 +705,7 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
     vtkErrorMacro("CreateBeamPolyData: Invalid beam node");
     return;
   }
-
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-  vtkSmartPointer<vtkCellArray> cellArray = vtkSmartPointer<vtkCellArray>::New();
-
+    
   vtkMRMLTableNode* mlcTableNode = nullptr;
 
   vtkIdType nofLeaves = 0;
@@ -536,20 +735,13 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
     }
   }
 
-  // static function ptr
-  bool(*AreEqual)(double, double) = vtkSlicerRtCommon::AreEqualWithTolerance;
-
   bool xOpened = !AreEqual( this->X2Jaw, this->X1Jaw);
   bool yOpened = !AreEqual( this->Y2Jaw, this->Y1Jaw);
 
   // Check that we have MLC with Jaws opening
   if (mlcTableNode && xOpened && yOpened)
   {
-    using PointVector = std::vector< std::pair< double, double > >;
-    using LeafDataVector = std::vector< std::array< double, 4 > >;
-    
     LeafDataVector mlc; // temporary MLC vector (Boundary and Position)
-    PointVector side12; // real points for side "1" and "2"
 
     const char* mlcName = mlcTableNode->GetName();
     bool typeMLCX = !strncmp( "MLCX", mlcName, strlen("MLCX"));
@@ -583,7 +775,8 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
     }
 
     // find first and last opened leaves visible within jaws
-    PointVector side1, side2; // temporary vectors to save visible points
+    // and fill sections vector for further processing
+    SectionVector sections; // sections (first & last leaf iterator) of opened MLC
     for ( auto it = mlc.begin(); it != mlc.end(); ++it)
     {
       double& pos1 = (*it)[2]; // leaf position "1"
@@ -611,173 +804,93 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
       {
         firstLeafIterator = it;
       }
-      else if (withinJaw && mlcOpened && firstLeafIterator != mlc.end())
+      if (withinJaw && mlcOpened && firstLeafIterator != mlc.end())
       {
         lastLeafIterator = it;
       }
+      if (firstLeafIterator != mlc.end() && lastLeafIterator != mlc.end() && !mlcOpened)
+      {
+        sections.push_back({ firstLeafIterator, lastLeafIterator});
+        firstLeafIterator = mlc.end();
+        lastLeafIterator = mlc.end();
+      }
     }
-    
-    // iterate through visible leaves to fill temporary points vectors
-    if (firstLeafIterator != mlc.end() && lastLeafIterator != mlc.end())
-    {
-      auto firstLeafIteratorJaws = firstLeafIterator;
-      auto lastLeafIteratorJaws = lastLeafIterator;
-      // find first and last visible leaves using Jaws data
-      for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
-      {
-        double& bound1 = (*it)[0]; // leaf begin boundary
-        double& bound2 = (*it)[1]; // leaf end boundary
-        if (bound1 <= jawBegin && bound2 > jawBegin)
-        {
-          firstLeafIteratorJaws = it;
-        }
-        else if (bound1 <= jawEnd && bound2 > jawEnd)
-        {
-          lastLeafIteratorJaws = it;
-        }
-      }
 
-      // find opened MLC leaves into Jaws opening (logical AND)
-      if (firstLeafIteratorJaws != firstLeafIterator)
-      {
-        firstLeafIterator = std::max( firstLeafIteratorJaws, firstLeafIterator);
-      }
-      if (lastLeafIteratorJaws != lastLeafIterator)
-      {
-        lastLeafIterator = std::min( lastLeafIteratorJaws, lastLeafIterator);
-      }
-
-      // add points for the visible leaves of side "1" and "2"
-      // into side1 and side2 points vectors
-      for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
-      {
-        double& bound1 = (*it)[0]; // leaf begin boundary
-        double& bound2 = (*it)[1]; // leaf end boundary
-        double& pos1 = (*it)[2]; // leaf position "1"
-        double& pos2 = (*it)[3]; // leaf position "2"
-        if (typeMLCX)
-        {
-          side1.push_back({ std::max( pos1, this->X1Jaw), bound1});
-          side1.push_back({ std::max( pos1, this->X1Jaw), bound2});
-          side2.push_back({ std::min( pos2, this->X2Jaw), bound1});
-          side2.push_back({ std::min( pos2, this->X2Jaw), bound2});
-        }
-        else if (typeMLCY)
-        {
-          side1.push_back({ bound1, std::max( pos1, this->Y1Jaw)});
-          side1.push_back({ bound2, std::max( pos1, this->Y1Jaw)});
-          side2.push_back({ bound1, std::min( pos2, this->Y2Jaw)});
-          side2.push_back({ bound2, std::min( pos2, this->Y2Jaw)});
-        }
-      }
-      mlc.clear(); // doesn't need anymore
-
-      // intersection between Jaws and MLC boundary (logical AND) lambda
-      auto intersectJawsMLC = [ jawBegin, jawEnd, typeMLCX, typeMLCY](PointVector::value_type& point)
-      {
-        double& leafBoundary = point.second;
-        if (typeMLCX) // JawsY and MLCX
-        {
-          leafBoundary = point.second;
-        }
-        else if (typeMLCY) // JawsX and MLCY
-        {
-          leafBoundary = point.first;
-        }
-
-        if (leafBoundary <= jawBegin)
-        {
-          leafBoundary = jawBegin;
-        }
-        else if (leafBoundary >= jawEnd)
-        {
-          leafBoundary = jawEnd;
-        }
-      };
-      // apply lambda to side "1"
-      std::for_each( side1.begin(), side1.end(), intersectJawsMLC);
-      // apply lambda to side "2"
-      std::for_each( side2.begin(), side2.end(), intersectJawsMLC);
-
-      // reverse side "2"
-      std::reverse( side2.begin(), side2.end());
-
-      // fill real points vector side12 without excessive points from side1 vector
-      PointVector::value_type& p = side1.front(); // start point
-      double& px = p.first; // x coordinate of p point
-      double& py = p.second; // y coordinate of p point
-      side12.push_back(p);
-      for ( size_t i = 1; i < side1.size() - 1; ++i)
-      {
-        double& pxNext = side1[i + 1].first; // x coordinate of next point
-        double& pyNext = side1[i + 1].second; // y coordinate of next point
-        if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
-        {
-          p = side1[i];
-          side12.push_back(p);
-        }
-      }
-      side12.push_back(side1.back()); // end point
-
-      // same for the side2 vector
-      p = side2.front();
-      side12.push_back(p);
-      for ( size_t i = 1; i < side2.size() - 1; ++i)
-      {
-        double& pxNext = side2[i + 1].first;
-        double& pyNext = side2[i + 1].second;
-        if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
-        {
-          p = side2[i];
-          side12.push_back(p);
-        }
-      }
-      side12.push_back(side2.back());
-    }
-    else
+    if (!sections.size()) // no visible sections
     {
       vtkErrorMacro("CreateBeamPolyData: Unable to calculate MLC visible data");
       return;
     }
 
-    // fill vtk points
-    points->InsertPoint( 0, 0, 0, this->SAD); // source
-
-    // side "1" and "2" points vector
-    vtkIdType pointIds = 0;
-    for ( PointVector::value_type& point : side12)
+    // append one or more visible sections to beam model poly data
+    auto append = vtkSmartPointer<vtkAppendPolyData>::New();
+    for (const SectionVector::value_type& section : sections)
     {
-      double& x = point.first;
-      double& y = point.second;
-      points->InsertPoint( pointIds + 1, 2. * x, 2. * y, -this->SAD);
-      pointIds++;
-    }
-    side12.clear(); // doesn't need anymore
+      if (section.first != mlc.end() && section.second != mlc.end())
+      {
+        vtkSmartPointer<vtkPolyData> beamPolyData = vtkSmartPointer<vtkPolyData>::New();
+        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+        vtkSmartPointer<vtkCellArray> cellArray = vtkSmartPointer<vtkCellArray>::New();
 
-    // fill cell array for side "1" and "2"
-    for ( vtkIdType i = 1; i < pointIds; ++i)
-    {
-      cellArray->InsertNextCell(3);
-      cellArray->InsertCellPoint(0);
-      cellArray->InsertCellPoint(i);
-      cellArray->InsertCellPoint(i + 1);
+        PointVector side12; // real points for side "1" and "2"
+        JawsParameters jawsParameters{ jawBegin, jawEnd, this->X1Jaw, this->X2Jaw, this->Y1Jaw, this->Y2Jaw };
+        MLCType mlcType{ typeMLCX, typeMLCY };
+
+        CreateMLCPointsFromSectionBorders( jawsParameters, mlcType, 
+          section, side12);
+
+        // fill vtk points
+        points->InsertPoint( 0, 0, 0, this->SAD); // source
+
+        // side "1" and "2" points vector
+        vtkIdType pointIds = 0;
+        for ( const PointVector::value_type& point : side12)
+        {
+          const double& x = point.first;
+          const double& y = point.second;
+          points->InsertPoint( pointIds + 1, 2. * x, 2. * y, -this->SAD);
+          pointIds++;
+        }
+        side12.clear(); // doesn't need anymore
+
+        // fill cell array for side "1" and "2"
+        for ( vtkIdType i = 1; i < pointIds; ++i)
+        {
+          cellArray->InsertNextCell(3);
+          cellArray->InsertCellPoint(0);
+          cellArray->InsertCellPoint(i);
+          cellArray->InsertCellPoint(i + 1);
+        }
+
+        // fill cell connection between side "2" -> side "1"
+        cellArray->InsertNextCell(3);
+        cellArray->InsertCellPoint(0);
+        cellArray->InsertCellPoint(1);
+        cellArray->InsertCellPoint(pointIds);
+
+        // Add the cap to the bottom
+        cellArray->InsertNextCell(pointIds);
+        for ( vtkIdType i = 1; i <= pointIds; i++)
+        {
+          cellArray->InsertCellPoint(i);
+        }
+
+        beamPolyData->SetPoints(points);
+        beamPolyData->SetPolys(cellArray);
+
+        // append section to form final polydata
+        append->AddInputData(beamPolyData);
+      }
     }
 
-    // fill cell connection between side "2" -> side "1"
-    cellArray->InsertNextCell(3);
-    cellArray->InsertCellPoint(0);
-    cellArray->InsertCellPoint(1);
-    cellArray->InsertCellPoint(pointIds);
-
-    // Add the cap to the bottom
-    cellArray->InsertNextCell(pointIds);
-    for ( vtkIdType i = 1; i <= pointIds; i++)
-    {
-      cellArray->InsertCellPoint(i);
-    }
+    append->Update();
+    beamModelPolyData->ShallowCopy(append->GetOutput());
   }
   else
   {
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+    vtkSmartPointer<vtkCellArray> cellArray = vtkSmartPointer<vtkCellArray>::New();
+
     points->InsertPoint(0,0,0,this->SAD);
     points->InsertPoint(1, 2*this->X1Jaw, 2*this->Y1Jaw, -this->SAD );
     points->InsertPoint(2, 2*this->X1Jaw, 2*this->Y2Jaw, -this->SAD );
@@ -810,10 +923,10 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
     cellArray->InsertCellPoint(2);
     cellArray->InsertCellPoint(3);
     cellArray->InsertCellPoint(4);
-  }
 
-  beamModelPolyData->SetPoints(points);
-  beamModelPolyData->SetPolys(cellArray);
+    beamModelPolyData->SetPoints(points);
+    beamModelPolyData->SetPolys(cellArray);
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -245,6 +245,20 @@ protected:
   double CollimatorAngle;
   /// Couch angle
   double CouchAngle;
+
+private:
+  /// Visible multi-leaf collimator points
+  typedef std::vector< std::pair< double, double > > MLCVisiblePointVector;
+  /// Multi-leaf collimator boundary position parameters 
+  typedef std::vector< std::array< double, 4 > > MLCBoundaryPositionVector;
+  /// Start and stop border of multi-leaf collimator opened section
+  typedef std::vector< std::pair< MLCBoundaryPositionVector::iterator, MLCBoundaryPositionVector::iterator > > MLCSectionVector;
+
+  /// \brief Create visible points of MLC enclosure (perimeter) 
+  ///  in IEC BEAM LIMITING DEVICE coordinate axis (isocenter plane)
+  void CreateMLCPointsFromSectionBorder( double jawBegin, double jawEnd, 
+    bool typeMLCX, bool typeMLCY, const MLCSectionVector::value_type& sectionBorder, 
+    MLCVisiblePointVector& side12);
 };
 
 #endif // __vtkMRMLRTBeamNode_h

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -189,7 +189,7 @@ public:
 protected:
   /// Create beam model from beam parameters, supporting MLC leaves
   /// \param beamModelPolyData Output polydata. If none given then the beam node's own polydata is used
-  void CreateBeamPolyData(vtkPolyData* beamModelPolyData=nullptr);
+  virtual void CreateBeamPolyData(vtkPolyData* beamModelPolyData=nullptr);
 
 protected:
   vtkMRMLRTBeamNode();

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -186,6 +186,21 @@ public:
   /// Set beam weight
   vtkSetMacro(BeamWeight, double);
 
+  /// Get source to jaws X distance
+  vtkGetMacro(SourceToJawsDistanceX, double);
+  /// Set source to jaws X distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetSourceToJawsDistanceX(double distance);
+
+  /// Get source to jaws Y distance
+  vtkGetMacro(SourceToJawsDistanceY, double);
+  /// Set source to jaws Y distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetSourceToJawsDistanceY(double distance);
+
+  /// Get source to multi-leaf collimator distance
+  vtkGetMacro(SourceToMultiLeafCollimatorDistance, double);
+  /// Set source to multi-leaf collimator distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetSourceToMultiLeafCollimatorDistance(double distance);
+
 protected:
   /// Create beam model from beam parameters, supporting MLC leaves
   /// \param beamModelPolyData Output polydata. If none given then the beam node's own polydata is used
@@ -216,6 +231,13 @@ protected:
   double Y2Jaw;
   /// Source-axis distance
   double SAD;
+
+  /// distance from source to beam limiting device X, ASYMX
+  double SourceToJawsDistanceX;
+  /// distance from source to beam limiting device Y, ASYMY
+  double SourceToJawsDistanceY;
+  /// distance from source to beam limiting device MLCX, MLCY
+  double SourceToMultiLeafCollimatorDistance;
 
   /// Gantry angle
   double GantryAngle;

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
@@ -63,10 +63,10 @@ vtkMRMLNodeNewMacro(vtkMRMLRTIonBeamNode);
 vtkMRMLRTIonBeamNode::vtkMRMLRTIonBeamNode()
   :
   Superclass(),
-  VSADx(Superclass::SAD),
-  IsocenterToJawsDistanceX(Superclass::SourceToJawsDistanceX),
-  IsocenterToJawsDistanceY(Superclass::SourceToJawsDistanceY),
-  IsocenterToMultiLeafCollimatorDistance(Superclass::SourceToMultiLeafCollimatorDistance),
+  VSADx(vtkMRMLRTBeamNode::SAD),
+  IsocenterToJawsDistanceX(vtkMRMLRTBeamNode::SourceToJawsDistanceX),
+  IsocenterToJawsDistanceY(vtkMRMLRTBeamNode::SourceToJawsDistanceY),
+  IsocenterToMultiLeafCollimatorDistance(vtkMRMLRTBeamNode::SourceToMultiLeafCollimatorDistance),
   IsocenterToRangeShifterDistance(4000.),
   ScanningSpotSize({ 15.0, 15.0 })
 {
@@ -88,64 +88,32 @@ void vtkMRMLRTIonBeamNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
+  vtkMRMLWriteXMLBeginMacro(of);
   // Write all MRML node attributes into output stream
-  of << " VSADx=\"" << this->VSADx << "\"";
-  of << " VSADy=\"" << this->VSADy << "\"";
-  of << " IsocenterToJawsDistanceX=\"" << this->IsocenterToJawsDistanceX << "\"";
-  of << " IsocenterToJawsDistanceY=\"" << this->IsocenterToJawsDistanceY << "\"";
-  of << " IsocenterToMultiLeafCollimatorDistance=\"" << this->IsocenterToMultiLeafCollimatorDistance << "\"";
-  of << " IsocenterToRangeShifterDistance=\"" << this->IsocenterToRangeShifterDistance << "\"";
-  of << " ScanningSpotSizeX=\"" << this->ScanningSpotSize[0] << "\"";
-  of << " ScanningSpotSizeY=\"" << this->ScanningSpotSize[1] << "\"";
+  vtkMRMLWriteXMLFloatMacro( VSADx, VSADx);
+  vtkMRMLWriteXMLFloatMacro( VSADy, VSADy);
+  vtkMRMLWriteXMLFloatMacro( IsocenterToJawsDistanceX, IsocenterToJawsDistanceX);
+  vtkMRMLWriteXMLFloatMacro( IsocenterToJawsDistanceY, IsocenterToJawsDistanceY);
+  vtkMRMLWriteXMLFloatMacro( IsocenterToMultiLeafCollimatorDistance, IsocenterToMultiLeafCollimatorDistance);
+  vtkMRMLWriteXMLFloatMacro( IsocenterToRangeShifterDistance, IsocenterToRangeShifterDistance);
+  vtkMRMLWriteXMLVectorMacro( ScanningSpotSize, ScanningSpotSize, float, 2);
+  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLRTIonBeamNode::ReadXMLAttributes(const char** atts)
 {
   Superclass::ReadXMLAttributes(atts);
-
-  // Read all MRML node attributes from two arrays of names and values
-  const char* attName = nullptr;
-  const char* attValue = nullptr;
-
-  while (*atts != nullptr)
-  {
-    attName = *(atts++);
-    attValue = *(atts++);
-
-    if (!strcmp( attName, "VSADx"))
-    {
-      this->VSADx = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "VSADy"))
-    {
-      this->VSADy = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "IsocenterToJawsDistanceX"))
-    {
-      this->IsocenterToJawsDistanceX = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "IsocenterToJawsDistanceY"))
-    {
-      this->IsocenterToJawsDistanceY = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "IsocenterToMultiLeafCollimatorDistance"))
-    {
-      this->IsocenterToMultiLeafCollimatorDistance = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "IsocenterToRangeShifterDistance"))
-    {
-      this->IsocenterToRangeShifterDistance = vtkVariant(attValue).ToDouble();
-    }
-    else if (!strcmp( attName, "ScanningSpotSizeX"))
-    {
-      this->ScanningSpotSize[0] = vtkVariant(attValue).ToFloat();
-    }
-    else if (!strcmp( attName, "ScanningSpotSizeY"))
-    {
-      this->ScanningSpotSize[1] = vtkVariant(attValue).ToFloat();
-    }
-  }
+  
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLFloatMacro( VSADx, VSADx);
+  vtkMRMLReadXMLFloatMacro( VSADy, VSADy);
+  vtkMRMLReadXMLFloatMacro( IsocenterToJawsDistanceX, IsocenterToJawsDistanceX);
+  vtkMRMLReadXMLFloatMacro( IsocenterToJawsDistanceY, IsocenterToJawsDistanceY);
+  vtkMRMLReadXMLFloatMacro( IsocenterToMultiLeafCollimatorDistance, IsocenterToMultiLeafCollimatorDistance);
+  vtkMRMLReadXMLFloatMacro( IsocenterToRangeShifterDistance, IsocenterToRangeShifterDistance);
+  vtkMRMLReadXMLVectorMacro( ScanningSpotSize, ScanningSpotSize, float, 2);
+  vtkMRMLReadXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -153,6 +121,8 @@ void vtkMRMLRTIonBeamNode::ReadXMLAttributes(const char** atts)
 // Does NOT copy: ID, FilePrefix, Name, VolumeID
 void vtkMRMLRTIonBeamNode::Copy(vtkMRMLNode *anode)
 {
+  int disabledModify = this->StartModify();
+
   // Do not call Copy function of the direct model base class, as it copies the poly data too,
   // which is undesired for beams, as they generate their own poly data from their properties.
   vtkMRMLDisplayableNode::Copy(anode);
@@ -190,14 +160,14 @@ void vtkMRMLRTIonBeamNode::Copy(vtkMRMLNode *anode)
   this->SetIsocenterToMultiLeafCollimatorDistance(node->GetIsocenterToMultiLeafCollimatorDistance());
   this->SetIsocenterToRangeShifterDistance(node->GetIsocenterToRangeShifterDistance());
 
-  float* scanSpotSize = node->GetScanningSpotSize();
-  this->SetScanningSpotSize({ scanSpotSize[0], scanSpotSize[1] });
+  this->SetScanningSpotSize(node->GetScanningSpotSize());
 
   this->SetGantryAngle(node->GetGantryAngle());
   this->SetCollimatorAngle(node->GetCollimatorAngle());
   this->SetCouchAngle(node->GetCouchAngle());
 
-  this->DisableModifiedEventOff();
+  this->EndModify(disabledModify);
+  
   this->InvokePendingModifiedEvent();
 }
 
@@ -212,14 +182,15 @@ void vtkMRMLRTIonBeamNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 
-  os << indent << " VSADx:   " << this->VSADx << "\n";
-  os << indent << " VSADy:   " << this->VSADy << "\n";
-  os << indent << " IsocenterToJawsDistanceX:   " << this->IsocenterToJawsDistanceX << "\n";
-  os << indent << " IsocenterToJawsDistanceY:   " << this->IsocenterToJawsDistanceY << "\n";
-  os << indent << " IsocenterToMultiLeafCollimatorDistance:   " << this->IsocenterToMultiLeafCollimatorDistance << "\n";
-  os << indent << " IsocenterToRangeShifterDistance:   " << this->IsocenterToRangeShifterDistance << "\n";
-  os << indent << " ScanningSpotSizeX:   " << this->ScanningSpotSize[0] << "\n";
-  os << indent << " ScanningSpotSizeY:   " << this->ScanningSpotSize[1] << "\n";
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintFloatMacro(VSADx);
+  vtkMRMLPrintFloatMacro(VSADy);
+  vtkMRMLPrintFloatMacro(IsocenterToJawsDistanceX);
+  vtkMRMLPrintFloatMacro(IsocenterToJawsDistanceY);
+  vtkMRMLPrintFloatMacro(IsocenterToMultiLeafCollimatorDistance);
+  vtkMRMLPrintFloatMacro(IsocenterToRangeShifterDistance);
+  vtkMRMLPrintVectorMacro( ScanningSpotSize, float, 2);
+  vtkMRMLPrintEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -233,7 +204,7 @@ void vtkMRMLRTIonBeamNode::SetAndObserveScanSpotTableNode(vtkMRMLTableNode* node
 
   this->SetNodeReferenceID( SCANSPOT_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 
-  this->InvokeCustomModifiedEvent(Superclass::BeamGeometryModified);
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
 }
 
 //----------------------------------------------------------------------------
@@ -281,6 +252,15 @@ void vtkMRMLRTIonBeamNode::SetVSAD(double VSAD[2])
 void vtkMRMLRTIonBeamNode::SetVSAD(const std::array< double, 2 >& VSAD)
 {
   this->SetVSAD( VSAD[0], VSAD[1]);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::SetScanningSpotSize(float size[2])
+{
+  this->ScanningSpotSize[0] = size[0];
+  this->ScanningSpotSize[1] = size[1];
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
 }
 
 //----------------------------------------------------------------------------

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
@@ -1,0 +1,525 @@
+/*==============================================================================
+
+  Copyright (c) Radiation Medicine Program, University Health Network,
+  Princess Margaret Hospital, Toronto, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, Princess Margaret Cancer Centre
+  and was supported by Cancer Care Ontario (CCO)'s ACRU program
+  with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).
+
+==============================================================================*/
+
+// Beams includes
+#include "vtkMRMLRTIonBeamNode.h"
+#include "vtkMRMLRTPlanNode.h"
+
+// SlicerRT includes
+#include "vtkSlicerRtCommon.h"
+
+// MRML includes
+#include <vtkMRMLModelDisplayNode.h>
+#include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLDoubleArrayNode.h>
+#include <vtkMRMLTableNode.h>
+#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLSubjectHierarchyNode.h>
+#include <vtkMRMLSubjectHierarchyConstants.h>
+
+// VTK includes
+#include <vtkCommand.h>
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+#include <vtkIntArray.h>
+#include <vtkTransform.h>
+#include <vtkTransformPolyDataFilter.h>
+#include <vtkDoubleArray.h>
+#include <vtkTable.h>
+#include <vtkCellArray.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLRTIonBeamNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLRTIonBeamNode::vtkMRMLRTIonBeamNode()
+  :
+  Superclass(),
+  VSADx(SAD)
+{
+  this->VSADx = 2000.0;
+  this->VSADy = 2500.0;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLRTIonBeamNode::~vtkMRMLRTIonBeamNode()
+{
+  this->SetBeamDescription(nullptr);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  // Write all MRML node attributes into output stream
+  of << " VSADx=\"" << this->VSADx << "\"";
+  of << " VSADy=\"" << this->VSADy << "\"";
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::ReadXMLAttributes(const char** atts)
+{
+  Superclass::ReadXMLAttributes(atts);
+
+  // Read all MRML node attributes from two arrays of names and values
+  const char* attName = nullptr;
+  const char* attValue = nullptr;
+
+  while (*atts != nullptr)
+  {
+    attName = *(atts++);
+    attValue = *(atts++);
+
+    if (!strcmp(attName, "VSADx"))
+    {
+      this->VSADx = vtkVariant(attValue).ToDouble();
+    }
+    else if (!strcmp(attName, "VSADy"))
+    {
+      this->VSADy = vtkVariant(attValue).ToDouble();
+    }
+  }
+}
+
+//----------------------------------------------------------------------------
+// Copy the node's attributes to this object.
+// Does NOT copy: ID, FilePrefix, Name, VolumeID
+void vtkMRMLRTIonBeamNode::Copy(vtkMRMLNode *anode)
+{
+  // Do not call Copy function of the direct model base class, as it copies the poly data too,
+  // which is undesired for beams, as they generate their own poly data from their properties.
+  vtkMRMLDisplayableNode::Copy(anode);
+
+  vtkMRMLRTIonBeamNode* node = vtkMRMLRTIonBeamNode::SafeDownCast(anode);
+  if (!node)
+  {
+    return;
+  }
+
+  // Create transform node for beam
+  this->CreateNewBeamTransformNode();
+
+  // Add beam in the same plan if beam nodes are in the same scene
+  vtkMRMLRTPlanNode* planNode = node->GetParentPlanNode();
+  if (planNode && node->GetScene() == this->Scene)
+  {
+    planNode->AddBeam(this);
+  }
+
+  // Copy beam parameters
+  this->DisableModifiedEventOn();
+
+  this->SetBeamNumber(node->GetBeamNumber());
+  this->SetBeamDescription(node->GetBeamDescription());
+  this->SetBeamWeight(node->GetBeamWeight());
+
+  this->SetX1Jaw(node->GetX1Jaw());
+  this->SetX2Jaw(node->GetX2Jaw());
+  this->SetY1Jaw(node->GetY1Jaw());
+  this->SetY2Jaw(node->GetY2Jaw());
+  this->SetVSADx(node->GetVSADx());
+  this->SetVSADy(node->GetVSADy());
+
+  this->SetGantryAngle(node->GetGantryAngle());
+  this->SetCollimatorAngle(node->GetCollimatorAngle());
+  this->SetCouchAngle(node->GetCouchAngle());
+
+  this->DisableModifiedEventOff();
+  this->InvokePendingModifiedEvent();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::SetScene(vtkMRMLScene* scene)
+{
+  Superclass::SetScene(scene);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+
+  os << indent << " VSADx:   " << this->VSADx << "\n";
+  os << indent << " VSADy:   " << this->VSADy << "\n";
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::CreateDefaultDisplayNodes()
+{
+  // Create default model display node
+  Superclass::CreateDefaultDisplayNodes();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::CreateDefaultTransformNode()
+{
+  Superclass::CreateDefaultTransformNode();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::CreateNewBeamTransformNode()
+{
+  // Create transform node for ion beam
+  Superclass::CreateNewBeamTransformNode();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::SetVSADy(double VSADyComponent)
+{
+  this->VSADy = VSADyComponent;
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::SetVSADx(double VSADxComponent)
+{
+  this->VSADx = VSADxComponent;
+  this->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=nullptr*/)
+{
+  if (!beamModelPolyData)
+  {
+    beamModelPolyData = this->GetPolyData();
+  }
+  if (!beamModelPolyData)
+  {
+    vtkErrorMacro("CreateBeamPolyData: Invalid beam node");
+    return;
+  }
+
+  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkSmartPointer<vtkCellArray> cellArray = vtkSmartPointer<vtkCellArray>::New();
+
+  vtkMRMLTableNode* mlcTableNode = nullptr;
+
+  vtkIdType nofLeaves = 0;
+
+  // MLC boundary data
+  vtkMRMLDoubleArrayNode* arrayNode = this->GetMLCBoundaryDoubleArrayNode();
+  vtkDoubleArray* mlcBoundArray = nullptr;
+  if (arrayNode)
+  {
+    mlcBoundArray = arrayNode->GetArray();
+    nofLeaves = mlcBoundArray ? (mlcBoundArray->GetNumberOfTuples() - 1) : 0;
+  }
+
+  // MLC position data
+  if (nofLeaves)
+  {
+    mlcTableNode = this->GetMLCPositionTableNode();
+    if (mlcTableNode && (mlcTableNode->GetNumberOfRows() == nofLeaves))
+    {
+      vtkDebugMacro("CreateBeamPolyData: Valid MLC nodes, number of leaves: " << nofLeaves);
+    }
+    else
+    {
+      vtkErrorMacro("CreateBeamPolyData: Invalid MLC nodes, or " \
+        "number of MLC boundaries and positions are different");
+      mlcTableNode = nullptr; // draw beam polydata without MLC
+    }
+  }
+
+  // static function ptr
+  bool(*AreEqual)(double, double) = vtkSlicerRtCommon::AreEqualWithTolerance;
+
+  bool xOpened = !AreEqual( this->X2Jaw, this->X1Jaw);
+  bool yOpened = !AreEqual( this->Y2Jaw, this->Y1Jaw);
+
+  // Check that we have MLC with Jaws opening
+  if (mlcTableNode && xOpened && yOpened)
+  {
+    using PointVector = std::vector< std::pair< double, double > >;
+    using LeafDataVector = std::vector< std::array< double, 4 > >;
+    
+    LeafDataVector mlc; // temporary MLC vector (Boundary and Position)
+    PointVector side12; // real points for side "1" and "2"
+
+    const char* mlcName = mlcTableNode->GetName();
+    bool typeMLCX = !strncmp( "MLCX", mlcName, strlen("MLCX"));
+    bool typeMLCY = !strncmp( "MLCY", mlcName, strlen("MLCY"));
+
+    // copy MLC data for easier processing
+    for ( vtkIdType leaf = 0; leaf < nofLeaves; leaf++)
+    {
+      vtkTable* table = mlcTableNode->GetTable();
+      double boundBegin = mlcBoundArray->GetTuple1(leaf);
+      double boundEnd = mlcBoundArray->GetTuple1(leaf + 1);
+      double pos1 = table->GetValue( leaf, 0).ToDouble();
+      double pos2 = table->GetValue( leaf, 1).ToDouble();
+      
+      mlc.push_back({ boundBegin, boundEnd, pos1, pos2 });
+    }
+
+    auto firstLeafIterator = mlc.end();
+    auto lastLeafIterator = mlc.end();
+    double& jawBegin = this->Y1Jaw;
+    double& jawEnd = this->Y2Jaw;
+    if (typeMLCX)
+    {
+      jawBegin = this->Y1Jaw;
+      jawEnd = this->Y2Jaw;
+    }
+    else if (typeMLCY)
+    {
+      jawBegin = this->X1Jaw;
+      jawEnd = this->X2Jaw;
+    }
+
+    // find first and last opened leaves visible within jaws
+    PointVector side1, side2; // temporary vectors to save visible points
+    for ( auto it = mlc.begin(); it != mlc.end(); ++it)
+    {
+      double& pos1 = (*it)[2]; // leaf position "1"
+      double& pos2 = (*it)[3]; // leaf position "2"
+      bool mlcOpened = !AreEqual( pos1, pos2);
+      bool withinJaw = false;
+      if (typeMLCX)
+      {
+        withinJaw = ((pos1 < this->X1Jaw && pos2 >= this->X1Jaw && pos2 <= this->X2Jaw) || 
+          (pos1 >= this->X1Jaw && pos1 <= this->X2Jaw && pos2 > this->X2Jaw) || 
+          (pos1 <= this->X1Jaw && pos2 >= this->X2Jaw) || 
+          (pos1 >= this->X1Jaw && pos1 <= this->X2Jaw && 
+            pos2 >= this->X1Jaw && pos2 <= this->X2Jaw));
+      }
+      else if (typeMLCY)
+      {
+        withinJaw = ((pos1 < this->Y1Jaw && pos2 >= this->Y1Jaw && pos2 <= this->Y2Jaw) || 
+          (pos1 >= this->Y1Jaw && pos1 <= this->Y2Jaw && pos2 > this->Y2Jaw) || 
+          (pos1 <= this->Y1Jaw && pos2 >= this->Y2Jaw) || 
+          (pos1 >= this->Y1Jaw && pos1 <= this->Y2Jaw && 
+            pos2 >= this->Y1Jaw && pos2 <= this->Y2Jaw));
+      }
+
+      if (withinJaw && mlcOpened && firstLeafIterator == mlc.end())
+      {
+        firstLeafIterator = it;
+      }
+      else if (withinJaw && mlcOpened && firstLeafIterator != mlc.end())
+      {
+        lastLeafIterator = it;
+      }
+    }
+    
+    // iterate through visible leaves to fill temporary points vectors
+    if (firstLeafIterator != mlc.end() && lastLeafIterator != mlc.end())
+    {
+      auto firstLeafIteratorJaws = firstLeafIterator;
+      auto lastLeafIteratorJaws = lastLeafIterator;
+      // find first and last visible leaves using Jaws data
+      for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
+      {
+        double& bound1 = (*it)[0]; // leaf begin boundary
+        double& bound2 = (*it)[1]; // leaf end boundary
+        if (bound1 <= jawBegin && bound2 > jawBegin)
+        {
+          firstLeafIteratorJaws = it;
+        }
+        else if (bound1 <= jawEnd && bound2 > jawEnd)
+        {
+          lastLeafIteratorJaws = it;
+        }
+      }
+
+      // find opened MLC leaves into Jaws opening (logical AND)
+      if (firstLeafIteratorJaws != firstLeafIterator)
+      {
+        firstLeafIterator = std::max( firstLeafIteratorJaws, firstLeafIterator);
+      }
+      if (lastLeafIteratorJaws != lastLeafIterator)
+      {
+        lastLeafIterator = std::min( lastLeafIteratorJaws, lastLeafIterator);
+      }
+
+      // add points for the visible leaves of side "1" and "2"
+      // into side1 and side2 points vectors
+      for ( auto it = firstLeafIterator; it <= lastLeafIterator; ++it)
+      {
+        double& bound1 = (*it)[0]; // leaf begin boundary
+        double& bound2 = (*it)[1]; // leaf end boundary
+        double& pos1 = (*it)[2]; // leaf position "1"
+        double& pos2 = (*it)[3]; // leaf position "2"
+        if (typeMLCX)
+        {
+          side1.push_back({ std::max( pos1, this->X1Jaw), bound1});
+          side1.push_back({ std::max( pos1, this->X1Jaw), bound2});
+          side2.push_back({ std::min( pos2, this->X2Jaw), bound1});
+          side2.push_back({ std::min( pos2, this->X2Jaw), bound2});
+        }
+        else if (typeMLCY)
+        {
+          side1.push_back({ bound1, std::max( pos1, this->Y1Jaw)});
+          side1.push_back({ bound2, std::max( pos1, this->Y1Jaw)});
+          side2.push_back({ bound1, std::min( pos2, this->Y2Jaw)});
+          side2.push_back({ bound2, std::min( pos2, this->Y2Jaw)});
+        }
+      }
+      mlc.clear(); // doesn't need anymore
+
+      // intersection between Jaws and MLC boundary (logical AND) lambda
+      auto intersectJawsMLC = [ jawBegin, jawEnd, typeMLCX, typeMLCY](PointVector::value_type& point)
+      {
+        double& leafBoundary = point.second;
+        if (typeMLCX) // JawsY and MLCX
+        {
+          leafBoundary = point.second;
+        }
+        else if (typeMLCY) // JawsX and MLCY
+        {
+          leafBoundary = point.first;
+        }
+
+        if (leafBoundary <= jawBegin)
+        {
+          leafBoundary = jawBegin;
+        }
+        else if (leafBoundary >= jawEnd)
+        {
+          leafBoundary = jawEnd;
+        }
+      };
+      // apply lambda to side "1"
+      std::for_each( side1.begin(), side1.end(), intersectJawsMLC);
+      // apply lambda to side "2"
+      std::for_each( side2.begin(), side2.end(), intersectJawsMLC);
+
+      // reverse side "2"
+      std::reverse( side2.begin(), side2.end());
+
+      // fill real points vector side12 without excessive points from side1 vector
+      PointVector::value_type& p = side1.front(); // start point
+      double& px = p.first; // x coordinate of p point
+      double& py = p.second; // y coordinate of p point
+      side12.push_back(p);
+      for ( size_t i = 1; i < side1.size() - 1; ++i)
+      {
+        double& pxNext = side1[i + 1].first; // x coordinate of next point
+        double& pyNext = side1[i + 1].second; // y coordinate of next point
+        if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
+        {
+          p = side1[i];
+          side12.push_back(p);
+        }
+      }
+      side12.push_back(side1.back()); // end point
+
+      // same for the side2 vector
+      p = side2.front();
+      side12.push_back(p);
+      for ( size_t i = 1; i < side2.size() - 1; ++i)
+      {
+        double& pxNext = side2[i + 1].first;
+        double& pyNext = side2[i + 1].second;
+        if (!AreEqual( px, pxNext) && !AreEqual( py, pyNext))
+        {
+          p = side2[i];
+          side12.push_back(p);
+        }
+      }
+      side12.push_back(side2.back());
+    }
+    else
+    {
+      vtkErrorMacro("CreateBeamPolyData: Unable to calculate MLC visible data");
+      return;
+    }
+
+    // fill vtk points
+    points->InsertPoint( 0, 0, 0, this->SAD); // source
+
+    // side "1" and "2" points vector
+    vtkIdType pointIds = 0;
+    for ( PointVector::value_type& point : side12)
+    {
+      double& x = point.first;
+      double& y = point.second;
+      points->InsertPoint( pointIds + 1, 2. * x, 2. * y, -this->SAD);
+      pointIds++;
+    }
+    side12.clear(); // doesn't need anymore
+
+    // fill cell array for side "1" and "2"
+    for ( vtkIdType i = 1; i < pointIds; ++i)
+    {
+      cellArray->InsertNextCell(3);
+      cellArray->InsertCellPoint(0);
+      cellArray->InsertCellPoint(i);
+      cellArray->InsertCellPoint(i + 1);
+    }
+
+    // fill cell connection between side "2" -> side "1"
+    cellArray->InsertNextCell(3);
+    cellArray->InsertCellPoint(0);
+    cellArray->InsertCellPoint(1);
+    cellArray->InsertCellPoint(pointIds);
+
+    // Add the cap to the bottom
+    cellArray->InsertNextCell(pointIds);
+    for ( vtkIdType i = 1; i <= pointIds; i++)
+    {
+      cellArray->InsertCellPoint(i);
+    }
+  }
+  else
+  {
+    points->InsertPoint(0,0,0,this->SAD);
+    points->InsertPoint(1, 2*this->X1Jaw, 2*this->Y1Jaw, -this->SAD );
+    points->InsertPoint(2, 2*this->X1Jaw, 2*this->Y2Jaw, -this->SAD );
+    points->InsertPoint(3, 2*this->X2Jaw, 2*this->Y2Jaw, -this->SAD );
+    points->InsertPoint(4, 2*this->X2Jaw, 2*this->Y1Jaw, -this->SAD );
+
+    cellArray->InsertNextCell(3);
+    cellArray->InsertCellPoint(0);
+    cellArray->InsertCellPoint(1);
+    cellArray->InsertCellPoint(2);
+
+    cellArray->InsertNextCell(3);
+    cellArray->InsertCellPoint(0);
+    cellArray->InsertCellPoint(2);
+    cellArray->InsertCellPoint(3);
+
+    cellArray->InsertNextCell(3);
+    cellArray->InsertCellPoint(0);
+    cellArray->InsertCellPoint(3);
+    cellArray->InsertCellPoint(4);
+
+    cellArray->InsertNextCell(3);
+    cellArray->InsertCellPoint(0);
+    cellArray->InsertCellPoint(4);
+    cellArray->InsertCellPoint(1);
+
+    // Add the cap to the bottom
+    cellArray->InsertNextCell(4);
+    cellArray->InsertCellPoint(1);
+    cellArray->InsertCellPoint(2);
+    cellArray->InsertCellPoint(3);
+    cellArray->InsertCellPoint(4);
+  }
+
+  beamModelPolyData->SetPoints(points);
+  beamModelPolyData->SetPolys(cellArray);
+}

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
@@ -347,10 +347,9 @@ void vtkMRMLRTIonBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=n
   }
   else
   {
-    vtkErrorMacro("CreateBeamPolyData: Invalid table node with " \
+    vtkWarningMacro("CreateBeamPolyData: Invalid or absent table node with " \
       "scan spot parameters for a node " 
       << "\"" << this->GetName() << "\"");
-    return;
   }
     
   // Scanning spot beam

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.h
@@ -69,11 +69,15 @@ public:
 public:
   /// Get VSAD distance x component
   vtkGetMacro( VSADx, double);
+  /// Set VSAD distance x component
+  vtkSetMacro( VSADx, double);
   /// Get VSAD distance y component
   vtkGetMacro( VSADy, double);
+  /// Set VSAD distance y component
+  vtkSetMacro( VSADy, double);
 
   /// Set VSAD distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
-  void SetVSAD( double VSADx,  double VSADy);
+  void SetVSAD( double VSADx, double VSADy);
   void SetVSAD(double VSAD[2]);
   void SetVSAD(const std::array< double, 2 >& VSAD);
 
@@ -81,6 +85,7 @@ public:
 
   /// Set scanning spot size for modulated beam
   /// Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetScanningSpotSize(float ScanSpotSize[2]);
   void SetScanningSpotSize(const std::array< float, 2 >& ScanSpotSize);
 
   /// Get isocenter to jaws X distance

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.h
@@ -1,0 +1,101 @@
+/*==============================================================================
+
+  Copyright (c) Radiation Medicine Program, University Health Network,
+  Princess Margaret Hospital, Toronto, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kevin Wang, Princess Margaret Cancer Centre 
+  and was supported by Cancer Care Ontario (CCO)'s ACRU program 
+  with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).
+
+==============================================================================*/
+
+#ifndef __vtkMRMLRTIonBeamNode_h
+#define __vtkMRMLRTIonBeamNode_h
+
+// Beams includes
+#include "vtkSlicerBeamsModuleMRMLExport.h"
+
+// MRML includes
+#include "vtkMRMLRTBeamNode.h"
+
+/// \ingroup SlicerRt_QtModules_Beams
+class VTK_SLICER_BEAMS_MODULE_MRML_EXPORT vtkMRMLRTIonBeamNode : public vtkMRMLRTBeamNode
+{
+
+public:
+  static vtkMRMLRTIonBeamNode *New();
+  vtkTypeMacro(vtkMRMLRTIonBeamNode,vtkMRMLRTBeamNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Create instance of a GAD node. 
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Set node attributes from name/value pairs 
+  void ReadXMLAttributes(const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format. 
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy the node's attributes to this object 
+  void Copy(vtkMRMLNode *node) override;
+
+  /// Make sure display node and transform node are present and valid
+  void SetScene(vtkMRMLScene* scene) override;
+
+  /// Get unique node XML tag name (like Volume, Model) 
+  const char* GetNodeTagName() override { return "RTIonBeam"; };
+
+  /// Create and observe default display node
+  void CreateDefaultDisplayNodes() override;
+
+  /// Create transform node that places the beam poly data in the right position based on geometry.
+  /// Only creates it if missing
+  void CreateDefaultTransformNode() override;
+
+  /// Create transform node that places the beam poly data in the right position based on geometry.
+  /// Always creates a new transform node.
+  void CreateNewBeamTransformNode() override;
+
+public:
+
+  /// Get VSADx distance
+  vtkGetMacro( VSADx, double);
+  /// Set VSADx distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetVSADx(double VSADxComponent);
+
+  /// Get VSADy distance
+  vtkGetMacro( VSADy, double);
+  /// Set VSADy distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetVSADy(double VSADyComponent);
+
+protected:
+  /// Create beam model from beam parameters, supporting MLC leaves
+  /// \param beamModelPolyData Output polydata. If none given then the beam node's own polydata is used
+  virtual void CreateBeamPolyData(vtkPolyData* beamModelPolyData=nullptr);
+
+protected:
+  vtkMRMLRTIonBeamNode();
+  ~vtkMRMLRTIonBeamNode();
+  vtkMRMLRTIonBeamNode(const vtkMRMLRTIonBeamNode&);
+  void operator=(const vtkMRMLRTIonBeamNode&);
+
+// Beam properties
+protected:
+
+  /// Virtual Source-axis distance x component
+  double& VSADx; // using SAD to store value
+  /// Virtual Source-axis distance y component
+  double VSADy;
+};
+
+#endif // __vtkMRMLRTIonBeamNode_h

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.h
@@ -67,21 +67,53 @@ public:
   void CreateNewBeamTransformNode() override;
 
 public:
-
-  /// Get VSADx distance
+  /// Get VSAD distance x component
   vtkGetMacro( VSADx, double);
-  /// Set VSADx distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
-  void SetVSADx(double VSADxComponent);
-
-  /// Get VSADy distance
+  /// Get VSAD distance y component
   vtkGetMacro( VSADy, double);
-  /// Set VSADy distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
-  void SetVSADy(double VSADyComponent);
+
+  /// Set VSAD distance. Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetVSAD( double VSADx,  double VSADy);
+  void SetVSAD(double VSAD[2]);
+  void SetVSAD(const std::array< double, 2 >& VSAD);
+
+  float* GetScanningSpotSize() { return this->ScanningSpotSize.data(); }
+
+  /// Set scanning spot size for modulated beam
+  /// Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetScanningSpotSize(const std::array< float, 2 >& ScanSpotSize);
+
+  /// Get isocenter to jaws X distance
+  vtkGetMacro(IsocenterToJawsDistanceX, double);
+  /// Set isocenter to jaws X distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetIsocenterToJawsDistanceX(double distance);
+
+  /// Get isocenter to jaws Y distance
+  vtkGetMacro(IsocenterToJawsDistanceY, double);
+  /// Set isocenter to jaws Y distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetIsocenterToJawsDistanceY(double distance);
+
+  /// Get isocenter to range shifter distance
+  vtkGetMacro(IsocenterToRangeShifterDistance, double);
+  /// Set isocenter to range shifter. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetIsocenterToRangeShifterDistance(double distance);
+
+  /// Get isocenter to multi-leaf collimator distance
+  vtkGetMacro(IsocenterToMultiLeafCollimatorDistance, double);
+  /// Set isocenter to multi-leaf collimator distance. Triggers \sa BeamTransformModified event and re-generation of beam model
+  void SetIsocenterToMultiLeafCollimatorDistance(double distance);
+
+  /// Set and observe scan spot position map & meterset weights table node
+  /// Triggers \sa BeamGeometryModified event and re-generation of beam model
+  void SetAndObserveScanSpotTableNode(vtkMRMLTableNode* node);
+  /// Get scan spot position map & meterset weights table node
+  vtkMRMLTableNode* GetScanSpotTableNode();
 
 protected:
-  /// Create beam model from beam parameters, supporting MLC leaves
+  /// Create beam model from beam parameters, supporting MLC leaves, jaws
+  /// and scan spot map for modulated scan mode
   /// \param beamModelPolyData Output polydata. If none given then the beam node's own polydata is used
-  virtual void CreateBeamPolyData(vtkPolyData* beamModelPolyData=nullptr);
+  void CreateBeamPolyData(vtkPolyData* beamModelPolyData=nullptr) override;
 
 protected:
   vtkMRMLRTIonBeamNode();
@@ -93,9 +125,22 @@ protected:
 protected:
 
   /// Virtual Source-axis distance x component
-  double& VSADx; // using SAD to store value
+  double& VSADx; // using SAD to store value from vtkMRMLRTBeamNode
   /// Virtual Source-axis distance y component
   double VSADy;
+  /// distance from isocenter to beam limiting device X, ASYMX
+  // using SourceToJawsDistanceX to store value from vtkMRMLRTBeamNode
+  double& IsocenterToJawsDistanceX;
+  /// distance from isocenter to beam limiting device Y, ASYMY
+  // using SourceToJawsDistanceY to store value from vtkMRMLRTBeamNode
+  double& IsocenterToJawsDistanceY;
+  /// distance from isocenter to beam limiting device MLCX, MLCY
+  // using SourceToMultiLeafCollimatorDistance to store value from vtkMRMLRTBeamNode
+  double& IsocenterToMultiLeafCollimatorDistance;
+  /// distance from isocenter to range shifter device
+  double IsocenterToRangeShifterDistance;
+
+  std::array< float, 2 > ScanningSpotSize;
 };
 
 #endif // __vtkMRMLRTIonBeamNode_h

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -830,7 +830,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
   {
     unsigned int dicomBeamNumber = rtReader->GetBeamNumberForIndex(beamIndex);
     const char* beamName = rtReader->GetBeamName(dicomBeamNumber);
-    unsigned int nofCointrolPoints = rtReader->GetNumberOfControlPoints(dicomBeamNumber);
+    unsigned int nofCointrolPoints = rtReader->GetBeamNumberOfControlPoints(dicomBeamNumber);
 
     for ( unsigned int cointrolPointIndex = 0; cointrolPointIndex < nofCointrolPoints; ++cointrolPointIndex)
     {
@@ -863,7 +863,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
 
       // Set beam geometry parameters from DICOM
       double jawPositions[2][2] = {{0.0, 0.0},{0.0, 0.0}};
-      if (rtReader->GetControlPointJawPositions( dicomBeamNumber, cointrolPointIndex, jawPositions))
+      if (rtReader->GetBeamControlPointJawPositions( dicomBeamNumber, cointrolPointIndex, jawPositions))
       {
         beamNode->SetX1Jaw(jawPositions[0][0]);
         beamNode->SetX2Jaw(jawPositions[0][1]);
@@ -871,9 +871,9 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
         beamNode->SetY2Jaw(jawPositions[1][1]);
       }
 
-      beamNode->SetGantryAngle(rtReader->GetControlPointGantryAngle( dicomBeamNumber, cointrolPointIndex));
-      beamNode->SetCollimatorAngle(rtReader->GetControlPointBeamLimitingDeviceAngle( dicomBeamNumber, cointrolPointIndex));
-      beamNode->SetCouchAngle(rtReader->GetControlPointPatientSupportAngle( dicomBeamNumber, cointrolPointIndex));
+      beamNode->SetGantryAngle(rtReader->GetBeamControlPointGantryAngle( dicomBeamNumber, cointrolPointIndex));
+      beamNode->SetCollimatorAngle(rtReader->GetBeamControlPointBeamLimitingDeviceAngle( dicomBeamNumber, cointrolPointIndex));
+      beamNode->SetCouchAngle(rtReader->GetBeamControlPointPatientSupportAngle( dicomBeamNumber, cointrolPointIndex));
 
       // SAD for RTPlan, source to beam limiting devices (Jaws, MLC)
       if (beamNode && !ionBeamNode)
@@ -892,7 +892,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
         ionBeamNode->SetIsocenterToJawsDistanceX(rtReader->GetBeamIsocenterToJawsDistanceX(dicomBeamNumber));
         ionBeamNode->SetIsocenterToJawsDistanceY(rtReader->GetBeamIsocenterToJawsDistanceY(dicomBeamNumber));
         ionBeamNode->SetIsocenterToMultiLeafCollimatorDistance(rtReader->GetBeamIsocenterToMultiLeafCollimatorDistance(dicomBeamNumber));
-        bool res = rtReader->GetControlPointScanningSpotSize( dicomBeamNumber, 
+        bool res = rtReader->GetBeamControlPointScanningSpotSize( dicomBeamNumber, 
           cointrolPointIndex, ScanSpotSize);
         if (res)
         {
@@ -901,7 +901,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
       }
 
       // Set isocenter to parent plan
-      double* isocenter = rtReader->GetControlPointIsocenterPositionRas( dicomBeamNumber, 
+      double* isocenter = rtReader->GetBeamControlPointIsocenterPositionRas( dicomBeamNumber, 
         cointrolPointIndex);
       planNode->SetIsocenterSpecification(vtkMRMLRTPlanNode::ArbitraryPoint);
       if (beamIndex == 0)
@@ -934,7 +934,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
       vtkMRMLTableNode* mlcTableNode = nullptr;
       vtkMRMLDoubleArrayNode* mlcArrayNode = nullptr;
       // Check MLC
-      const char* mlcName = rtReader->GetControlPointMultiLeafCollimatorPositions( dicomBeamNumber, 
+      const char* mlcName = rtReader->GetBeamControlPointMultiLeafCollimatorPositions( dicomBeamNumber, 
         cointrolPointIndex, boundaries, positions);
       if (mlcName)
       {
@@ -957,7 +957,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
       if (ionBeamNode)
       {
         std::vector<float> positions, weights;
-        bool result = rtReader->GetControlPointScanSpotParameters( dicomBeamNumber, 
+        bool result = rtReader->GetBeamControlPointScanSpotParameters( dicomBeamNumber, 
           cointrolPointIndex, positions, weights);
         if (result)
         {

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
@@ -77,7 +77,7 @@ public:
   public:
     BeamLimitingDeviceEntry()
       :
-      SourceIsoDistance(0.),
+      SourceIsoDistance(400.),
       NumberOfPairs(0)
     {
     }
@@ -253,7 +253,7 @@ public:
       Number(0),
       Type("STATIC"),
       RadiationIon({ 0, 0, 0 }),
-      SourceAxisDistance({ 1000., 1000. }),
+      SourceAxisDistance({ 2000., 2000. }),
       SourceIsoToJawsDistance({ 500., 500. }),
       NumberOfCompensators(0),
       NumberOfBlocks(0),
@@ -474,7 +474,7 @@ vtkSlicerDicomRtReader::vtkInternal::ControlPointEntry::ControlPointEntry()
   BeamLimitingDeviceAngle(0.0),
   NominalBeamEnergy(0.0),
   MetersetRate(0.0),
-  JawPositions({ 0.0, 0.0, 0.0, 0.0 })
+  JawPositions({ -100.0, 100.0, -100.0, 100.0 })
 {
 }
 
@@ -1763,7 +1763,7 @@ void vtkSlicerDicomRtReader::vtkInternal::LoadRTIonPlan(DcmDataset* dataset)
             controlPoint.NumberOfPaintings = nofPaintings;
           }
         }
-        
+
         DRTBeamLimitingDevicePositionSequence &currentCollimatorPositionSequence =
           controlPointItem.getBeamLimitingDevicePositionSequence();
         if (currentCollimatorPositionSequence.isValid() &&

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
@@ -80,7 +80,7 @@ public:
 
   /// Get number of control points for a given beams
   /// \result >= 2 if number of control points are valid, 0 otherwise
-  unsigned int GetNumberOfControlPoints(unsigned int beamNumber);
+  unsigned int GetBeamNumberOfControlPoints(unsigned int beamNumber);
 
   /// Get beam number (as defined in DICOM) for a beam index (that is between 0 and numberOfBeams-1)
   unsigned int GetBeamNumberForIndex(unsigned int index);
@@ -98,11 +98,11 @@ public:
   const char* GetBeamRadiationType(unsigned int beamNumber);
 
   /// Get isocenter for a given control point of a beam
-  double* GetControlPointIsocenterPositionRas( unsigned int beamNumber, 
+  double* GetBeamControlPointIsocenterPositionRas( unsigned int beamNumber, 
     unsigned int controlPointIndex);
 
   /// Get nominal beam energy for a given control point of a beam
-  double GetControlPointNominalBeamEnergy( unsigned int beamNumber, 
+  double GetBeamControlPointNominalBeamEnergy( unsigned int beamNumber, 
     unsigned int controlPoint);
 
   /// Get source axis distance for a given beam
@@ -116,21 +116,21 @@ public:
   double GetBeamGantryAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get gantry angle for a given control point of a beam
-  double GetControlPointGantryAngle( unsigned int beamNumber, 
+  double GetBeamControlPointGantryAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
 
   /// Get beam patient support (couch) angle for a given beam
   double GetBeamPatientSupportAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get patient support (couch) angle for a given control point of a beam
-  double GetControlPointPatientSupportAngle( unsigned int beamNumber, 
+  double GetBeamControlPointPatientSupportAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
 
   /// Get beam beam limiting device (collimator) angle for a given beam
   double GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get beam limiting device (collimator) angle for a given control point of a beam
-  double GetControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
+  double GetBeamControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
 
   /// Get beam leaf jaw positions for a given beam
@@ -140,7 +140,7 @@ public:
   /// Get jaw positions for a given control point of a beam
   /// \param jawPositions Array in which the jaw positions are copied
   /// \return true if jaw positions are valid, false otherwise 
-  bool GetControlPointJawPositions( unsigned int beamNumber, 
+  bool GetBeamControlPointJawPositions( unsigned int beamNumber, 
     unsigned int controlPoint, double jawPositions[2][2]);
 
   /// Get MLC leaves boundaries & leaves positions opening for a given beam
@@ -155,14 +155,14 @@ public:
   /// \param positionMap Array in which the raw position map are copied
   /// \param metersetWeights Array in which the raw meterset weights are copied
   /// \return true if data is valid, false otherwise
-  bool GetControlPointScanSpotParameters( unsigned int beamNumber, 
+  bool GetBeamControlPointScanSpotParameters( unsigned int beamNumber, 
     unsigned int controlPointIndex, std::vector<float>& positionMap, 
     std::vector<float>& metersetWeights);
 
   /// Get Scan spot size for a given control point of a modulated ion beam
   /// \param ScanSpotSize Array in which the raw scanning spot size is copied
   /// \return true if data is valid, false otherwise
-  bool GetControlPointScanningSpotSize( unsigned int beamNumber, 
+  bool GetBeamControlPointScanningSpotSize( unsigned int beamNumber, 
     unsigned int controlPointIndex, std::array< float, 2 >& ScanSpotSize);
 
   /// Get source to beam limiting device distance (MLC) for a given beam of RTPlan
@@ -190,7 +190,7 @@ public:
   /// \param pairBoundaries Array in which the raw leaves boundaries are copied
   /// \param leafPositions Array in which the raw leaf positions are copied
   /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
-  const char* GetControlPointMultiLeafCollimatorPositions( unsigned int beamNumber, 
+  const char* GetBeamControlPointMultiLeafCollimatorPositions( unsigned int beamNumber, 
     unsigned int controlPoint, std::vector<double>& pairBoundaries, 
     std::vector<double>& leafPositions);
 

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
@@ -80,7 +80,7 @@ public:
 
   /// Get number of control points for a given beams
   /// \result >= 2 if number of control points are valid, 0 otherwise
-//  unsigned int GetBeamNumberOfControlPoints(unsigned int beamNumber);
+  unsigned int GetNumberOfControlPoints(unsigned int beamNumber);
 
   /// Get beam number (as defined in DICOM) for a beam index (that is between 0 and numberOfBeams-1)
   unsigned int GetBeamNumberForIndex(unsigned int index);
@@ -89,73 +89,110 @@ public:
   const char* GetBeamName(unsigned int beamNumber);
 
   /// Get beam isocenter for a given beam
-  double* GetBeamIsocenterPositionRas(unsigned int beamNumber);
+  double* GetBeamIsocenterPositionRas(unsigned int beamNumber); // DEPRICATED
+
+  /// Get radiation type (primary particle) for a given beam
+  const char* GetBeamTreatmentDeliveryType(unsigned int beamNumber);
+
+  /// Get radiation type (primary particle) for a given beam
+  const char* GetBeamRadiationType(unsigned int beamNumber);
 
   /// Get isocenter for a given control point of a beam
-//  double* GetControlPointIsocenterPositionRas( unsigned int beamNumber, 
-//    unsigned int controlPoint);
+  double* GetControlPointIsocenterPositionRas( unsigned int beamNumber, 
+    unsigned int controlPointIndex);
 
-  /// Get beam source axis distance for a given beam
+  /// Get nominal beam energy for a given control point of a beam
+  double GetControlPointNominalBeamEnergy( unsigned int beamNumber, 
+    unsigned int controlPoint);
+
+  /// Get source axis distance for a given beam
   double GetBeamSourceAxisDistance(unsigned int beamNumber);
-
-  /// Get source axis distance for a given control point of a beam
-//  double GetControlPointSourceAxisDistance( unsigned int beamNumber, 
-//    unsigned int controlPoint);
 
   /// Get virtual source axis distance for a given control point of a beam
   /// \return pointer to VSAD[2], or nullptr othervise
-//  double* GetControlPointVirtualSourceAxisDistance( unsigned int beamNumber, 
-//    unsigned int controlPoint);
+  double* GetBeamVirtualSourceAxisDistance(unsigned int beamNumber);
 
   /// Get beam gantry angle for a given beam
-  double GetBeamGantryAngle(unsigned int beamNumber);
+  double GetBeamGantryAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get gantry angle for a given control point of a beam
-//  double GetControlPointGantryAngle( unsigned int beamNumber, 
-//    unsigned int controlPoint);
+  double GetControlPointGantryAngle( unsigned int beamNumber, 
+    unsigned int controlPoint);
 
   /// Get beam patient support (couch) angle for a given beam
-  double GetBeamPatientSupportAngle(unsigned int beamNumber);
+  double GetBeamPatientSupportAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get patient support (couch) angle for a given control point of a beam
-//  double GetControlPointPatientSupportAngle( unsigned int beamNumber, 
-//    unsigned int controlPoint);
+  double GetControlPointPatientSupportAngle( unsigned int beamNumber, 
+    unsigned int controlPoint);
 
   /// Get beam beam limiting device (collimator) angle for a given beam
-  double GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber);
+  double GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber); // DEPRICATED
 
   /// Get beam limiting device (collimator) angle for a given control point of a beam
-//  double GetControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
-//    unsigned int controlPoint);
+  double GetControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
+    unsigned int controlPoint);
 
   /// Get beam leaf jaw positions for a given beam
   /// \param jawPositions Array in which the jaw positions are copied
-  void GetBeamLeafJawPositions(unsigned int beamNumber, double jawPositions[2][2]);
+  void GetBeamLeafJawPositions(unsigned int beamNumber, double jawPositions[2][2]); // DEPRICATED
 
-  /// Get leaf jaw positions for a given control point of a beam
+  /// Get jaw positions for a given control point of a beam
   /// \param jawPositions Array in which the jaw positions are copied
-//  void GetControlPointLeafJawPositions( unsigned int beamNumber, 
-//    unsigned int controlPoint, double jawPositions[2][2]);
+  /// \return true if jaw positions are valid, false otherwise 
+  bool GetControlPointJawPositions( unsigned int beamNumber, 
+    unsigned int controlPoint, double jawPositions[2][2]);
 
   /// Get MLC leaves boundaries & leaves positions opening for a given beam
   /// \param pairBoundaries Array in which the raw leaves boundaries are copied
   /// \param leafPositions Array in which the raw leaf positions are copied
   /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
   const char* GetBeamMultiLeafCollimatorPositions( unsigned int beamNumber, 
-    std::vector<double>& pairBoundaries, std::vector<double>& leafPositions);
+    std::vector<double>& pairBoundaries, std::vector<double>& leafPositions); // DEPRICATED
 
-  /// Get source to beam limiting device distance (MLC) for a given beam
+  /// Get Scan spot position map and meterset weights for a given 
+  /// control point of a modulated ion beam
+  /// \param positionMap Array in which the raw position map are copied
+  /// \param metersetWeights Array in which the raw meterset weights are copied
+  /// \return true if data is valid, false otherwise
+  bool GetControlPointScanSpotParameters( unsigned int beamNumber, 
+    unsigned int controlPointIndex, std::vector<float>& positionMap, 
+    std::vector<float>& metersetWeights);
+
+  /// Get Scan spot size for a given control point of a modulated ion beam
+  /// \param ScanSpotSize Array in which the raw scanning spot size is copied
+  /// \return true if data is valid, false otherwise
+  bool GetControlPointScanningSpotSize( unsigned int beamNumber, 
+    unsigned int controlPointIndex, std::array< float, 2 >& ScanSpotSize);
+
+  /// Get source to beam limiting device distance (MLC) for a given beam of RTPlan
+  /// or isocenter to beam limiting device distance (MLC) for a given beam of RTIonPlan
   /// \param beamNumber - number of a beam
-  /// \return source to beam limiting device distance
-  double GetBeamSourceToMultiLeafCollimatorDistance( unsigned int beamNumber);
+  /// \return source to beam limiting device distance, 0.0 in case of an error
+  double GetBeamSourceToMultiLeafCollimatorDistance(unsigned int beamNumber);
+  double GetBeamIsocenterToMultiLeafCollimatorDistance(unsigned int beamNumber);
+
+  /// Get source to beam limiting device distance (Jaws X) for a given beam of RTPlan
+  /// or isocenter to beam limiting device distance (Jaws X) for a given beam of RTIonPlan
+  /// \param beamNumber - number of a beam
+  /// \return source to beam limiting device distance, 0.0 in case of an error
+  double GetBeamSourceToJawsDistanceX(unsigned int beamNumber);
+  double GetBeamIsocenterToJawsDistanceX(unsigned int beamNumber);
+
+  /// Get source to beam limiting device distance (Jaws Y) for a given beam of RTPlan
+  /// or isocenter to beam limiting device distance (Jaws Y) for a given beam of RTIonPlan
+  /// \param beamNumber - number of a beam
+  /// \return source to beam limiting device distance, 0.0 in case of an error
+  double GetBeamSourceToJawsDistanceY(unsigned int beamNumber);
+  double GetBeamIsocenterToJawsDistanceY(unsigned int beamNumber);
 
   /// Get MLC leaves boundaries & leaves positions opening for a given control point of a beam
   /// \param pairBoundaries Array in which the raw leaves boundaries are copied
   /// \param leafPositions Array in which the raw leaf positions are copied
   /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
-//  const char* GetControlPointMultiLeafCollimatorPositions( unsigned int beamNumber, 
-//    unsigned int controlPoint, std::vector<double>& pairBoundaries, 
-//    std::vector<double>& leafPositions);
+  const char* GetControlPointMultiLeafCollimatorPositions( unsigned int beamNumber, 
+    unsigned int controlPoint, std::vector<double>& pairBoundaries, 
+    std::vector<double>& leafPositions);
 
   /// Get number of channels
   int GetNumberOfChannels();

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
@@ -78,6 +78,10 @@ public:
   /// Get number of beams
   int GetNumberOfBeams();
 
+  /// Get number of control points for a given beams
+  /// \result >= 2 if number of control points are valid, 0 otherwise
+//  unsigned int GetBeamNumberOfControlPoints(unsigned int beamNumber);
+
   /// Get beam number (as defined in DICOM) for a beam index (that is between 0 and numberOfBeams-1)
   unsigned int GetBeamNumberForIndex(unsigned int index);
 
@@ -87,35 +91,51 @@ public:
   /// Get beam isocenter for a given beam
   double* GetBeamIsocenterPositionRas(unsigned int beamNumber);
 
+  /// Get isocenter for a given control point of a beam
+//  double* GetControlPointIsocenterPositionRas( unsigned int beamNumber, 
+//    unsigned int controlPoint);
+
   /// Get beam source axis distance for a given beam
   double GetBeamSourceAxisDistance(unsigned int beamNumber);
+
+  /// Get source axis distance for a given control point of a beam
+//  double GetControlPointSourceAxisDistance( unsigned int beamNumber, 
+//    unsigned int controlPoint);
+
+  /// Get virtual source axis distance for a given control point of a beam
+  /// \return pointer to VSAD[2], or nullptr othervise
+//  double* GetControlPointVirtualSourceAxisDistance( unsigned int beamNumber, 
+//    unsigned int controlPoint);
 
   /// Get beam gantry angle for a given beam
   double GetBeamGantryAngle(unsigned int beamNumber);
 
+  /// Get gantry angle for a given control point of a beam
+//  double GetControlPointGantryAngle( unsigned int beamNumber, 
+//    unsigned int controlPoint);
+
   /// Get beam patient support (couch) angle for a given beam
   double GetBeamPatientSupportAngle(unsigned int beamNumber);
 
+  /// Get patient support (couch) angle for a given control point of a beam
+//  double GetControlPointPatientSupportAngle( unsigned int beamNumber, 
+//    unsigned int controlPoint);
+
   /// Get beam beam limiting device (collimator) angle for a given beam
   double GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber);
+
+  /// Get beam limiting device (collimator) angle for a given control point of a beam
+//  double GetControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
+//    unsigned int controlPoint);
 
   /// Get beam leaf jaw positions for a given beam
   /// \param jawPositions Array in which the jaw positions are copied
   void GetBeamLeafJawPositions(unsigned int beamNumber, double jawPositions[2][2]);
 
-  /// Get MLCX leaves boundaries & leaves positions opening for a given beam
-  /// \param pairBoundaries Array in which the raw leaves boundaries are copied
-  /// \param leafPositions Array in which the raw leaf positions are copied
-  /// \return true if data is valid, false otherwise
-  bool GetBeamMultiLeafCollimatorPositionsX( unsigned int beamNumber, 
-    std::vector<double>& pairBoundaries, std::vector<double>& leafPositions);
-
-  /// Get MLCY leaves boundaries & leaves positions opening for a given beam
-  /// \param pairBoundaries Array in which the raw leaves boundaries are copied
-  /// \param leafPositions Array in which the raw leaf positions are copied
-  /// \return true if data is valid, false otherwise
-  bool GetBeamMultiLeafCollimatorPositionsY( unsigned int beamNumber, 
-    std::vector<double>& pairBoundaries, std::vector<double>& leafPositions);
+  /// Get leaf jaw positions for a given control point of a beam
+  /// \param jawPositions Array in which the jaw positions are copied
+//  void GetControlPointLeafJawPositions( unsigned int beamNumber, 
+//    unsigned int controlPoint, double jawPositions[2][2]);
 
   /// Get MLC leaves boundaries & leaves positions opening for a given beam
   /// \param pairBoundaries Array in which the raw leaves boundaries are copied
@@ -123,6 +143,19 @@ public:
   /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
   const char* GetBeamMultiLeafCollimatorPositions( unsigned int beamNumber, 
     std::vector<double>& pairBoundaries, std::vector<double>& leafPositions);
+
+  /// Get source to beam limiting device distance (MLC) for a given beam
+  /// \param beamNumber - number of a beam
+  /// \return source to beam limiting device distance
+  double GetBeamSourceToMultiLeafCollimatorDistance( unsigned int beamNumber);
+
+  /// Get MLC leaves boundaries & leaves positions opening for a given control point of a beam
+  /// \param pairBoundaries Array in which the raw leaves boundaries are copied
+  /// \param leafPositions Array in which the raw leaf positions are copied
+  /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
+//  const char* GetControlPointMultiLeafCollimatorPositions( unsigned int beamNumber, 
+//    unsigned int controlPoint, std::vector<double>& pairBoundaries, 
+//    std::vector<double>& leafPositions);
 
   /// Get number of channels
   int GetNumberOfChannels();
@@ -234,6 +267,8 @@ public:
   vtkGetMacro(LoadRTDoseSuccessful, bool);
   /// Get load plan successful flag
   vtkGetMacro(LoadRTPlanSuccessful, bool);
+  /// Get load plan successful flag
+  vtkGetMacro(LoadRTIonPlanSuccessful, bool); 
   /// Get load image successful flag
   vtkGetMacro(LoadRTImageSuccessful, bool);
 
@@ -311,6 +346,9 @@ protected:
 
   /// Flag indicating if RT Plan has been successfully read from the input dataset
   bool LoadRTPlanSuccessful;
+
+  /// Flag indicating if RT Ion Plan has been successfully read from the input dataset
+  bool LoadRTIonPlanSuccessful;
 
   /// Flag indicating if RT Image has been successfully read from the input dataset
   bool LoadRTImageSuccessful;


### PR DESCRIPTION
Greetings,

vtkSlicerDicomRtReader class - RTIonPlan support and control points support, some C-like arrays replaced with std::array for easier copy and assign operations. Scan spot position map inital support for modulated scan type of rt ion beam. Fraction module from DICOM is used to check if beams are available.

vtkSlicerDicomRtImportExportModuleLogic class - each control point is represented as a separate beam. Table nodes are set a children of a corresponding beam nodes.

vtkMRMLRTIonBeamNode class is added for ion beam parameters and visualization.

vtkMRMLRTBeamNode multiple visible sections of MLC opening have been added (corvus-6.2.2-phantom example data control point 10 & 11)

I can split this pull request on several parts if its very big.