### PR TITLE
ENH: Changed the media surrounding the phantom form Vacuum to Air

### DIFF
--- a/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
@@ -332,7 +332,7 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     enflag = 2        # for ph-sp beam input or full BEAM sim.
     mode = 0          # default file format for ph-sp data (enflag=2)
     medsur = 0        # medium number for the region outside the phantom             # I=8: 1
-    dsurround_1 = 10  # thickness (cm) of region surrounding phantom in x direction  # I=8: 30
+    dsurround_1 = 60  # thickness (cm) of region surrounding phantom in x direction  # I=8: 30
     dflag = 0         # dsurround(1) applied to x direction only                     # I=8: 1
     dsurround_2 = 0   # thickness (cm) of region surrounding phantom in y direction  # I=8: 60
     dsurround_3 = 0   # thickness (cm) of region surrounding phantom in +z direction # I=8: 30

--- a/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/OrthovoltageDoseEngine.py
@@ -331,7 +331,7 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     # Record SC2
     enflag = 2        # for ph-sp beam input or full BEAM sim.
     mode = 0          # default file format for ph-sp data (enflag=2)
-    medsur = 0        # medium number for the region outside the phantom             # I=8: 1
+    medsur = 1        # medium number for the region outside the phantom             # I=8: 1
     dsurround_1 = 60  # thickness (cm) of region surrounding phantom in x direction  # I=8: 30
     dflag = 0         # dsurround(1) applied to x direction only                     # I=8: 1
     dsurround_2 = 0   # thickness (cm) of region surrounding phantom in y direction  # I=8: 60


### PR DESCRIPTION
ENH: Changed medsur for 0 to 1 to represent the change from vacuum to Air materials. This is more realistic based on the fact that the phatom (patient) is usually surrounded by Air. However, this may change in the future because the number (1) that I use to represent Air means that Air materials will always have to be number 1 in the series of the materials in the CT phantom. 

![image](https://user-images.githubusercontent.com/84034071/125324338-d30f3000-e30d-11eb-86c3-4a142868212c.png)
