### PR TITLE
BUG: Make absolute isodose color table node available for editing

### DIFF
--- a/Isodose/CMakeLists.txt
+++ b/Isodose/CMakeLists.txt
@@ -18,10 +18,10 @@ set(MODULE_INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_BINARY_DIR}/Logic
   ${CMAKE_CURRENT_SOURCE_DIR}/Widgets
   ${CMAKE_CURRENT_BINARY_DIR}/Widgets
-  ${SlicerRtCommon_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/SubjectHierarchyPlugins
   ${CMAKE_CURRENT_BINARY_DIR}/SubjectHierarchyPlugins
   ${qSlicerSubjectHierarchyModuleWidgets_INCLUDE_DIRS}
+  ${vtkSlicerColorsModuleLogic_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS

--- a/Isodose/Logic/CMakeLists.txt
+++ b/Isodose/Logic/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_LOGIC_EXPORT")
 set(${KIT}_INCLUDE_DIRECTORIES
   ${SlicerRtCommon_INCLUDE_DIRS}
   ${vtkSlicerSubjectHierarchyModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerColorsModuleLogic_INCLUDE_DIRS}
   )
 
 set(${KIT}_SRCS
@@ -19,6 +20,7 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicerRtCommon
   vtkSlicerSubjectHierarchyModuleLogic
+  vtkSlicerColorsModuleLogic
   MRMLCore
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}

--- a/Isodose/Logic/vtkSlicerIsodoseModuleLogic.h
+++ b/Isodose/Logic/vtkSlicerIsodoseModuleLogic.h
@@ -39,6 +39,8 @@ class vtkMRMLIsodoseNode;
 class vtkMRMLModelHierarchyNode;
 class vtkMRMLScalarVolumeNode;
 
+class vtkSlicerColorLogic;
+
 /// \ingroup SlicerRt_QtModules_Isodose
 class VTK_SLICER_ISODOSE_LOGIC_EXPORT vtkSlicerIsodoseModuleLogic : public vtkSlicerModuleLogic
 {
@@ -108,6 +110,8 @@ protected:
 private:
   vtkSlicerIsodoseModuleLogic(const vtkSlicerIsodoseModuleLogic&) = delete;
   void operator=(const vtkSlicerIsodoseModuleLogic&) = delete;
+  /// Unique name of the copy of default isodose color table node
+  static std::string IsodoseColorNodeCopyUniqueName;
 };
 
 #endif

--- a/Isodose/qSlicerIsodoseModule.cxx
+++ b/Isodose/qSlicerIsodoseModule.cxx
@@ -19,6 +19,10 @@
 
 ==============================================================================*/
 
+// SlicerQt includes
+#include <qSlicerCoreApplication.h>
+#include <qSlicerModuleManager.h>
+
 // SubjectHierarchy Plugins includes
 #include "qSlicerSubjectHierarchyPluginHandler.h"
 #include "qSlicerSubjectHierarchyIsodosePlugin.h"
@@ -26,9 +30,15 @@
 // Isodose Logic includes
 #include <vtkSlicerIsodoseModuleLogic.h>
 
+// Color Logic includes
+#include <vtkSlicerColorLogic.h>
+
 // Isodose includes
 #include "qSlicerIsodoseModule.h"
 #include "qSlicerIsodoseModuleWidget.h"
+
+// Qt includes
+#include <QDebug>
 
 //-----------------------------------------------------------------------------
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
@@ -92,6 +102,12 @@ QStringList qSlicerIsodoseModule::contributors()const
   moduleContributors << QString("Csaba Pinter (Queen's)");
   moduleContributors << QString("Andras Lasso (Queen's)");
   return moduleContributors;
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerIsodoseModule::dependencies() const
+{
+  return QStringList() << "Colors";
 }
 
 //-----------------------------------------------------------------------------

--- a/Isodose/qSlicerIsodoseModule.h
+++ b/Isodose/qSlicerIsodoseModule.h
@@ -61,6 +61,7 @@ public:
 
   /// Return the categories for the module
   QStringList categories()const override;
+  QStringList dependencies() const override;
 
 protected:
 


### PR DESCRIPTION
Possible fix for a bug in discussion: https://discourse.slicer.org/t/isodose-generation/20115