### PR TITLE
ENH: Sequence nodes are used for dynamic beam with multiple control points, static beam with two control point is loaded as usual

### DIFF
--- a/BatchProcessing/BatchStructureSetConversion.py
+++ b/BatchProcessing/BatchStructureSetConversion.py
@@ -228,7 +228,7 @@ class BatchStructureSetConversionTest(ScriptedLoadableModuleTest):
 
       # Download, unzip, import, and load data. Verify selected plugins and loaded nodes.
       selectedPlugins = { 'Scalar Volume':1, 'RT':2 }
-      loadedNodes = { 'vtkMRMLScalarVolumeNode':2, \
+      loadedNodes = { 'vtkMRMLScalarVolumeNode':3, \
                       'vtkMRMLSegmentationNode':1 }
       with DICOMUtils.LoadDICOMFilesToDatabase( \
           self.dicomZipFileUrl, self.dicomZipFilePath, \

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
@@ -187,6 +187,33 @@ void vtkSlicerBeamsModuleLogic::UpdateTransformForBeam(vtkMRMLRTBeamNode* beamNo
   iecLogic->UpdateBeamTransform(beamNode);
 }
 
+//---------------------------------------------------------------------------
+void vtkSlicerBeamsModuleLogic::UpdateTransformForBeam( vtkMRMLScene* beamSequenceScene, 
+  vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter)
+{
+  if (!beamNode)
+  {
+    vtkErrorMacro("UpdateTransformForBeam: Invalid beam node");
+    return;
+  }
+  if (!beamTransformNode)
+  {
+    vtkErrorMacro("UpdateTransformForBeam: Invalid beam transform node");
+    return;
+  }
+
+  if (!beamSequenceScene)
+  {
+    vtkErrorMacro("UpdateTransformForBeam: Invalid MRML scene");
+    return;
+  }
+
+  //TODO: Use one IEC logic in a private scene for all beam transform updates?
+  vtkSmartPointer<vtkSlicerIECTransformLogic> iecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
+  iecLogic->SetMRMLScene(beamSequenceScene);
+  iecLogic->UpdateBeamTransform( beamNode, beamTransformNode, isocenter);
+}
+
 //----------------------------------------------------------------------------
 void vtkSlicerBeamsModuleLogic::ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData)
 {

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -50,6 +50,16 @@ public:
 
   vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);
 
+  /// Update parent transform of a given beam using its parameters and the IEC logic
+  /// without using plan node (only isocenter position)
+  /// @param beamSequenceScene - inner scene of the beam sequence node
+  /// @param beamNode - a current beam node (must be added to the beam sequence node beforehand)
+  /// @param beamTransformNode - parent transform of the beam according to the beam parameters and isocenter
+  /// @param isocenter - isocenter position
+  /// \warning This method is used only in vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequence
+  void UpdateTransformForBeam( vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode, 
+    vtkMRMLLinearTransformNode* beamTransformNode, double isocenter[3]);
+
 protected:
   vtkSlicerBeamsModuleLogic();
   ~vtkSlicerBeamsModuleLogic() override;

--- a/Beams/Logic/vtkSlicerIECTransformLogic.h
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.h
@@ -135,8 +135,12 @@ public:
 
   /// Update parent transform node of a given beam from the IEC transform hierarchy and the beam parameters
   void UpdateBeamTransform(vtkMRMLRTBeamNode* beamNode);
+  /// Update parent transform node of a given beam from the IEC transform hierarchy and the beam parameters
+  /// \warning This method is used only in vtkSlicerBeamsModuleLogic::UpdateTransformForBeam
+  void UpdateBeamTransform( vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter);
+
   /// Update IEC transforms according to beam node
-  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode);
+  void UpdateIECTransformsFromBeam( vtkMRMLRTBeamNode* beamNode, double* isocenter = nullptr);
 
 protected:
   /// Get name of transform node between two coordinate systems

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -34,6 +34,7 @@ class vtkMRMLTableNode;
 class vtkMRMLRTPlanNode;
 class vtkMRMLScalarVolumeNode;
 class vtkMRMLSegmentationNode;
+class vtkMRMLLinearTransformNode;
 
 /// \ingroup SlicerRt_QtModules_Beams
 class VTK_SLICER_BEAMS_MODULE_MRML_EXPORT vtkMRMLRTBeamNode : public vtkMRMLModelNode
@@ -70,6 +71,9 @@ public:
   /// Copy the node's attributes to this object 
   void Copy(vtkMRMLNode *node) override;
 
+  /// Copy node content (excludes basic data, such a name and node reference)
+  vtkMRMLCopyContentMacro(vtkMRMLRTBeamNode);
+
   /// Make sure display node and transform node are present and valid
   void SetScene(vtkMRMLScene* scene) override;
 
@@ -86,6 +90,11 @@ public:
   /// Create transform node that places the beam poly data in the right position based on geometry.
   /// Always creates a new transform node.
   virtual void CreateNewBeamTransformNode();
