### PR TITLE
WIP: ENH: Relative dose representation for isolevels

### DIFF
--- a/Isodose/Logic/vtkMRMLIsodoseNode.cxx
+++ b/Isodose/Logic/vtkMRMLIsodoseNode.cxx
@@ -50,6 +50,9 @@ vtkMRMLIsodoseNode::vtkMRMLIsodoseNode()
   this->ShowScalarBar = false;
   this->ShowScalarBar2D = false;
   this->ShowDoseVolumesOnly = true;
+  this->DoseUnits = DoseUnitsType::Unknown;
+  this->ReferenceDoseValue = -1.;
+  this->RelativeRepresentationFlag = false;
 
   this->HideFromEditors = false;
 }
@@ -69,6 +72,10 @@ void vtkMRMLIsodoseNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(ShowScalarBar, ShowScalarBar);
   vtkMRMLWriteXMLBooleanMacro(ShowScalarBar2D, ShowScalarBar2D);
   vtkMRMLWriteXMLBooleanMacro(ShowDoseVolumesOnly, ShowDoseVolumesOnly);
+  vtkMRMLWriteXMLIntMacro(DoseUnits, DoseUnits);
+  vtkMRMLWriteXMLFloatMacro(ReferenceDoseValue, ReferenceDoseValue);
+  vtkMRMLWriteXMLBooleanMacro(RelativeRepresentationFlag, RelativeRepresentationFlag);
+
   vtkMRMLWriteXMLEndMacro(); 
 }
 
@@ -84,6 +91,9 @@ void vtkMRMLIsodoseNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(ShowScalarBar, ShowScalarBar);
   vtkMRMLReadXMLBooleanMacro(ShowScalarBar2D, ShowScalarBar2D);
   vtkMRMLReadXMLBooleanMacro(ShowDoseVolumesOnly, ShowDoseVolumesOnly);
+  vtkMRMLReadXMLIntMacro(DoseUnits, DoseUnits);
+  vtkMRMLReadXMLFloatMacro(ReferenceDoseValue, ReferenceDoseValue);
+  vtkMRMLReadXMLBooleanMacro(RelativeRepresentationFlag, RelativeRepresentationFlag);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -104,6 +114,9 @@ void vtkMRMLIsodoseNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyBooleanMacro(ShowScalarBar);
   vtkMRMLCopyBooleanMacro(ShowScalarBar2D);
   vtkMRMLCopyBooleanMacro(ShowDoseVolumesOnly);
+  vtkMRMLCopyIntMacro(DoseUnits);
+  vtkMRMLCopyFloatMacro(ReferenceDoseValue);
+  vtkMRMLCopyBooleanMacro(RelativeRepresentationFlag);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -120,6 +133,9 @@ void vtkMRMLIsodoseNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(ShowScalarBar);
   vtkMRMLPrintBooleanMacro(ShowScalarBar2D);
   vtkMRMLPrintBooleanMacro(ShowDoseVolumesOnly);
+  vtkMRMLPrintIntMacro(DoseUnits);
+  vtkMRMLPrintFloatMacro(ReferenceDoseValue);
+  vtkMRMLPrintBooleanMacro(RelativeRepresentationFlag);
   vtkMRMLPrintEndMacro();
 }
 
