### PR TITLE
BUG: Fix treatment machine jump before changing certain parameters

### DIFF
--- a/Beams/Logic/vtkSlicerIECTransformLogic.cxx
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.cxx
@@ -298,7 +298,7 @@ void vtkSlicerIECTransformLogic::UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* 
 }
 
 //-----------------------------------------------------------------------------
-void vtkSlicerIECTransformLogic::UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode, double* isocenter)
+void vtkSlicerIECTransformLogic::UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode/*=nullptr*/, double* isocenter/*=nullptr*/)
 {
   if (!this->GetMRMLScene())
   {

--- a/Beams/Logic/vtkSlicerIECTransformLogic.h
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.h
@@ -147,10 +147,10 @@ public:
   void UpdateBeamTransform(vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter=nullptr);
 
   /// Update IEC transforms according to beam node
-  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter = nullptr);
+  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter=nullptr);
 
   /// Update fixed reference to RAS transform based on isocenter and patient support transforms
-  void UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode, double* isocenter = nullptr);
+  void UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr);
 
   /// Update GantryToFixedReference transform based on gantry angle parameter
   void UpdateGantryToFixedReferenceTransform(double gantryRotationAngleDeg);

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -428,6 +428,9 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   //TODO: Add the REV transform to the IEC transform map and use it for the GetTransform... functions
   this->IECLogic->BuildIECTransformHierarchy();
 
+  // Make sure the fixed reference to RAS is correct
+  this->IECLogic->UpdateFixedReferenceToRASTransform();
+
   // Create transform nodes if they do not exist
   vtkSmartPointer<vtkMRMLLinearTransformNode> additionalCollimatorDevicesToCollimatorTransformNode;
   if (!scene->GetFirstNodeByName(ADDITIONALCOLLIMATORMOUNTEDDEVICES_TO_COLLIMATOR_TRANSFORM_NODE_NAME))


### PR DESCRIPTION
The FixedToRAS transform was not initialized properly, so the treatment machine did a big jump when changing certain parameters (such as table top related) when the transform was updated.