### PR TITLE
ENH: Use vtkMRMLMarkupsROINode instead of vtkMRMLAnnotationROINode in ExternalBeamPlanning module

### DIFF
--- a/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
+++ b/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
@@ -248,7 +248,7 @@ vtkMRMLMarkupsCurveNode* vtkSlicerMLCPositionLogic::CalculatePositionConvexHullC
       curveNode->AddControlPoint(point); // add point to the closed curve
     }
 
-    delete xyCoordinates;
+    delete [] xyCoordinates;
     return curveNode.GetPointer();
   }
   else

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -378,7 +378,7 @@
        <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_DoseROI">
         <property name="nodeTypes">
          <stringlist>
-          <string>vtkMRMLAnnotationROINode</string>
+          <string>vtkMRMLMarkupsROINode</string>
          </stringlist>
         </property>
        </widget>

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -599,7 +599,7 @@ void qSlicerExternalBeamPlanningModuleWidget::doseROINodeChanged(vtkMRMLNode* no
 
   //TODO:
   // planNode->DisableModifiedEventOn();
-  // planNode->SetAndObserveDoseROINode(vtkMRMLAnnotationsROINode::SafeDownCast(node));
+  // planNode->SetAndObserveDoseROINode(vtkMRMLMarkupsROINode::SafeDownCast(node));
   // planNode->DisableModifiedEventOff();
 }
 


### PR DESCRIPTION
Fix for #216. The DoseROI isn't implemented in any case in ExternalBeamPlanning module.