@@ -171,4 +187,22 @@ void vtkMRMLIsodoseNode::SetAndObserveColorTableNode(vtkMRMLColorTableNode* node
   }
 
   doseVolumeNode->SetNodeReferenceID(COLOR_TABLE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLIsodoseNode::SetDoseUnits(int doseUnits)
+{
+  switch (doseUnits)
+  {
+    case 0:
+      SetDoseUnits(DoseUnitsType::Gy);
+      break;
+    case 1:
+      SetDoseUnits(DoseUnitsType::Relative);
+      break;
+    case -1:
+    default:
+      SetDoseUnits(DoseUnitsType::Unknown);
+      break;
+  }
 }

--- a/Isodose/Logic/vtkMRMLIsodoseNode.h
+++ b/Isodose/Logic/vtkMRMLIsodoseNode.h
@@ -37,6 +37,7 @@ class vtkMRMLColorTableNode;
 class VTK_SLICER_ISODOSE_LOGIC_EXPORT vtkMRMLIsodoseNode : public vtkMRMLNode
 {
 public:
+  enum DoseUnitsType { Unknown = -1, Gy = 0, Relative = 1 };
   static const char* COLOR_TABLE_REFERENCE_ROLE;
 
   static vtkMRMLIsodoseNode *New();
@@ -94,11 +95,26 @@ public:
   vtkSetMacro(ShowDoseVolumesOnly, bool);
   vtkBooleanMacro(ShowDoseVolumesOnly, bool);
 
+  /// Get/Set reference dose value
+  vtkGetMacro(ReferenceDoseValue, double);
+  vtkSetMacro(ReferenceDoseValue, double);
+
+  /// Get/Set dose units type
+  vtkGetMacro(DoseUnits, DoseUnitsType);
+  vtkSetMacro(DoseUnits, DoseUnitsType);
+
+  /// Get/Set relative representation flag
+  vtkGetMacro(RelativeRepresentationFlag, bool);
+  vtkSetMacro(RelativeRepresentationFlag, bool);
+  vtkBooleanMacro(RelativeRepresentationFlag, bool);
+
 protected:
   vtkMRMLIsodoseNode();
   ~vtkMRMLIsodoseNode();
   vtkMRMLIsodoseNode(const vtkMRMLIsodoseNode&);
   void operator=(const vtkMRMLIsodoseNode&);
+
+  void SetDoseUnits(int doseUnits);
 
 protected:
   /// State of Show isodose lines checkbox
@@ -115,6 +131,16 @@ protected:
 
   /// State of Show dose volumes only checkbox
   bool ShowDoseVolumesOnly;
+
+  /// Type of dose units
+  DoseUnitsType DoseUnits;
+
+  /// Reference dose value
+  double ReferenceDoseValue;
+
+  /// Whether use relative isolevels representation
+  /// for absolute dose (Gy) and unknown units or not
+  bool RelativeRepresentationFlag;
 };
 
 #endif

--- a/Isodose/Logic/vtkSlicerIsodoseModuleLogic.h
+++ b/Isodose/Logic/vtkSlicerIsodoseModuleLogic.h
@@ -47,6 +47,7 @@ public:
   static const std::string ISODOSE_MODEL_NODE_NAME_PREFIX;
   static const std::string ISODOSE_PARAMETER_SET_BASE_NAME_PREFIX;
   static const std::string ISODOSE_ROOT_HIERARCHY_NAME_POSTFIX;
+  static const std::string ISODOSE_RELATIVE_ROOT_HIERARCHY_NAME_POSTFIX;
   static const std::string ISODOSE_COLOR_TABLE_NODE_NAME_POSTFIX;
 
 public:
@@ -75,9 +76,15 @@ public:
   /// Creates default isodose color table. Gets and returns if already exists
   static vtkMRMLColorTableNode* GetDefaultIsodoseColorTable(vtkMRMLScene* scene);
 
-  /// Creates default dose color table (which is the default isodose color table stretched.
+  /// Creates relative isodose color table. Gets and returns if already exists
+  static vtkMRMLColorTableNode* GetRelativeIsodoseColorTable(vtkMRMLScene *scene);
+
+  /// Creates default dose color table (which is the default isodose color table stretched).
   /// Gets and returns if already exists
   static vtkMRMLColorTableNode* CreateDefaultDoseColorTable(vtkMRMLScene *scene);
+
+  /// Creates relative dose color table. Gets and returns if already exists
+  static vtkMRMLColorTableNode* CreateRelativeDoseColorTable(vtkMRMLScene *scene);
 
 protected:
   /// Loads default isodose color table from the supplied color table file

--- a/Isodose/Resources/UI/qSlicerIsodoseModule.ui
+++ b/Isodose/Resources/UI/qSlicerIsodoseModule.ui
@@ -6,29 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>402</width>
-    <height>528</height>
+    <width>373</width>
+    <height>604</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Isodose</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>4</number>
-   </property>
-   <property name="topMargin">
-    <number>4</number>
-   </property>
-   <property name="rightMargin">
-    <number>4</number>
-   </property>
-   <property name="bottomMargin">
-    <number>4</number>
-   </property>
-   <property name="spacing">
-    <number>4</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout_6">
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
@@ -63,41 +48,8 @@
      <property name="text">
       <string>Input</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <property name="spacing">
-       <number>4</number>
-      </property>
-      <item row="0" column="2">
-       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_DoseVolume">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="1" column="1">
        <widget class="QLabel" name="label_NotDoseVolumeWarning">
         <property name="palette">
          <palette>
@@ -231,6 +183,15 @@
            <colorrole role="ToolTipText">
             <brush brushstyle="SolidPattern">
              <color alpha="255">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </brush>
+           </colorrole>
+           <colorrole role="PlaceholderText">
+            <brush brushstyle="NoBrush">
+             <color alpha="128">
               <red>0</red>
               <green>0</green>
               <blue>0</blue>
@@ -374,6 +335,15 @@
              </color>
             </brush>
            </colorrole>
+           <colorrole role="PlaceholderText">
+            <brush brushstyle="NoBrush">
+             <color alpha="128">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </brush>
+           </colorrole>
           </inactive>
           <disabled>
            <colorrole role="WindowText">
@@ -511,11 +481,21 @@
              </color>
             </brush>
            </colorrole>
+           <colorrole role="PlaceholderText">
+            <brush brushstyle="NoBrush">
+             <color alpha="128">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </brush>
+           </colorrole>
           </disabled>
          </palette>
         </property>
         <property name="font">
          <font>
+          <family>Liberation Sans</family>
           <pointsize>8</pointsize>
           <weight>75</weight>
           <bold>true</bold>
@@ -526,21 +506,25 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="qMRMLColorTableView" name="tableView_IsodoseLevels">
-        <attribute name="horizontalHeaderVisible">
-         <bool>true</bool>
-        </attribute>
-       </widget>
-      </item>
       <item row="0" column="1">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Dose volume:</string>
+       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_DoseVolume">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="1">
        <widget class="QSpinBox" name="spinBox_NumberOfLevels">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -553,14 +537,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="label_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Number of iso levels:</string>
+         <string>Dose volume:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="0">
        <widget class="QCheckBox" name="checkBox_ShowDoseVolumesOnly">
         <property name="text">
          <string>Show dose volumes only</string>
@@ -570,8 +554,131 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="qMRMLColorTableView" name="tableView_IsodoseLevels">
+        <attribute name="horizontalHeaderVisible">
+         <bool>true</bool>
+        </attribute>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Number of iso levels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_RelativeIsolevels">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Show isolevels as a percentage from the prescribed dose</string>
+        </property>
+        <property name="title">
+         <string>Relative isolevels of dose</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLabel" name="label_DoseValue">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="toolTip">
+              <string>Prescribed or reference dose value</string>
+             </property>
+             <property name="text">
+              <string>Dose value:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ctkSliderWidget" name="sliderWidget_ReferenceDose">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QLabel" name="label_PercentageOfMaximumVolumeDose">
+             <property name="text">
+              <string>Percentage of maximum volume dose:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_PercentageOfMaxVolumeDose">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_Apply">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Generate isodose</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="3" column="0">
     <widget class="ctkCollapsibleButton" name="CollapsibleButton_DisplayOptions">
@@ -655,55 +762,20 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_Apply">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Generate isodose</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
   <customwidget>
    <class>qMRMLColorTableView</class>
    <extends>QTableView</extends>
@@ -719,12 +791,6 @@
    <class>qSlicerWidget</class>
    <extends>QWidget</extends>
    <header>qSlicerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleButton</class>
-   <extends>QWidget</extends>
-   <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -759,6 +825,70 @@
     <hint type="destinationlabel">
      <x>399</x>
      <y>62</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>groupBox_RelativeIsolevels</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_DoseValue</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>173</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>65</x>
+     <y>170</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>groupBox_RelativeIsolevels</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>sliderWidget_ReferenceDose</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>173</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>223</x>
+     <y>170</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>groupBox_RelativeIsolevels</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_PercentageOfMaximumVolumeDose</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>173</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>142</x>
+     <y>198</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>groupBox_RelativeIsolevels</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_PercentageOfMaxVolumeDose</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>173</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>301</x>
+     <y>198</y>
     </hint>
    </hints>
   </connection>

--- a/Isodose/qSlicerIsodoseModuleWidget.h
+++ b/Isodose/qSlicerIsodoseModuleWidget.h
@@ -59,6 +59,8 @@ public slots:
 
   /// Process loaded scene
   void onSceneImportedEvent();
+  /// Process is scene is closed
+  void onSceneClosedEvent();
 
   /// Set current parameter node
   void setParameterNode(vtkMRMLNode *node);
@@ -96,6 +98,12 @@ protected slots:
 
   /// Slot called on modify of the color table
   void updateScalarBarsFromSelectedColorTable();
+
+  /// Slot setting type of isolevels representation
+  void setRelativeIsolevelsFlag(bool useRelativeIsolevels);
+
+  /// Slot called to set reference dose value
+  void setReferenceDoseValue(double value);
 
 protected:
   // Generates a new isodose level name

--- a/SlicerRtCommon/vtkSlicerRtCommon.cxx
+++ b/SlicerRtCommon/vtkSlicerRtCommon.cxx
@@ -87,6 +87,7 @@ const std::string vtkSlicerRtCommon::DICOMRTIMPORT_SOURCE_HIERARCHY_NODE_NAME_PO
 const std::string vtkSlicerRtCommon::DICOMRTIMPORT_BEAMMODEL_HIERARCHY_NODE_NAME_POSTFIX = "_Beams";
 
 const char* vtkSlicerRtCommon::DEFAULT_DOSE_COLOR_TABLE_NAME = "Dose_ColorTable";
+const char* vtkSlicerRtCommon::RELATIVE_DOSE_COLOR_TABLE_NAME = "Dose_ColorTable_Relative";
 
 //----------------------------------------------------------------------------
 // Utility functions

--- a/SlicerRtCommon/vtkSlicerRtCommon.h
+++ b/SlicerRtCommon/vtkSlicerRtCommon.h
@@ -116,6 +116,7 @@ public:
   static const std::string DICOMRTIMPORT_BEAMMODEL_HIERARCHY_NODE_NAME_POSTFIX;
 
   static const char* DEFAULT_DOSE_COLOR_TABLE_NAME;
+  static const char* RELATIVE_DOSE_COLOR_TABLE_NAME;
 
   //----------------------------------------------------------------------------
   // Utility functions


### PR DESCRIPTION
Here is my understanding of relative dose isolevels, possible solution for #36, #96.

If RTDOSE type is "GY" then clicking on "Percentage dose isolevels" check box you can switch between absolute and relative isolevels representation. If RTDOSE type is "RELATIVE" then only relative representation is available.

Screenshot as an example:
![image](https://user-images.githubusercontent.com/3785912/99175234-e4228580-271b-11eb-8bbe-3b2088b6932d.png)
