### PR TITLE
Allow for setting fiducial specific RBF radius

### DIFF
--- a/PlmLandwarp/plastimatch_slicer_landwarp.cxx
+++ b/PlmLandwarp/plastimatch_slicer_landwarp.cxx
@@ -99,7 +99,6 @@ main (int argc, char *argv[])
 
   /* Set other parameters */
   lw->default_val=plmslc_landwarp_default_value;
-  lw->rbf_radius=plmslc_landwarp_rbf_radius;
   lw->young_modulus=plmslc_landwarp_stiffness;
   lw->num_clusters=plmslc_landwarp_num_clusters;
 
@@ -110,6 +109,25 @@ main (int argc, char *argv[])
   if (plmslc_landwarp_moving_fiducials.size() < num_fiducials) {
     num_fiducials = plmslc_landwarp_moving_fiducials.size();
   }
+
+  unsigned long num_rbf_radius = plmslc_landwarp_rbf_radius.size();
+
+  if (num_rbf_radius != 1 && num_rbf_radius != num_fiducials){
+    return EXIT_FAILURE;
+  }
+
+  lw->adapt_radius = (float *)malloc(num_fiducials*sizeof(float));
+  lw->rbf_radius = 0.0;
+  for (unsigned long i = 0; i<num_fiducials; i++){
+    if (num_rbf_radius == 1){
+      lw->adapt_radius[i] = plmslc_landwarp_rbf_radius[0];
+    }else{
+      lw->adapt_radius[i] = plmslc_landwarp_rbf_radius[i];
+    }
+    lw->rbf_radius += lw->adapt_radius[i];
+  }
+
+  lw->rbf_radius = lw->rbf_radius / num_fiducials;
 
   /* NSh: pointset_load_fcsv assumes RAS, as does Slicer.
      For some reason, pointset_load_txt assumes LPS.

--- a/PlmLandwarp/plastimatch_slicer_landwarp.cxx
+++ b/PlmLandwarp/plastimatch_slicer_landwarp.cxx
@@ -112,7 +112,9 @@ main (int argc, char *argv[])
 
   unsigned long num_rbf_radius = plmslc_landwarp_rbf_radius.size();
 
-  if (num_rbf_radius != 1 && num_rbf_radius != num_fiducials){
+  if (num_rbf_radius > 1 && num_rbf_radius != num_fiducials){
+    std::cerr << "The number of RBF radius specified is more than one but does not match the number of fiducials.\n"
+              << "Specify one RBF radius to use as a global parameter or multiple comma separated values corresponding to each fiducial.\n";
     return EXIT_FAILURE;
   }
 

--- a/PlmLandwarp/plastimatch_slicer_landwarp.xml
+++ b/PlmLandwarp/plastimatch_slicer_landwarp.xml
@@ -81,13 +81,13 @@
       <default>gauss</default>
       <description>Radial basis function to use</description>
     </string-enumeration>
-    <float>
+    <float-vector>
      <name>plmslc_landwarp_rbf_radius</name>
      <label>RBF radius</label>
      <longflag>rbfradius</longflag>
      <default>50.0</default>
      <description>Radius of the radial basis function</description>
-    </float>
+    </float-vector>
     <integer>
       <name>plmslc_landwarp_num_clusters</name>
       <label>Number of clusters</label>

--- a/PlmLandwarp/plastimatch_slicer_landwarp.xml
+++ b/PlmLandwarp/plastimatch_slicer_landwarp.xml
@@ -86,7 +86,7 @@
      <label>RBF radius</label>
      <longflag>rbfradius</longflag>
      <default>50.0</default>
-     <description>Radius of the radial basis function</description>
+     <description>Radius of the radial basis function. If more than one value is specified then these are used as fiducial specific RBF radius. Therefore, the number of radius must be one or the same as the number of fiducials.</description>
     </float-vector>
     <integer>
       <name>plmslc_landwarp_num_clusters</name>


### PR DESCRIPTION
Hi, in the context of [this](https://discourse.slicer.org/t/plastimatch-landwarp-with-variable-rbf-radius/20226) discussion, would it be possible to include these changes?

It modifies landwarp allowing to specify multiple RBF radius. Default behavior is still one radius value.

This also requires the following changes in plastimatch source: SlicerRt/plastimatch#1

Thanks!