### PR TITLE
ENH: Changed the dsurround(1) from 10 cm to 60 cm to enable dose calculations for a source away from the phantom.

### DIFF
--- a/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
@@ -332,7 +332,7 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     enflag = 2        # for ph-sp beam input or full BEAM sim.
     mode = 0          # default file format for ph-sp data (enflag=2)
     medsur = 0        # medium number for the region outside the phantom             # I=8: 1
-    dsurround_1 = 10  # thickness (cm) of region surrounding phantom in x direction  # I=8: 30
+    dsurround_1 = 60  # thickness (cm) of region surrounding phantom in x direction  # I=8: 30
     dflag = 0         # dsurround(1) applied to x direction only                     # I=8: 1
     dsurround_2 = 0   # thickness (cm) of region surrounding phantom in y direction  # I=8: 60
     dsurround_3 = 0   # thickness (cm) of region surrounding phantom in +z direction # I=8: 30


### PR DESCRIPTION
* We currently extend our research to include Co-60 beams for which the source is away from the phantom. The dsurround(1) of 10 cm works for Orthovoltage but limits dose calculation when dsource is increased as for the case of Co-60 source. Increasing the dsurround(1) accomodates Co-60 beams without affecting Orthovoltage dose calculations.

   
![image](https://user-images.githubusercontent.com/84034071/125116375-a31c1e80-e0ba-11eb-9545-23ae97b1ec0f.png)
