### PR TITLE
Double array node removed from MLC data storage

### DIFF
--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
@@ -244,7 +244,7 @@ void vtkSlicerBeamsModuleLogic::ProcessMRMLNodesEvents(vtkObject* caller, unsign
         // if caller node and referenced table node is the same
         // update beam polydata
         vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(*beamIterator);
-        vtkMRMLTableNode* beamMLCTableNode = beamNode->GetMLCPositionTableNode();
+        vtkMRMLTableNode* beamMLCTableNode = beamNode->GetMultiLeafCollimatorTableNode();
         vtkMRMLTableNode* tableNode = vtkMRMLTableNode::SafeDownCast(caller);
         if (beamMLCTableNode == tableNode)
         {

--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -660,7 +660,6 @@ void vtkMRMLRTBeamNode::CreateBeamPolyData(vtkPolyData* beamModelPolyData/*=null
         append->AddInputData(beamPolyData);
       }
     }
-
     append->Update();
     beamModelPolyData->ShallowCopy(append->GetOutput());
   }

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -30,7 +30,6 @@
 
 class vtkPolyData;
 class vtkMRMLScene;
-class vtkMRMLDoubleArrayNode;
 class vtkMRMLTableNode;
 class vtkMRMLRTPlanNode;
 class vtkMRMLScalarVolumeNode;
@@ -99,17 +98,11 @@ public:
   /// Get parent plan node
   vtkMRMLRTPlanNode* GetParentPlanNode();
 
-  /// Get MLC boundary double array node
-  vtkMRMLDoubleArrayNode* GetMLCBoundaryDoubleArrayNode();
-  /// Set and observe MLC boundary double array node.
+  /// Get MLC boundary and position table node
+  vtkMRMLTableNode* GetMultiLeafCollimatorTableNode();
+  /// Set and observe MLC boundary and position table node
   /// Triggers \sa BeamGeometryModified event and re-generation of beam model
-  void SetAndObserveMLCBoundaryDoubleArrayNode(vtkMRMLDoubleArrayNode* node);
-
-  /// Get MLC position table node
-  vtkMRMLTableNode* GetMLCPositionTableNode();
-  /// Set and observe MLC position table node
-  /// Triggers \sa BeamGeometryModified event and re-generation of beam model
-  void SetAndObserveMLCPositionTableNode(vtkMRMLTableNode* node);
+  void SetAndObserveMultiLeafCollimatorTableNode(vtkMRMLTableNode* node);
 
   /// Get DRR volume node
   vtkMRMLScalarVolumeNode* GetDRRVolumeNode();
@@ -257,7 +250,7 @@ private:
   /// \brief Create visible points of MLC enclosure (perimeter) 
   ///  in IEC BEAM LIMITING DEVICE coordinate axis (isocenter plane)
   void CreateMLCPointsFromSectionBorder( double jawBegin, double jawEnd, 
-    bool typeMLCX, bool typeMLCY, const MLCSectionVector::value_type& sectionBorder, 
+    bool mlcType, const MLCSectionVector::value_type& sectionBorder, 
     MLCVisiblePointVector& side12);
 };
 

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
@@ -29,7 +29,6 @@
 // MRML includes
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLScalarVolumeNode.h>
-#include <vtkMRMLDoubleArrayNode.h>
 #include <vtkMRMLTableNode.h>
 #include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLLinearTransformNode.h>

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -742,59 +742,21 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadRtPlan(vtkSlicerD
       this->SetupRtImageGeometry(beamNode);
     }
   }
-/*
-  // Exec after batch processing has ended (once again)
+
+  // Allow beam modification after all beams are loaded
   if (beams)
   {
     for (int i=0; i<beams->GetNumberOfItems(); ++i)
     {
       vtkMRMLRTBeamNode *beamNode = vtkMRMLRTBeamNode::SafeDownCast(beams->GetItemAsObject(i));
 
-      vtkIdType beamShId = vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
-      vtkIdType mlcPositionShId = vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
-
       if (beamNode)
       {
-        // Update beam node using observed nodes, and don't show display nodes of the beams
-        // set beam node as a parent for a observed nodes
- //       beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
-        vtkMRMLModelDisplayNode* displayNode = vtkMRMLModelDisplayNode::SafeDownCast(beamNode->GetDisplayNode());
-        if (displayNode)
-        {
-          displayNode->VisibilityOff();
-        }
-        // put observed mlc data under beam and ion beam node parent
-        beamShId = shNode->GetItemByDataNode(beamNode);
-        if (vtkMRMLTableNode* mlcTableNode = beamNode->GetMultiLeafCollimatorTableNode())
-        {
-          mlcPositionShId = shNode->GetItemByDataNode(mlcTableNode);
-        }
-        if (beamShId != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID && 
-          mlcPositionShId != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
-        {
-          shNode->SetItemParent( mlcPositionShId, beamShId);
-        }
-
-        // put observed scan spot data under ion beam node parent
-        if (vtkMRMLRTIonBeamNode *ionBeamNode = vtkMRMLRTIonBeamNode::SafeDownCast(beamNode))
-        {
-          vtkIdType scanSpotShId = vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
-
-          if (vtkMRMLTableNode* scanSpotTableNode = ionBeamNode->GetScanSpotTableNode())
-          {
-            scanSpotShId = shNode->GetItemByDataNode(scanSpotTableNode);
-          }
-
-          if (beamShId != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID && 
-            scanSpotShId != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
-          {
-            shNode->SetItemParent( scanSpotShId, beamShId);
-          }
-        }
+        beamNode->DisableModifiedEventOff();
       }
     }
   }
-*/
+
   return true;
 }
 
@@ -999,7 +961,7 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
         ionBeamNode->SetAndObserveScanSpotTableNode(scanSpotTableNode);
       }
 
-      // Update beam geometry (allow beam modification)
+      // Update beam geometry
       beamNode->InvokePendingModifiedEvent();
 
       // Create beam model hierarchy root node if has not been created yet

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
@@ -2665,12 +2665,6 @@ const char* vtkSlicerDicomRtReader::GetBeamType(unsigned int beamNumber)
   return (beam->Type.empty() ? nullptr : beam->Type.c_str());
 }
 
