### PR TITLE
ENH: Allow loading invalid deformable DICOM SRO created by ImSimQA software

### DIFF
--- a/DicomSroImportExport/Logic/vtkSlicerDicomSroReader.cxx
+++ b/DicomSroImportExport/Logic/vtkSlicerDicomSroReader.cxx
@@ -222,6 +222,13 @@ void vtkSlicerDicomSroReader::Update()
           if (!this->LoadSpatialRegistrationSuccessful)
           {
             vtkWarningMacro("vtkSlicerDicomSroReader::Update: failed to load spatial registration");
+
+            // WORKAROUND START
+            // maybe the SOP instance UID was set incorrectly, give it one more chance
+            // and try to read it with UID_DeformableSpatialRegistrationStorage
+            sopClass = UID_DeformableSpatialRegistrationStorage;
+            // WORKAROUND END
+
           }
         }
         if (sopClass == UID_DeformableSpatialRegistrationStorage)


### PR DESCRIPTION
This workaround should be removed once ImSimQA updates its software.

See discussion here: https://discourse.slicer.org/t/application-of-deformation-field-not-doing-anything/13402/7