### PR TITLE
STYLE: Subject hierarchy beam node items moved to LoadExternalBeamPlan

### DIFF
--- a/DicomRtImportExport/Testing/Python/DicomRtImportTest.py
+++ b/DicomRtImportExport/Testing/Python/DicomRtImportTest.py
@@ -147,14 +147,14 @@ class DicomRtImportTest(unittest.TestCase):
     # Volumes: Dose, RT image
     self.assertEqual( len( slicer.util.getNodes('vtkMRMLScalarVolumeNode*') ), 2 )
     # Model hierarchies: Beam models (parent + individual beams)
-    self.assertEqual( len( slicer.util.getNodes('vtkMRMLModelHierarchyNode*') ), 11 )
+    self.assertEqual( len( slicer.util.getNodes('vtkMRMLModelHierarchyNode*') ), 6 )
     # Segmentation: The loaded structures
     self.assertEqual( len( slicer.util.getNodes('vtkMRMLSegmentationNode*') ), 1 )
     # Markups: the RT plan POI
     self.assertEqual( len( slicer.util.getNodes('vtkMRMLMarkupsFiducialNode*') ), 1 )
     # Subject hierarchy items
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
-    self.assertEqual( shNode.GetNumberOfItems(), 42 )
+    self.assertEqual( shNode.GetNumberOfItems(), 28 )
 
   #------------------------------------------------------------------------------
   def TestSection_SaveScene(self):


### PR DESCRIPTION
After latest changes (removed batch processing) i moved subject hierarchy items for MLC and ScanSpot table nodes from LoadRtPlan method to LoadExternalBeamPlan which is looked more reasonable.

Everything works just the same, except RTPlan with dozens of beams load very slow.

UPD: all tests passed (linux biuld) except py_IGRTWorkflow_SelfTest