### PR TITLE
ENH: Corrent transformation from patient support frame to fixed referenced frame

### DIFF
--- a/Beams/Logic/vtkSlicerIECTransformLogic.cxx
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.cxx
@@ -313,7 +313,7 @@ void vtkSlicerIECTransformLogic::UpdateIECTransformsFromBeam( vtkMRMLRTBeamNode*
     this->GetTransformNodeBetween(PatientSupportRotation, FixedReference);
   vtkTransform* patientSupportToFixedReferenceTransform = vtkTransform::SafeDownCast(patientSupportRotationToFixedReferenceTransformNode->GetTransformToParent());
   patientSupportToFixedReferenceTransform->Identity();
-  patientSupportToFixedReferenceTransform->RotateZ(beamNode->GetCouchAngle());
+  patientSupportToFixedReferenceTransform->RotateZ(-1. * beamNode->GetCouchAngle());
   patientSupportToFixedReferenceTransform->Modified();
 
   // Update IEC Patient to RAS transform based on the isocenter defined in the beam's parent plan

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -1227,7 +1227,7 @@ bool vtkSlicerDrrImageComputationLogic::SetupGeometry( vtkMRMLDrrImageComputatio
 
   vtkNew<vtkTransform> couchToFixedTransform;
   couchToFixedTransform->Identity();
-  couchToFixedTransform->RotateWXYZ(couchAngle, 0.0, 1.0, 0.0);
+  couchToFixedTransform->RotateWXYZ(-1. * couchAngle, 0.0, 1.0, 0.0);
 
   vtkNew<vtkTransform> gantryToCouchTransform;
   gantryToCouchTransform->Identity();


### PR DESCRIPTION
Same as [RtImportExport](https://github.com/SlicerRt/SlicerRT/blob/master/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx#L2069-#L2071)

Tests after the fix:
	  1 - qSlicerBeamsModuleGenericTest (Failed)
	  2 - qSlicerBeamsModuleWidgetGenericTest (Failed)
	 39 - vtkSlicerSegmentComparisonModuleLogicTest_EclipseProstate_Transformed (Failed)
	 47 - py_nomainwindow_PlmProtonDoseEngineTest (Failed)
