### PR TITLE
BUG: A newly created isodose lines node will not replace an old one

### DIFF
--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -916,9 +916,3 @@ void vtkMRMLRTBeamNode::CreateMLCPointsFromSectionBorder( double jawBegin,
   }
   side12.push_back(side2.back());
 }
-
-//----------------------------------------------------------------------------
-bool vtkMRMLRTBeamNode::AreEqual( double v1, double v2)
-{
-  return vtkSlicerRtCommon::AreEqualWithTolerance( v1, v2);
-}

--- a/Beams/MRML/vtkMRMLRTBeamNode.h
+++ b/Beams/MRML/vtkMRMLRTBeamNode.h
@@ -261,8 +261,6 @@ protected:
   void CreateMLCPointsFromSectionBorder( double jawBegin, double jawEnd, 
     bool mlcType, const MLCSectionVector::value_type& sectionBorder, 
     MLCVisiblePointVector& side12);
-
-  static bool AreEqual( double v1, double v2);
 };
 
 #endif // __vtkMRMLRTBeamNode_h


### PR DESCRIPTION
Possible fix for issue #224. Multiple isolines model nodes for a single RTDOSE, only the last isolines model node is observed.