### PR TITLE
BUG: Fix crash while loading RTDOSE DICOM file

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -427,7 +427,7 @@ bool vtkMRMLRTPlanNode::SetIsocenterPosition(double isocenter[3])
     return false;
   }
 
-  fiducialNode->SetNthControlPointPositionFromArray(ISOCENTER_FIDUCIAL_INDEX, isocenter);
+  fiducialNode->SetNthControlPointPosition(ISOCENTER_FIDUCIAL_INDEX, isocenter);
 
   return true;
 }


### PR DESCRIPTION
1. Fix crash while loading RTDOSE DICOM file;
2. Fix deprecated Markups API warning;
3. Minor changes.

"Isodose" module logic creates several color tables. In order to change or add data into color table, for isodose and dose visualization, it must be editable or a copy of a default color table. If the scene was cleared and all the nodes were deleted, the editable isodose was deleted as well, and it wouldn't be created again with proper lookup table.

For that reason if one is trying to load RTDOSE volume, the program crashes at the [line](https://github.com/SlicerRt/SlicerRT/blob/master/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx#L571-#L572), even if isodose table node pointer is valid!

А singleton tag was added to the copy of default isodose color table to fix the crash.

How to test the crash.

1. Load a DICOM series with RTDOSE, for example: [https://github.com/SlicerRt/SlicerRtData/tree/master/eclipse-8.1.20-phantom-prostate](https://github.com/SlicerRt/SlicerRtData/tree/master/eclipse-8.1.20-phantom-prostate)
2. Clear the scene. "File"->"Close Scene" or Ctrl+W -> "Close Scene"
3. Try to load the same series once again.
