### PR TITLE
ENH: Update Plastimatch from 1.9.0 to 1.9.2

### DIFF
--- a/SuperBuild/External_Plastimatch.cmake
+++ b/SuperBuild/External_Plastimatch.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "4bc64806812a0c0b73255391ad373db3fe8844db" # slicerrt-1.9.0-2020.04.10-2e729bc2c
+    "b23dd474cf27c7145c4c650e615ece7c6323eb7d" # slicerrt-1.9.2-2021.01.18-4d1dd4b9
     QUIET
     )
 


### PR DESCRIPTION
The following plastimatch merge requests have been cherry-picked and integrated to [slicerrt-1.9.2-2021.01.18-4d1dd4b9](https://github.com/SlicerRt/plastimatch/tree/slicerrt-1.9.2-2021.01.18-4d1dd4b9):
* https://gitlab.com/plastimatch/plastimatch/-/merge_requests/26
* https://gitlab.com/plastimatch/plastimatch/-/merge_requests/27

List of changes:

```
$ git shortlog 4bc64806..b23dd474 --no-merges 
Gregory C. Sharp (50):
      Add masking capability to plastimatch compare
      Add poor test case for plm compare --mask
      Work on 1D LUT
      Work on getting emacs call graph to work
      Minor script change
      Fix bug that causes compile error
      Skeleton for point-dmap metric
      Enable unsigned distance map
      Update test case for pd metric
      Add support for fixed_pointset in bspline metric
      Rough draft of adding --fixed option to plastimatch xf-convert
      Add regression test for xf-convert with --fixed option
      Work on pd metric
      Fix pd metric test case
      Fix to pd metric
      Let plastimatch not crash when reading empty directories
      Remove erroneous error message
      Add ushort option to readmha
      Fix rasterization bug when direction cosines are not identity
      Possible fix for ITK 5 compilation issue
      A better fix for the ITK 5 compile issue
      Fix bug using --input-prefix with nii.gz file type
      Update to change_orientation script
      Add support for JPEG compressed DICOM
      Allow grid_spac to be specified with only a single number
      Add partial support for 64-bit integer images
      Update chage_orientation.pl
      Fix DICOM load failure when series instance UID is duplicated between image and structure set
      Add ability to build without DCMTK
      Make plastimatch build on ITK 5.1.0
      Add an option to resize dose geometry to match image geometry
      Fix xio plan parsing
      Misc unimportant changes
      Update fixrpm to make it more robust
      Partly revert bad commit
      Remove obsolete OpenCL cmake code; Add itkContourExtractor2DImageFilter code from ITK 5.1.2 for use with ITK 4 installations
      More work on getting gcc 10 to compile ITK 4
      Finally I must accept the fact that Fedora's ITK package is broken.
      Fix cmake warning
      Update deprecated CUDA function calls
      Make plastimatch cuda compile under clang++
      Modernize several CMake scripts
      Fix build when libLBFGS is not installed
      Update for building on Visual Studio 2015
      Another update for building on Visual Studio 2015
      Fix for macOS/OS X
      Version 1.9.1
      Fix Windows packaging bug
      More work on windows packaging
      Version 1.9.2

Jean-Christophe Fillion-Robin (1):
      [Backport MR-27] COMP: Fix configuration against ITKv5 excluding compile test

Keyur Shah (14):
      Add song-maurer option to plastimatch dmap
      Add song-maurer option to plastimatch dmap
      Add functions to compute song-maurer option for plastimatch dmap
      Fix song-maurer option for plastimatch dmap
      Fix bug in song-maurer option for plastimatch dmap
      Fix openmp issue in song-maurer option for plastimatch dmap
      Work on openmp issue in song-maurer option for plastimatch dmap
      Fix openmp issue in song-maurer option for plastimatch dmap
      Point to dmap metric
      Fix point to dmap metric
      Fix point to dmap metric
      Remove print statements in the point to dmap metric
      Edit point to dmap metric (PDM does not chnage over optimizer iterations)
      Fix point to dmap metric

Michael Colonel (3):
      [Backport MR-26] COMP: Ensure reconstruct include directory is exported in the build interface
      [Backport MR-26] STYLE: Remove redundant line from drr cli parsing logic
      [Backport MR-26] ENH: Update drr cli and logic to support custom output file
```