### PR TITLE
COMP: Fix integration of Plastimatch external project in custom app

### DIFF
--- a/SuperBuild/External_Plastimatch.cmake
+++ b/SuperBuild/External_Plastimatch.cmake
@@ -3,6 +3,13 @@ set(proj Plastimatch)
 
 # Set dependency list
 set(${proj}_DEPENDS "")
+if(DEFINED Slicer_SOURCE_DIR)
+  list(APPEND ${proj}_DEPENDS
+    DCMTK
+    ITK
+    VTK
+    )
+endif()
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)


### PR DESCRIPTION
This commit ensures Plastimatch is built against the DCMTK, ITK and
VTK build trees made available by the custom application build system.