### PR TITLE
ENH: Fix absent ReferencedUID for DoseVolume

### DIFF
--- a/DicomRtImportExport/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/DicomRtImportExport/SubjectHierarchyPlugins/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${KIT}_EXPORT_DIRECTIVE "Q_SLICER_${MODULE_NAME_UPPER}_SUBJECT_HIERARCHY_PLU
 set(${KIT}_INCLUDE_DIRECTORIES
   ${SlicerRtCommon_INCLUDE_DIRS}
   ${vtkSlicerPlanarImageModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerBeamsModuleMRML_INCLUDE_DIRS}
   ${vtkSlicerSubjectHierarchyModuleLogic_INCLUDE_DIRS}
   ${qSlicerSubjectHierarchyModuleWidgets_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}


### PR DESCRIPTION
Possible fix #233. I can't test it, because i don't have Eclipse planning system, and i don't know what other DICOM tags are missing. This PR doesn't break anything.
