### PR TITLE
ENH: Better check of beams module and fraction scheme module presence

### DIFF
--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtReader.cxx
@@ -802,6 +802,7 @@ void vtkSlicerDicomRtReader::vtkInternal::LoadRTPlan(DcmDataset* dataset)
   }
 
   vtkDebugWithObjectMacro(this->External, "LoadRTPlan: Load RT Plan object");
+  bool hasFractionSchemeModule = true;
   if (rtPlan.isRTFractionSchemeModulePresent(OFTrue) == OFTrue)
   {
     vtkDebugWithObjectMacro( this->External, "LoadRTPlan: Fraction Scheme is correct");
@@ -810,14 +811,10 @@ void vtkSlicerDicomRtReader::vtkInternal::LoadRTPlan(DcmDataset* dataset)
   {
     vtkWarningWithObjectMacro( this->External, "LoadRTPlan: Fraction Scheme is partially correct");
   }
-  else if (rtPlan.isRTFractionSchemeModulePresent() == OFTrue)
-  {
-    vtkWarningWithObjectMacro( this->External, "LoadRTPlan: Fraction Scheme is partially correct");
-  }
   else
   {
-    vtkErrorWithObjectMacro( this->External, "LoadRTPlan: Fraction Scheme is absent");
-    return;
+    vtkDebugWithObjectMacro( this->External, "LoadRTPlan: Fraction Scheme is absent");
+    hasFractionSchemeModule = false;
   }
 
   // Check beams module
@@ -897,7 +894,10 @@ void vtkSlicerDicomRtReader::vtkInternal::LoadRTPlan(DcmDataset* dataset)
 
   }
 
-  if ((hasBeamsModule && haveBeams) || (hasBrachyApplicationSetupsModule && haveBrachy))
+  if ((!hasFractionSchemeModule && hasBeamsModule) || // only has beams module
+    (hasFractionSchemeModule && hasBeamsModule && haveBeams) || // has both beams and fraction scheme modules, number of beams is greater than zero for one or more fraction groups
+    (!hasBeamsModule && hasBrachyApplicationSetupsModule && haveBrachy) || // doesn't have beams module, has both brachy and fraction scheme modules, number of brachy application setups is greater than zero for one or more fraction groups
+    (!hasBeamsModule && hasBrachyApplicationSetupsModule)) // only has brachy application setups module
   {
     vtkDebugWithObjectMacro( this->External, "LoadRTPlan: Data is available for loading");
   }


### PR DESCRIPTION
Has been added a better check of beams module and fraction scheme module presence in RTPLan. Fix for issue #201 

The [standard](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.20.3.html) describe several cases of relation between beams and fraction scheme module:
1. Only beams module  (brachy application setups must be absent)
2. Both beams and fraction scheme modules, number of beams is greater than zero for one or more fraction groups (brachy application setups must be absent)
3. Only brachy application setups module (beams module must be absent)
4. Both brachy and fraction scheme modules, number of brachy application setups is greater than zero for one or more fraction groups (beams module must be absent)