-//---------------------------------------------------------------------------- DEPRECATED
-double* vtkSlicerDicomRtReader::GetBeamIsocenterPositionRas(unsigned int beamNumber)
-{
-  return GetBeamControlPointIsocenterPositionRas( beamNumber, 0);
-}
-
 //----------------------------------------------------------------------------
 const char* vtkSlicerDicomRtReader::GetBeamTreatmentDeliveryType(unsigned int beamNumber)
 {
@@ -2743,12 +2737,6 @@ double* vtkSlicerDicomRtReader::GetBeamVirtualSourceAxisDistance(unsigned int be
   return beam->SourceAxisDistance.data();
 }
 
-//---------------------------------------------------------------------------- DEPRECATED
-double vtkSlicerDicomRtReader::GetBeamGantryAngle(unsigned int beamNumber)
-{
-  return GetBeamControlPointGantryAngle( beamNumber, 0);
-}
-
 //----------------------------------------------------------------------------
 double vtkSlicerDicomRtReader::GetBeamControlPointGantryAngle( unsigned int beamNumber, 
   unsigned int controlPointIndex)
@@ -2770,12 +2758,6 @@ double vtkSlicerDicomRtReader::GetBeamControlPointGantryAngle( unsigned int beam
      "No control point sequence data for current beam: " << beam->Name);
   }
   return 0.0;
-}
-
-//---------------------------------------------------------------------------- DEPRECATED
-double vtkSlicerDicomRtReader::GetBeamPatientSupportAngle(unsigned int beamNumber)
-{
-  return GetBeamControlPointPatientSupportAngle( beamNumber, 0);
 }
 
 //----------------------------------------------------------------------------
@@ -2801,12 +2783,6 @@ double vtkSlicerDicomRtReader::GetBeamControlPointPatientSupportAngle( unsigned 
   return 0.0;
 }
 
-//---------------------------------------------------------------------------- DEPRECATED
-double vtkSlicerDicomRtReader::GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber)
-{
-  return GetBeamControlPointBeamLimitingDeviceAngle( beamNumber, 0);
-}
-
 //----------------------------------------------------------------------------
 double vtkSlicerDicomRtReader::GetBeamControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
   unsigned int controlPointIndex)
