### PR TITLE
STYLE: Use cross platform vtkMath methods instead of 180./M_PI constant

### DIFF
--- a/Docs/user_guide/modules/drr.md
+++ b/Docs/user_guide/modules/drr.md
@@ -50,7 +50,7 @@ based on [plastimatch drr](http://www.plastimatch.org/drr.html) ones.
 
 ### Graphical User Interface loadable module (GUI)
 
-![image](https://user-images.githubusercontent.com/3785912/107616582-6a892d80-6c5f-11eb-8e8f-968a31b89fac.png)
+![image](https://user-images.githubusercontent.com/3785912/118298680-726b9e80-b4e8-11eb-8a39-c5e607459e62.png)
 
 Loadable GUI module "DRR Image Computation" uses CLI module's logic and nodes data to calculate
 and visualize DRR image. It also shows basic detector elements such as: detector boundary,
@@ -61,14 +61,16 @@ Markups data is only for WYSIWYG purpose.
 
 #### Reference input nodes
 
-![image](https://user-images.githubusercontent.com/3785912/96576548-01aa2e00-12db-11eb-9a4a-6ed445d6fc4f.png)
+![image](https://user-images.githubusercontent.com/3785912/118298709-7e576080-b4e8-11eb-8c2b-b1a4f8222eba.png)
 
 1. **CT volume**: Input CT data
 2. **RT beam**: Input RT beam (vtkMRMLRTBeamNode) for source and detector orientation parameters
-3. **Show DRR markups**: Show or hide detector markups
+2. **Camera**: Camera node (vtkMRMLCameraNode) to update if needed beam geometry and transformation
+3. **Update beam**: Update beam geometry and transformation using camera node data 
+4. **Show DRR markups**: Show or hide detector markups
 
 CT data is represented by vtkMRMLScalarVolumeNode object. RT beam data is
-represented by vtkMRMLRTBeamNode object.
+represented by vtkMRMLRTBeamNode object. Camera data is represented by vtkMRMLCameraNode object.
 
 #### Geometry basic parameters
 
@@ -82,7 +84,6 @@ represented by vtkMRMLRTBeamNode object.
 #### Image Window Parameters
 8. **Columns**: Number of image columns in subwindow 
 9. **Rows**: Number of image rows in subwindow
-
 
 #### Plastimatch DRR image processing
 

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -60,10 +60,10 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkCamera.h>
+#include <vtkMath.h>
 
 // std includes
-#define _USE_MATH_DEFINES // Required for M_PI constant
-#include <math.h>
+#include <cmath>
 
 // SlicerRT includes
 #include <vtkSlicerRtCommon.h>
@@ -1471,10 +1471,10 @@ bool vtkSlicerDrrImageComputationLogic::UpdateBeamFromCamera(vtkMRMLDrrImageComp
     cameraProjIEC[1] *= -1.;
     cameraProjIEC[2] *= -1.;
     // Theta [0, pi], phi [0, 2*pi]
-    double phi_x = acos(cameraProjIEC[0] / sqrt(cameraProjIEC[0] * cameraProjIEC[0] + cameraProjIEC[1] * cameraProjIEC[1])) * 180. / M_PI;
-    double phi_y = asin(cameraProjIEC[1] / sqrt(cameraProjIEC[0] * cameraProjIEC[0] + cameraProjIEC[1] * cameraProjIEC[1])) * 180. / M_PI;
-    double phi = atan(cameraProjIEC[1] / cameraProjIEC[0]) * 180. / M_PI;
-    double theta = acos(cameraProjIEC[2] / sqrt(cameraProjIEC[0] * cameraProjIEC[0] + cameraProjIEC[1] * cameraProjIEC[1] +  + cameraProjIEC[2] * cameraProjIEC[2])) * 180. / M_PI;
+    double phi_x = vtkMath::DegreesFromRadians(acos(cameraProjIEC[0] / vtkMath::Norm(cameraProjIEC, 2)));
+    double phi_y = vtkMath::DegreesFromRadians(asin(cameraProjIEC[1] / vtkMath::Norm(cameraProjIEC, 2)));
+    double phi = vtkMath::DegreesFromRadians(atan(cameraProjIEC[1] / cameraProjIEC[0]));
+    double theta = vtkMath::DegreesFromRadians(acos(cameraProjIEC[2] / vtkMath::Norm(cameraProjIEC, 3)));
     if (phi_x > 0. && phi_y > 0.)
     {
       phi = 360. - phi_x;
@@ -1491,8 +1491,7 @@ bool vtkSlicerDrrImageComputationLogic::UpdateBeamFromCamera(vtkMRMLDrrImageComp
     // Update geometry and transform of the beam
     beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);
     beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamTransformModified);
-    // Reset beam node 
-    parameterNode->SetAndObserveBeamNode(beamNode);
+
     return true;
   }
   else

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
@@ -43,7 +43,6 @@ class vtkMRMLMarkupsPlaneNode;
 class vtkMRMLMarkupsClosedCurveNode;
 class vtkMRMLMarkupsFiducialNode;
 class vtkMRMLMarkupsLineNode;
-class vtkMRMLCameraNode;
 
 class vtkMRMLLinearTransformNode;
 

--- a/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
+++ b/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
@@ -513,6 +513,7 @@ void qSlicerDrrImageComputationModuleWidget::onUpdateBeamFromCameraClicked()
   // Update DRR RT beam parameters from observed 3D camera node data
   if (d->logic()->UpdateBeamFromCamera(parameterNode))
   {
+    d->logic()->UpdateMarkupsNodes(parameterNode); // Update markups geometry
     parameterNode->Modified(); // Update imager and image markups, DRR arguments
   }
 }


### PR DESCRIPTION
This should work in both Linux and Windows systems.