+
+  /// Create transform node that places the beam poly data in the right position based on geometry.
+  /// Always creates a new transform node.
+  /// This method is used only in vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequence
+  virtual vtkMRMLLinearTransformNode* CreateBeamTransformNode(vtkMRMLScene *externalScene);
 
   /// Update beam poly data based on beam geometry parameters (jaws, MLC)
   void UpdateGeometry();

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.cxx
@@ -172,6 +172,39 @@ void vtkMRMLRTIonBeamNode::Copy(vtkMRMLNode *anode)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLRTIonBeamNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent( anode, deepCopy);
+
+  vtkMRMLRTIonBeamNode* node = vtkMRMLRTIonBeamNode::SafeDownCast(anode);
+  if (!node)
+  {
+    return;
+  }
+
+  this->SetBeamNumber(node->GetBeamNumber());
+  this->SetBeamDescription(node->GetBeamDescription());
+  this->SetBeamWeight(node->GetBeamWeight());
+
+  this->SetX1Jaw(node->GetX1Jaw());
+  this->SetX2Jaw(node->GetX2Jaw());
+  this->SetY1Jaw(node->GetY1Jaw());
+  this->SetY2Jaw(node->GetY2Jaw());
+  this->SetVSAD( node->GetVSADx(), node->GetVSADy());
+  this->SetIsocenterToJawsDistanceX(node->GetIsocenterToJawsDistanceX());
+  this->SetIsocenterToJawsDistanceY(node->GetIsocenterToJawsDistanceY());
+  this->SetIsocenterToMultiLeafCollimatorDistance(node->GetIsocenterToMultiLeafCollimatorDistance());
+  this->SetIsocenterToRangeShifterDistance(node->GetIsocenterToRangeShifterDistance());
+
+  this->SetScanningSpotSize(node->GetScanningSpotSize());
+
+  this->SetGantryAngle(node->GetGantryAngle());
+  this->SetCollimatorAngle(node->GetCollimatorAngle());
+  this->SetCouchAngle(node->GetCouchAngle());
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLRTIonBeamNode::SetScene(vtkMRMLScene* scene)
 {
   Superclass::SetScene(scene);
@@ -231,6 +264,13 @@ void vtkMRMLRTIonBeamNode::CreateNewBeamTransformNode()
 {
   // Create transform node for ion beam
   Superclass::CreateNewBeamTransformNode();
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLRTIonBeamNode::CreateBeamTransformNode(vtkMRMLScene* scene)
+{
+  // Create transform node for ion beam
+  return Superclass::CreateBeamTransformNode(scene);
 }
 
 //----------------------------------------------------------------------------

--- a/Beams/MRML/vtkMRMLRTIonBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTIonBeamNode.h
@@ -49,6 +49,9 @@ public:
   /// Copy the node's attributes to this object 
   void Copy(vtkMRMLNode *node) override;
 
+  /// Copy node content (excludes basic data, such a name and node reference)
+  vtkMRMLCopyContentMacro(vtkMRMLRTIonBeamNode);
+
   /// Make sure display node and transform node are present and valid
   void SetScene(vtkMRMLScene* scene) override;
 
@@ -65,6 +68,10 @@ public:
   /// Create transform node that places the beam poly data in the right position based on geometry.
   /// Always creates a new transform node.
   void CreateNewBeamTransformNode() override;
+
+  /// Create transform node that places the beam poly data in the right position based on geometry.
+  /// Always creates a new transform node.
+  vtkMRMLLinearTransformNode* CreateBeamTransformNode(vtkMRMLScene*) override;
 
 public:
   /// Get VSAD distance x component

--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -612,6 +612,41 @@ void vtkMRMLRTPlanNode::AddBeam(vtkMRMLRTBeamNode* beamNode)
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLRTPlanNode::AddProxyBeam(vtkMRMLRTBeamNode* beamNode)
+{
+  if (!this->GetScene())
+  {
+    vtkErrorMacro("AddProxyBeam: Invalid MRML scene");
+    return;
+  }
+  if (!beamNode)
+  {
+    return;
+  }
+
+  // Get subject hierarchy item for the RT Plan
+  vtkIdType planShItemID = this->GetPlanSubjectHierarchyItemID();
+  if (planShItemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
+  {
+    vtkErrorMacro("AddProxyBeam: Failed to access RT plan subject hierarchy item, although it should always be available");
+    return;
+  }
+  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(beamNode->GetScene());
+  if (!shNode)
+  {
+    vtkErrorMacro("AddProxyBeam: Failed to access subject hierarchy node");
+    return;
+  }
+
+  // Set the beam number
+  beamNode->SetBeamNumber(this->NextBeamNumber++);
+
+  // Add beam node in the right subject hierarchy branch
+  shNode->CreateItem(planShItemID, beamNode);
+  this->Modified();
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLRTPlanNode::RemoveBeam(vtkMRMLRTBeamNode* beamNode)
 {
   if (!this->GetScene())

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -95,6 +95,12 @@ public:
 
   /// Add given beam node to plan
   void AddBeam(vtkMRMLRTBeamNode* beam);
+
+  /// Add given proxy beam node to plan
+  /// @param proxyBeam - Pointer to the selected beam of the beam sequence node,
+  /// the selection process is controlled by a sequence browser node
+  void AddProxyBeam(vtkMRMLRTBeamNode* proxyBeam);
+
   /// Remove given beam node from plan
   void RemoveBeam(vtkMRMLRTBeamNode* beam);
   /// Remove all beam nodes from plan

--- a/DicomRtImportExport/Logic/CMakeLists.txt
+++ b/DicomRtImportExport/Logic/CMakeLists.txt
@@ -9,7 +9,10 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicerSubjectHierarchyModuleLogic_INCLUDE_DIRS}
   ${vtkSlicerSegmentationsModuleMRML_INCLUDE_DIRS}
   ${vtkSlicerSegmentationsModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerSequencesModuleMRML_INCLUDE_DIRS}
+  ${vtkSlicerSequencesModuleLogic_INCLUDE_DIRS}
   ${vtkSlicerDICOMLibModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerBeamsModuleLogic_INCLUDE_DIRS}
   ${PlmCommon_INCLUDE_DIRS}
   ${PLASTIMATCH_INCLUDE_DIRS}
   )
@@ -29,6 +32,8 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicerSubjectHierarchyModuleLogic
   vtkSlicerSegmentationsModuleMRML
   vtkSlicerSegmentationsModuleLogic
+  vtkSlicerSequencesModuleMRML
+  vtkSlicerSequencesModuleLogic
   vtkSlicerIsodoseModuleLogic
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}

--- a/DicomRtImportExport/Testing/Python/DicomRtImportTest.py
+++ b/DicomRtImportExport/Testing/Python/DicomRtImportTest.py
@@ -146,8 +146,8 @@ class DicomRtImportTest(unittest.TestCase):
     # Verify that the correct number of objects were loaded
     # Volumes: Dose, RT image
     self.assertEqual( len( slicer.util.getNodes('vtkMRMLScalarVolumeNode*') ), 2 )
-    # Model hierarchies: Beam models (parent + individual beams)
-    self.assertEqual( len( slicer.util.getNodes('vtkMRMLModelHierarchyNode*') ), 6 )
+    # RT Beam nodes (static beams and dynamic beam sequences)
+    self.assertEqual( len( slicer.util.getNodes('vtkMRMLRTBeamNode*') ), 5 )
     # Segmentation: The loaded structures
     self.assertEqual( len( slicer.util.getNodes('vtkMRMLSegmentationNode*') ), 1 )
     # Markups: the RT plan POI

--- a/Testing/Python/IGRTWorkflow_SelfTest.py
+++ b/Testing/Python/IGRTWorkflow_SelfTest.py
@@ -99,7 +99,7 @@ class IGRTWorkflow_SelfTestTest(ScriptedLoadableModuleTest):
     self.tempDir = IGRTWorkflow_SelfTestDir + '/Temp'
 
     self.day1CTName = '2: ENT IMRT'
-    self.day1DoseName = '5: RTDOSE: BRAI1'
+    self.day1DoseName = '5: RTDOSE'
     self.day1StructureSetName = '3: RTSTRUCT: ENT'
     self.day1PlanName = '4: RTPLAN: BRAI1'
     self.day1IsodosesName = '5: RTDOSE: BRAI1_IsodoseSurfaces'
@@ -131,9 +131,9 @@ class IGRTWorkflow_SelfTestTest(ScriptedLoadableModuleTest):
 
         # Download, unzip, import, and load data. Verify selected plugins and loaded nodes.
         selectedPlugins = { 'Scalar Volume':2, 'RT':3 }
-        loadedNodes = { 'vtkMRMLScalarVolumeNode':2, \
+        loadedNodes = { 'vtkMRMLScalarVolumeNode':3, \
                         'vtkMRMLSegmentationNode':1, \
-                        'vtkMRMLModelHierarchyNode':7 }
+                        'vtkMRMLRTBeamNode':6 }
         with DICOMUtils.LoadDICOMFilesToDatabase( \
             self.dicomZipFileUrl, self.dicomZipFilePath, \
             self.dicomDataDir, self.expectedNumOfFilesInDicomDataDir, \


### PR DESCRIPTION
WIP:

There are several problems:

1. If number of beams is more than one i have an output is console:
` vtkMRMLHierarchyNode::SetIndexInParent() index 1, outside the range 0-0 `
` vtkMRMLHierarchyNode::SetIndexInParent() index 2, outside the range 0-0 `
` vtkMRMLHierarchyNode::SetIndexInParent() index 3, outside the range 0-0 `
` vtkMRMLHierarchyNode::SetIndexInParent() index 4, outside the range 0-0 `
` vtkMRMLHierarchyNode::SetIndexInParent() index 5, outside the range 0-0 `

2. I don't know how to add beam proxy node to plan node, for correct isocenter position. Now transformation node is in wrong position.
 