@@ -2828,12 +2804,6 @@ double vtkSlicerDicomRtReader::GetBeamControlPointBeamLimitingDeviceAngle( unsig
      "No control point sequence data for current beam: " << beam->Name);
   }
   return 0.0;
-}
-
-//---------------------------------------------------------------------------- DEPRECATED
-void vtkSlicerDicomRtReader::GetBeamLeafJawPositions(unsigned int beamNumber, double jawPositions[2][2])
-{
-  GetBeamControlPointJawPositions( beamNumber, 0, jawPositions);
 }
 
 //----------------------------------------------------------------------------
@@ -2861,14 +2831,6 @@ bool vtkSlicerDicomRtReader::GetBeamControlPointJawPositions( unsigned int beamN
      "No control point sequence data for current beam: " << beam->Name);
   }
   return false;
-}
-
-//---------------------------------------------------------------------------- DEPRECATED
-const char* vtkSlicerDicomRtReader::GetBeamMultiLeafCollimatorPositions( unsigned int beamNumber, 
-  std::vector<double>& pairBoundaries, std::vector<double>& leafPositions)
-{
-  return GetBeamControlPointMultiLeafCollimatorPositions( beamNumber, 0, 
-    pairBoundaries, leafPositions);
 }
 
 //----------------------------------------------------------------------------

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.h
@@ -91,9 +91,6 @@ public:
   /// Get type of beam
   const char* GetBeamType(unsigned int beamNumber);
 
-  /// Get beam isocenter for a given beam
-  double* GetBeamIsocenterPositionRas(unsigned int beamNumber); // DEPRECATED
-
   /// Get radiation type (primary particle) for a given beam
   const char* GetBeamTreatmentDeliveryType(unsigned int beamNumber);
 
@@ -115,43 +112,23 @@ public:
   /// \return pointer to VSAD[2], or nullptr othervise
   double* GetBeamVirtualSourceAxisDistance(unsigned int beamNumber);
 
-  /// Get beam gantry angle for a given beam
-  double GetBeamGantryAngle(unsigned int beamNumber); // DEPRECATED
-
   /// Get gantry angle for a given control point of a beam
   double GetBeamControlPointGantryAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
-
-  /// Get beam patient support (couch) angle for a given beam
-  double GetBeamPatientSupportAngle(unsigned int beamNumber); // DEPRECATED
 
   /// Get patient support (couch) angle for a given control point of a beam
   double GetBeamControlPointPatientSupportAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
 
-  /// Get beam beam limiting device (collimator) angle for a given beam
-  double GetBeamBeamLimitingDeviceAngle(unsigned int beamNumber); // DEPRECATED
-
   /// Get beam limiting device (collimator) angle for a given control point of a beam
   double GetBeamControlPointBeamLimitingDeviceAngle( unsigned int beamNumber, 
     unsigned int controlPoint);
-
-  /// Get beam leaf jaw positions for a given beam
-  /// \param jawPositions Array in which the jaw positions are copied
-  void GetBeamLeafJawPositions(unsigned int beamNumber, double jawPositions[2][2]); // DEPRECATED
 
   /// Get jaw positions for a given control point of a beam
   /// \param jawPositions Array in which the jaw positions are copied
   /// \return true if jaw positions are valid, false otherwise 
   bool GetBeamControlPointJawPositions( unsigned int beamNumber, 
     unsigned int controlPoint, double jawPositions[2][2]);
-
-  /// Get MLC leaves boundaries & leaves positions opening for a given beam
-  /// \param pairBoundaries Array in which the raw leaves boundaries are copied
-  /// \param leafPositions Array in which the raw leaf positions are copied
-  /// \return "MLCX" or "MLCY" if data is valid, nullptr otherwise
-  const char* GetBeamMultiLeafCollimatorPositions( unsigned int beamNumber, 
-    std::vector<double>& pairBoundaries, std::vector<double>& leafPositions); // DEPRECATED
 
   /// Get Scan spot position map and meterset weights for a given 
   /// control point of a modulated ion beam


### PR DESCRIPTION
All the MLC data use single table node, plus some minor changes in beam node. 

Obsolete methods have been removed from DicomRtReader. 

Some changes in DicomRtImportExportModuleLogic for faster loading of RtPlan with dozens of beams (control points).
