### PR TITLE
BUG: Fix shared labelmap bugs in SegmentComparison/SegmentMorphology

### DIFF
--- a/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
+++ b/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
@@ -130,16 +130,14 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
 
   // Get segment binary labelmaps
   vtkSmartPointer<vtkOrientedImageData> referenceSegmentLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
-  if ( !vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation(
-    referenceSegmentationNode, referenceSegmentID, referenceSegmentLabelmap ) )
+  if (!referenceSegmentationNode->GetBinaryLabelmapRepresentation(referenceSegmentID, referenceSegmentLabelmap))
   {
     std::string errorMessage("Failed to get binary labelmap from reference segment: " + std::string(referenceSegmentID));
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
   vtkSmartPointer<vtkOrientedImageData> compareSegmentLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
-  if ( !vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation(
-    compareSegmentationNode, compareSegmentID, compareSegmentLabelmap ) )
+  if (!referenceSegmentationNode->GetBinaryLabelmapRepresentation(compareSegmentID, compareSegmentLabelmap))
   {
     std::string errorMessage("Failed to get binary labelmap from reference segment: " + std::string(compareSegmentID));
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);

--- a/SegmentMorphology/Logic/vtkSlicerSegmentMorphologyModuleLogic.cxx
+++ b/SegmentMorphology/Logic/vtkSlicerSegmentMorphologyModuleLogic.cxx
@@ -193,8 +193,7 @@ std::string vtkSlicerSegmentMorphologyModuleLogic::ApplyMorphologyOperation(vtkM
   // Prepare segment A for processing
   vtkSmartPointer<vtkOrientedImageData> imageA = vtkSmartPointer<vtkOrientedImageData>::New();
   const char* segmentAID = parameterNode->GetSegmentAID();
-  if ( !vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation(
-    inputSegmentationANode, segmentAID, imageA ) )
+  if (!inputSegmentationANode->GetBinaryLabelmapRepresentation(segmentAID, imageA))
   {
     std::string errorMessage("Failed to get binary labelmap from segment A: " + std::string(segmentAID));
     vtkErrorMacro("ApplyMorphologyOperation: " << errorMessage);
@@ -216,8 +215,7 @@ std::string vtkSlicerSegmentMorphologyModuleLogic::ApplyMorphologyOperation(vtkM
       vtkErrorMacro("ApplyMorphologyOperation: " << errorMessage);
       return errorMessage;
     }
-    if ( !vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation(
-      inputSegmentationBNode, segmentBID, imageB ) )
+    if (!inputSegmentationBNode->GetBinaryLabelmapRepresentation(segmentBID, imageB))
     {
       std::string errorMessage("Failed to get binary labelmap from segment B: " + std::string(segmentAID));
       vtkErrorMacro("ApplyMorphologyOperation: " << errorMessage);


### PR DESCRIPTION
In SegmentComparison/SegmentMorphology, the vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation function was used to get the binary labelmaps. This function returns the internal "shared" representation of the segments, rather than the individual segment labelmap. This caused issues in SegmentComparison/SegmentMorphology, which expected only a single segment in each labelmap.

Fixed by changing vtkSlicerSegmentationsModuleLogic::GetSegmentBinaryLabelmapRepresentation to vtkSegmentationNode::GetBinaryLabelmapRepresentation, which retrieves the individual non-shared labelmap for each representation.