### PR TITLE
BUG: Multiple control points loading is disabled, only control point 0 will be loaded (issue #145)

### DIFF
--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -805,7 +805,12 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadExternalBeamPlan(
         nofCointrolPoints = 1; // will be used only control point 0
       }
     }
-    
+
+    //TODO: Implement correct loading of multiple control points (e.g. sequence nodes)
+    singleBeam = true;
+    vtkWarningWithObjectMacro( this->External, "LoadExternalBeamPlan: Multiple control points loading are currently disabled!");
+    nofCointrolPoints = 1; // will be used only control point 0
+
     for ( unsigned int cointrolPointIndex = 0; cointrolPointIndex < nofCointrolPoints; ++cointrolPointIndex)
     {
       // Create the beam node for each control point


### PR DESCRIPTION
Temporary fix for issue #145. Tests are passed, except python scripts.

If multiple control points are not required immediately.