### PR TITLE
ENH: Make IEC transform logic independent from MRML

### DIFF
--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
@@ -401,11 +401,12 @@ void vtkSlicerBeamsModuleLogic::UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* b
 
   // Update fixed reference to RAS transform as well
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();
-  this->UpdateRASRelatedTransforms(nullptr, parentPlanNode, isocenter);
+  this->UpdateRASRelatedTransforms(nullptr, parentPlanNode, isocenter, true);
 }
 
 //-----------------------------------------------------------------------------
-void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(vtkSlicerIECTransformLogic* iecLogic/*=nullptr*/, vtkMRMLRTPlanNode* planNode/*=nullptr*/, double* isocenter/*=nullptr*/)
+void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(
+  vtkSlicerIECTransformLogic* iecLogic/*=nullptr*/, vtkMRMLRTPlanNode* planNode/*=nullptr*/, double* isocenter/*=nullptr*/, bool transformForBeam/*=false*/)
 {
   if (!this->GetMRMLScene())
   {
@@ -476,7 +477,7 @@ void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(vtkSlicerIECTransform
   // Set up concatenation for final fixed reference to RAS transform
   vtkNew<vtkGeneralTransform> tableTopToTableTopEccentricRotationGeneralTransform;
   iecLogic->GetTransformBetween(
-    vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation, tableTopToTableTopEccentricRotationGeneralTransform, true);
+    vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation, tableTopToTableTopEccentricRotationGeneralTransform, transformForBeam);
   vtkNew<vtkTransform> tableTopToTableTopEccentricRotationLinearTransform;
   if (!vtkMRMLTransformNode::IsGeneralTransformLinear(tableTopToTableTopEccentricRotationGeneralTransform, tableTopToTableTopEccentricRotationLinearTransform))
   {
@@ -486,7 +487,7 @@ void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(vtkSlicerIECTransform
 
   vtkNew<vtkGeneralTransform> patientSupportRotationToFixedReferenceGeneralTransform;
   iecLogic->GetTransformBetween(
-    vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference, patientSupportRotationToFixedReferenceGeneralTransform, true);
+    vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference, patientSupportRotationToFixedReferenceGeneralTransform, transformForBeam);
   vtkNew<vtkTransform> patientSupportRotationToFixedReferenceLinearTransform;
   if (!vtkMRMLTransformNode::IsGeneralTransformLinear(patientSupportRotationToFixedReferenceGeneralTransform, patientSupportRotationToFixedReferenceLinearTransform))
   {
@@ -498,6 +499,7 @@ void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(vtkSlicerIECTransform
   fixedReferenceToRASTransformNew->Concatenate(fixedReferenceToRASTransformBeamComponent);
   tableTopToTableTopEccentricRotationLinearTransform->Inverse();
   fixedReferenceToRASTransformNew->Concatenate(tableTopToTableTopEccentricRotationLinearTransform);
+  patientSupportRotationToFixedReferenceLinearTransform->Inverse();
   fixedReferenceToRASTransformNew->Concatenate(patientSupportRotationToFixedReferenceLinearTransform);
 
   // Update fixed reference to RAS transform in IEC logic

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -49,10 +49,14 @@ public:
   vtkTypeMacro(vtkSlicerBeamsModuleLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
+  /// Get transform node between two coordinate systems is exists
+  /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
+  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
+  vtkMRMLLinearTransformNode* GetTransformNodeBetween(
+    vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame);
+
   /// Update parent transform of a given beam using its parameters and the IEC logic
   void UpdateTransformForBeam(vtkMRMLRTBeamNode* beamNode);
-
-  vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);
 
   /// Update parent transform of a given beam using its parameters and the IEC logic
   /// without using plan node (only isocenter position)
@@ -61,7 +65,7 @@ public:
   /// @param beamTransformNode - parent transform of the beam according to the beam parameters and isocenter
   /// @param isocenter - isocenter position
   /// \warning This method is used only in vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequence
-  void UpdateTransformForBeam( vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode, 
+  void UpdateTransformForBeam(vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode, 
     vtkMRMLLinearTransformNode* beamTransformNode, double isocenter[3]);
 
 public:
@@ -71,19 +75,20 @@ public:
   /// \warning This method is used only in vtkSlicerBeamsModuleLogic::UpdateTransformForBeam
   void UpdateBeamTransform(vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter = nullptr);
 
-public:
-  /// Get transform node between two coordinate systems is exists
-  /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
-  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
-  vtkMRMLLinearTransformNode* GetTransformNodeBetween(
-    vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame);
+  /// Update IEC transforms according to beam node. Function kept separate from \sa UpdateBeamTransform for usage in the DRR module
+  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter=nullptr);
 
 public:
-  /// Update IEC transforms according to beam node
-  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter = nullptr);
+  /// Update FixedReference to RAS and RAS to Patient transforms based on isocenter and patient support transforms.
+  /// \param planNode: Plan node to get the isocenter position from
+  /// \param isocenter: Option to set any isocenter for dynamic beams
+  void UpdateRASRelatedTransforms(vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr);
 
-  /// Update fixed reference to RAS transform based on isocenter and patient support transforms
-  void UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode = nullptr, double* isocenter = nullptr);
+public:
+  vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);
+
+  /// Possibility to use an external IEC logic. This is useful for testing.
+  void SetIECLogic(vtkSlicerIECTransformLogic* iecLogic);
 
 protected:
   vtkSlicerBeamsModuleLogic();
@@ -107,8 +112,7 @@ private:
   vtkSlicerMLCPositionLogic* MLCPositionLogic;
 
 private:
-  vtkSmartPointer<vtkSlicerIECTransformLogic> IecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
+  vtkSlicerIECTransformLogic* IECLogic;
 };
 
 #endif
-

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -76,10 +76,12 @@ public:
   /// \param iecLogic: IEC logic to use for the update. Useful if the Room's Eye View module wants to use this function with its own configuration.
   /// \param planNode: Plan node to get the isocenter position from
   /// \param isocenter: Option to set any isocenter for dynamic beams
-  void UpdateRASRelatedTransforms(vtkSlicerIECTransformLogic* iecLogic=nullptr, vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr);
+  /// \param transformForBeam: calculate dynamic transformation for beam model or other models. False by default.
+  void UpdateRASRelatedTransforms(vtkSlicerIECTransformLogic* iecLogic=nullptr, vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr, bool transformForBeam=false);
 
 public:
   vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);
+  vtkGetObjectMacro(IECLogic, vtkSlicerIECTransformLogic);
 
   /// Possibility to use an external IEC logic. This is useful for testing.
   void SetIECLogic(vtkSlicerIECTransformLogic* iecLogic);

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -41,8 +41,7 @@
 class vtkSlicerMLCPositionLogic;
 
 /// \ingroup SlicerRt_QtModules_Beams
-class VTK_SLICER_BEAMS_LOGIC_EXPORT vtkSlicerBeamsModuleLogic :
-  public vtkSlicerModuleLogic
+class VTK_SLICER_BEAMS_LOGIC_EXPORT vtkSlicerBeamsModuleLogic : public vtkSlicerModuleLogic
 {
 public:
   static vtkSlicerBeamsModuleLogic *New();
@@ -80,9 +79,10 @@ public:
 
 public:
   /// Update FixedReference to RAS and RAS to Patient transforms based on isocenter and patient support transforms.
+  /// \param iecLogic: IEC logic to use for the update. Useful if the Room's Eye View module wants to use this function with its own configuration.
   /// \param planNode: Plan node to get the isocenter position from
   /// \param isocenter: Option to set any isocenter for dynamic beams
-  void UpdateRASRelatedTransforms(vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr);
+  void UpdateRASRelatedTransforms(vtkSlicerIECTransformLogic* iecLogic=nullptr, vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr);
 
 public:
   vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -29,10 +29,14 @@
 
 // Slicer includes
 #include "vtkSlicerModuleLogic.h"
+#include <vtkSlicerIECTransformLogic.h>
 
 // Beams includes
 #include "vtkSlicerBeamsModuleLogicExport.h"
 #include "vtkMRMLRTBeamNode.h"
+
+// VTK includes
+#include <vtkNew.h>
 
 class vtkSlicerMLCPositionLogic;
 
@@ -60,6 +64,27 @@ public:
   void UpdateTransformForBeam( vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode, 
     vtkMRMLLinearTransformNode* beamTransformNode, double isocenter[3]);
 
+public:
+  /// Update parent transform node of a given beam from the IEC transform hierarchy and the beam parameters
+  void UpdateBeamTransform(vtkMRMLRTBeamNode* beamNode);
+  /// Update parent transform node of a given beam from the IEC transform hierarchy and the beam parameters
+  /// \warning This method is used only in vtkSlicerBeamsModuleLogic::UpdateTransformForBeam
+  void UpdateBeamTransform(vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter = nullptr);
+
+public:
+  /// Get transform node between two coordinate systems is exists
+  /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
+  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
+  vtkMRMLLinearTransformNode* GetTransformNodeBetween(
+    vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame);
+
+public:
+  /// Update IEC transforms according to beam node
+  void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter = nullptr);
+
+  /// Update fixed reference to RAS transform based on isocenter and patient support transforms
+  void UpdateFixedReferenceToRASTransform(vtkMRMLRTPlanNode* planNode = nullptr, double* isocenter = nullptr);
+
 protected:
   vtkSlicerBeamsModuleLogic();
   ~vtkSlicerBeamsModuleLogic() override;
@@ -80,6 +105,9 @@ private:
   void operator=(const vtkSlicerBeamsModuleLogic&) = delete;
   
   vtkSlicerMLCPositionLogic* MLCPositionLogic;
+
+private:
+  vtkSmartPointer<vtkSlicerIECTransformLogic> IecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
 };
 
 #endif

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -48,12 +48,6 @@ public:
   vtkTypeMacro(vtkSlicerBeamsModuleLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// Get transform node between two coordinate systems is exists
-  /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
-  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
-  vtkMRMLLinearTransformNode* GetTransformNodeBetween(
-    vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame);
-
   /// Update parent transform of a given beam using its parameters and the IEC logic
   void UpdateTransformForBeam(vtkMRMLRTBeamNode* beamNode);
 

--- a/Beams/Logic/vtkSlicerIECTransformLogic.cxx
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.cxx
@@ -31,8 +31,6 @@
 // STD includes
 #include <array>
 
-
-
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerIECTransformLogic);
 
@@ -55,21 +53,52 @@ vtkSlicerIECTransformLogic::vtkSlicerIECTransformLogic()
   this->CoordinateSystemsMap[WedgeFilter] = "WedgeFilter";
   this->CoordinateSystemsMap[Patient] = "Patient";
 
-  this->IecTransforms.clear();
-  this->IecTransforms.push_back(std::make_pair(FixedReference, RAS));
-  this->IecTransforms.push_back(std::make_pair(Gantry, FixedReference));
-  this->IecTransforms.push_back(std::make_pair(Collimator, Gantry));
-  this->IecTransforms.push_back(std::make_pair(WedgeFilter, Collimator));
-  this->IecTransforms.push_back(std::make_pair(LeftImagingPanel, Gantry));
-  this->IecTransforms.push_back(std::make_pair(RightImagingPanel, Gantry));
-  this->IecTransforms.push_back(std::make_pair(PatientSupportRotation, FixedReference)); // Rotation component of patient support transform
-  this->IecTransforms.push_back(std::make_pair(PatientSupport, PatientSupportRotation)); // Scaling component of patient support transform
-  this->IecTransforms.push_back(std::make_pair(TableTopEccentricRotation, PatientSupportRotation)); // NOTE: Currently not supported by REV
-  this->IecTransforms.push_back(std::make_pair(TableTop, TableTopEccentricRotation));
-  this->IecTransforms.push_back(std::make_pair(Patient, TableTop));
-  this->IecTransforms.push_back(std::make_pair(RAS, Patient));
-  this->IecTransforms.push_back(std::make_pair(FlatPanel, Gantry));
+  this->IECTransforms.clear();
+  this->IECTransforms.push_back(std::make_pair(FixedReference, RAS));
+  this->IECTransforms.push_back(std::make_pair(Gantry, FixedReference));
+  this->IECTransforms.push_back(std::make_pair(Collimator, Gantry));
+  this->IECTransforms.push_back(std::make_pair(WedgeFilter, Collimator));
+  this->IECTransforms.push_back(std::make_pair(LeftImagingPanel, Gantry));
+  this->IECTransforms.push_back(std::make_pair(RightImagingPanel, Gantry));
+  this->IECTransforms.push_back(std::make_pair(PatientSupportRotation, FixedReference)); // Rotation component of patient support transform
+  this->IECTransforms.push_back(std::make_pair(PatientSupport, PatientSupportRotation)); // Scaling component of patient support transform
+  this->IECTransforms.push_back(std::make_pair(TableTopEccentricRotation, PatientSupportRotation)); // NOTE: Currently not supported by REV
+  this->IECTransforms.push_back(std::make_pair(TableTop, TableTopEccentricRotation));
+  this->IECTransforms.push_back(std::make_pair(Patient, TableTop));
+  this->IECTransforms.push_back(std::make_pair(RAS, Patient));
+  this->IECTransforms.push_back(std::make_pair(FlatPanel, Gantry));
 
+  // Set names for elementary transforms for discovery
+  this->FixedReferenceToRasTransform->SetObjectName(this->GetTransformNameBetween(FixedReference, RAS).c_str());
+  this->GantryToFixedReferenceTransform->SetObjectName(this->GetTransformNameBetween(Gantry, FixedReference).c_str());
+  this->CollimatorToGantryTransform->SetObjectName(this->GetTransformNameBetween(Collimator, Gantry).c_str());
+  this->WedgeFilterToCollimatorTransform->SetObjectName(this->GetTransformNameBetween(WedgeFilter, Collimator).c_str());
+  this->LeftImagingPanelToGantryTransform->SetObjectName(this->GetTransformNameBetween(LeftImagingPanel, Gantry).c_str());
+  this->RightImagingPanelToGantryTransform->SetObjectName(this->GetTransformNameBetween(RightImagingPanel, Gantry).c_str());
+  this->PatientSupportRotationToFixedReferenceTransform->SetObjectName(this->GetTransformNameBetween(PatientSupportRotation, FixedReference).c_str());
+  this->PatientSupportToPatientSupportRotationTransform->SetObjectName(this->GetTransformNameBetween(PatientSupport, PatientSupportRotation).c_str());
+  this->TableTopEccentricRotationToPatientSupportRotationTransform->SetObjectName(this->GetTransformNameBetween(TableTopEccentricRotation, PatientSupportRotation).c_str());
+  this->TableTopToTableTopEccentricRotationTransform->SetObjectName(this->GetTransformNameBetween(TableTop, TableTopEccentricRotation).c_str());
+  this->PatientToTableTopTransform->SetObjectName(this->GetTransformNameBetween(Patient, TableTop).c_str());
+  this->RasToPatientTransform->SetObjectName(this->GetTransformNameBetween(RAS, Patient).c_str());
+  this->FlatPanelToGantryTransform->SetObjectName(this->GetTransformNameBetween(FlatPanel, Gantry).c_str());
+
+  // Build list of elementary transforms for discovery by name
+  this->ElementaryTransforms.push_back(this->FixedReferenceToRasTransform);
+  this->ElementaryTransforms.push_back(this->GantryToFixedReferenceTransform);
+  this->ElementaryTransforms.push_back(this->CollimatorToGantryTransform);
+  this->ElementaryTransforms.push_back(this->WedgeFilterToCollimatorTransform);
+  this->ElementaryTransforms.push_back(this->LeftImagingPanelToGantryTransform);
+  this->ElementaryTransforms.push_back(this->RightImagingPanelToGantryTransform);
+  this->ElementaryTransforms.push_back(this->PatientSupportRotationToFixedReferenceTransform);
+  this->ElementaryTransforms.push_back(this->PatientSupportToPatientSupportRotationTransform);
+  this->ElementaryTransforms.push_back(this->TableTopEccentricRotationToPatientSupportRotationTransform);
+  this->ElementaryTransforms.push_back(this->TableTopToTableTopEccentricRotationTransform);
+  this->ElementaryTransforms.push_back(this->PatientToTableTopTransform);
+  this->ElementaryTransforms.push_back(this->RasToPatientTransform);
+  this->ElementaryTransforms.push_back(this->FlatPanelToGantryTransform);
+
+  // Define the transform hierarchy
   this->CoordinateSystemsHierarchy.clear();
   // key - parent, value - children
   this->CoordinateSystemsHierarchy[FixedReference] = { Gantry, PatientSupportRotation };
@@ -79,13 +108,53 @@ vtkSlicerIECTransformLogic::vtkSlicerIECTransformLogic()
   this->CoordinateSystemsHierarchy[TableTopEccentricRotation] = { TableTop };
   this->CoordinateSystemsHierarchy[TableTop] = { Patient };
   this->CoordinateSystemsHierarchy[Patient] = { RAS };
+
+  //
+  // Build concatenated transform hierarchy
+  // 
+  this->GantryToFixedReferenceConcatenatedTransform->Concatenate(this->FixedReferenceToRasTransform);
+  this->GantryToFixedReferenceConcatenatedTransform->Concatenate(this->GantryToFixedReferenceTransform);
+
+  this->CollimatorToGantryConcatenatedTransform->Concatenate(this->GantryToFixedReferenceConcatenatedTransform);
+  this->CollimatorToGantryConcatenatedTransform->Concatenate(this->CollimatorToGantryTransform);
+
+  this->WedgeFilterToCollimatorConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
+  this->WedgeFilterToCollimatorConcatenatedTransform->Concatenate(this->WedgeFilterToCollimatorTransform);
+    
+  this->LeftImagingPanelToGantryConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
+  this->LeftImagingPanelToGantryConcatenatedTransform->Concatenate(this->LeftImagingPanelToGantryTransform);
+
+  this->RightImagingPanelToGantryConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
+  this->RightImagingPanelToGantryConcatenatedTransform->Concatenate(this->RightImagingPanelToGantryTransform);
+
+  this->FlatPanelToGantryConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
+  this->FlatPanelToGantryConcatenatedTransform->Concatenate(this->FlatPanelToGantryTransform);
+
+  this->PatientSupportRotationToFixedReferenceConcatenatedTransform->Concatenate(this->FixedReferenceToRasTransform);
+  this->PatientSupportRotationToFixedReferenceConcatenatedTransform->Concatenate(this->PatientSupportRotationToFixedReferenceTransform);
+
+  this->PatientSupportToPatientSupportRotationConcatenatedTransform->Concatenate(this->PatientSupportRotationToFixedReferenceConcatenatedTransform);
+  this->PatientSupportToPatientSupportRotationConcatenatedTransform->Concatenate(this->PatientSupportToPatientSupportRotationTransform);
+
+  this->TableTopEccentricRotationToPatientSupportRotationConcatenatedTransform->Concatenate(this->PatientSupportRotationToFixedReferenceConcatenatedTransform);
+  this->TableTopEccentricRotationToPatientSupportRotationConcatenatedTransform->Concatenate(this->TableTopEccentricRotationToPatientSupportRotationTransform);
+
+  this->TableTopToTableEccentricRotationConcatenatedTransform->Concatenate(this->TableTopEccentricRotationToPatientSupportRotationConcatenatedTransform);
+  this->TableTopToTableEccentricRotationConcatenatedTransform->Concatenate(this->TableTopToTableTopEccentricRotationTransform);
+
+  this->PatientToTableTopConcatenatedTransform->Concatenate(this->TableTopToTableEccentricRotationConcatenatedTransform);
+  this->PatientToTableTopConcatenatedTransform->Concatenate(this->PatientToTableTopTransform);
+
+  this->RasToPatientConcatenatedTransform->Concatenate(this->PatientToTableTopConcatenatedTransform);
+  this->RasToPatientConcatenatedTransform->Concatenate(this->RasToPatientTransform);
 }
 
 //-----------------------------------------------------------------------------
 vtkSlicerIECTransformLogic::~vtkSlicerIECTransformLogic()
 {
   this->CoordinateSystemsMap.clear();
-  this->IecTransforms.clear();
+  this->IECTransforms.clear();
+  this->ElementaryTransforms.clear();
 }
 
 //----------------------------------------------------------------------------
@@ -93,77 +162,34 @@ void vtkSlicerIECTransformLogic::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os, indent);
 
-  os << indent << "Transforms:" << std::endl;
-  os << indent << "FixedReferenceToRasTransform: " << FixedReferenceToRasTransform << std::endl;
-  os << indent << "GantryToFixedReferenceTransform: " << GantryToFixedReferenceTransform << std::endl;
-  os << indent << "Concatenated GantryToFixedReferenceTransform: " << transformGantryToFixedReferenceConcatenated << std::endl;
-  os << indent << "CollimatorToGantryTransform: " << CollimatorToGantryTransform << std::endl;
-  os << indent << "Concatenated CollimatorToGantryTransform: " << transformCollimatorToGantryConcatenated << std::endl;
-  os << indent << "WedgeFilterToCollimatorTransform: " << WedgeFilterToCollimatorTransform << std::endl;
-  os << indent << "Concatenated WedgeFilterToCollimatorTransform: " << transformWedgeFilterToCollimatorConcatenated << std::endl;
-  os << indent << "AdditionalCollimatorDevicesToCollimatorTransform: " << AdditionalCollimatorDevicesToCollimatorTransform << std::endl;
-  os << indent << "Concatenated AdditionalCollimatorDevicesToCollimatorTransform: " << transformAdditionalCollimatorDevicesToCollimatorConcatenated << std::endl;
-  os << indent << "LeftImagingPanelToGantryTransform: " << LeftImagingPanelToGantryTransform << std::endl;
-  os << indent << "Concatenated LeftImagingPanelToGantryTransform: " << transformLeftImagingPanelToGantryConcatenated << std::endl;
-  os << indent << "RightImagingPanelToGantryTransform: " << RightImagingPanelToGantryTransform << std::endl;
-  os << indent << "Concatenated RightImagingPanelToGantryTransform: " << transformRightImagingPanelToGantryConcatenated << std::endl;
-  os << indent << "FlatPanelToGantryTransform: " << FlatPanelToGantryTransform << std::endl;
-  os << indent << "Concatenated FlatPanelToGantryTransform: " << transformFlatPanelToGantryConcatenated << std::endl;
-  os << indent << "PatientSupportRotationToFixedReferenceTransform: " << PatientSupportRotationToFixedReferenceTransform << std::endl;
-  os << indent << "Concatenated PatientSupportRotationToFixedReferenceTransform: " << transformPatientSupportRotationToFixedReferenceConcatenated << std::endl;
-  os << indent << "PatientSupportToPatientSupportRotationTransform: " << PatientSupportToPatientSupportRotationTransform << std::endl;
-  os << indent << "Concatenated PatientSupportToPatientSupportRotationTransform: " << transformPatientSupportToPatientSupportRotationConcatenated << std::endl;
-  os << indent << "TableTopEccentricRotationToPatientSupportRotationTransform: " << TableTopEccentricRotationToPatientSupportRotationTransform << std::endl;
-  os << indent << "Concatenated TableTopEccentricRotationToPatientSupportRotationTransform: " << transformTableTopEccentricRotationToPatientSupportRotationConcatenated << std::endl;
-  os << indent << "TableTopToTableTopEccentricRotationTransform: " << TableTopToTableTopEccentricRotationTransform << std::endl;
-  os << indent << "Concatenated TableTopToTableTopEccentricRotationTransform: " << transformTableTopToTableEccentricRotationConcatenated << std::endl;
-  os << indent << "PatientToTableTopTransform: " << PatientToTableTopTransform << std::endl;
-  os << indent << "Concatenated PatientToTableTopTransform: " << transformPatientToTableTopConcatenated << std::endl;
-  os << indent << "RasToPatientTransform: " << RasToPatientTransform << std::endl;
-  os << indent << "Concatenated RasToPatientTransform: " << transformRasToPatientConcatenated << std::endl;
-}
-
-//---------------------------------------------------------------------------
-void vtkSlicerIECTransformLogic::BuildIECTransformHierarchy()
-{
-  transformGantryToFixedReferenceConcatenated->Concatenate(FixedReferenceToRasTransform);
-  transformGantryToFixedReferenceConcatenated->Concatenate(GantryToFixedReferenceTransform);
-
-  transformCollimatorToGantryConcatenated->Concatenate(transformGantryToFixedReferenceConcatenated);
-  transformCollimatorToGantryConcatenated->Concatenate(CollimatorToGantryTransform);
-
-  transformWedgeFilterToCollimatorConcatenated->Concatenate(transformCollimatorToGantryConcatenated);
-  transformWedgeFilterToCollimatorConcatenated->Concatenate(WedgeFilterToCollimatorTransform);
+  os << indent << std::endl << "Elementary tansforms:" << std::endl;
+  os << indent << "FixedReferenceToRasTransform: " << this->FixedReferenceToRasTransform << std::endl;
+  os << indent << "GantryToFixedReferenceTransform: " << this->GantryToFixedReferenceTransform << std::endl;
+  os << indent << "CollimatorToGantryTransform: " << this->CollimatorToGantryTransform << std::endl;
+  os << indent << "WedgeFilterToCollimatorTransform: " << this->WedgeFilterToCollimatorTransform << std::endl;
+  os << indent << "LeftImagingPanelToGantryTransform: " << this->LeftImagingPanelToGantryTransform << std::endl;
+  os << indent << "RightImagingPanelToGantryTransform: " << this->RightImagingPanelToGantryTransform << std::endl;
+  os << indent << "FlatPanelToGantryTransform: " << this->FlatPanelToGantryTransform << std::endl;
+  os << indent << "PatientSupportRotationToFixedReferenceTransform: " << this->PatientSupportRotationToFixedReferenceTransform << std::endl;
+  os << indent << "PatientSupportToPatientSupportRotationTransform: " << this->PatientSupportToPatientSupportRotationTransform << std::endl;
+  os << indent << "TableTopEccentricRotationToPatientSupportRotationTransform: " << this->TableTopEccentricRotationToPatientSupportRotationTransform << std::endl;
+  os << indent << "TableTopToTableTopEccentricRotationTransform: " << this->TableTopToTableTopEccentricRotationTransform << std::endl;
+  os << indent << "PatientToTableTopTransform: " << this->PatientToTableTopTransform << std::endl;
+  os << indent << "RasToPatientTransform: " << this->RasToPatientTransform << std::endl;
   
-  transformAdditionalCollimatorDevicesToCollimatorConcatenated->Concatenate(transformWedgeFilterToCollimatorConcatenated);
-  transformAdditionalCollimatorDevicesToCollimatorConcatenated->Concatenate(AdditionalCollimatorDevicesToCollimatorTransform);
-  
-  transformLeftImagingPanelToGantryConcatenated->Concatenate(transformCollimatorToGantryConcatenated);
-  transformLeftImagingPanelToGantryConcatenated->Concatenate(LeftImagingPanelToGantryTransform);
-
-  transformRightImagingPanelToGantryConcatenated->Concatenate(transformCollimatorToGantryConcatenated);
-  transformRightImagingPanelToGantryConcatenated->Concatenate(RightImagingPanelToGantryTransform);
-
-  transformFlatPanelToGantryConcatenated->Concatenate(transformCollimatorToGantryConcatenated);
-  transformFlatPanelToGantryConcatenated->Concatenate(FlatPanelToGantryTransform);
-
-  transformPatientSupportRotationToFixedReferenceConcatenated->Concatenate(FixedReferenceToRasTransform);
-  transformPatientSupportRotationToFixedReferenceConcatenated->Concatenate(PatientSupportRotationToFixedReferenceTransform);
-
-  transformPatientSupportToPatientSupportRotationConcatenated->Concatenate(transformPatientSupportRotationToFixedReferenceConcatenated);
-  transformPatientSupportToPatientSupportRotationConcatenated->Concatenate(PatientSupportToPatientSupportRotationTransform);
-
-  transformTableTopEccentricRotationToPatientSupportRotationConcatenated->Concatenate(transformPatientSupportRotationToFixedReferenceConcatenated);
-  transformTableTopEccentricRotationToPatientSupportRotationConcatenated->Concatenate(TableTopEccentricRotationToPatientSupportRotationTransform);
-
-  transformTableTopToTableEccentricRotationConcatenated->Concatenate(transformTableTopEccentricRotationToPatientSupportRotationConcatenated);
-  transformTableTopToTableEccentricRotationConcatenated->Concatenate(TableTopToTableTopEccentricRotationTransform);
-
-  transformPatientToTableTopConcatenated->Concatenate(transformTableTopToTableEccentricRotationConcatenated);
-  transformPatientToTableTopConcatenated->Concatenate(PatientToTableTopTransform);
-
-  transformRasToPatientConcatenated->Concatenate(transformPatientToTableTopConcatenated);
-  transformRasToPatientConcatenated->Concatenate(RasToPatientTransform);
+  os << indent << std::endl << "Concatenated transforms:" << std::endl;
+  os << indent << "GantryToFixedReferenceConcatenatedTransform: " << this->GantryToFixedReferenceConcatenatedTransform << std::endl;
+  os << indent << "CollimatorToGantryConcatenatedTransform: " << this->CollimatorToGantryConcatenatedTransform << std::endl;
+  os << indent << "WedgeFilterToCollimatorConcatenatedTransform: " << this->WedgeFilterToCollimatorConcatenatedTransform << std::endl;
+  os << indent << "LeftImagingPanelToGantryConcatenatedTransform: " << this->LeftImagingPanelToGantryConcatenatedTransform << std::endl;
+  os << indent << "RightImagingPanelToGantryConcatenatedTransform: " << this->RightImagingPanelToGantryConcatenatedTransform << std::endl;
+  os << indent << "FlatPanelToGantryConcatenatedTransform: " << this->FlatPanelToGantryConcatenatedTransform << std::endl;
+  os << indent << "PatientSupportRotationToFixedReferenceConcatenatedTransform: " << this->PatientSupportRotationToFixedReferenceConcatenatedTransform << std::endl;
+  os << indent << "PatientSupportToPatientSupportRotationConcatenatedTransform: " << this->PatientSupportToPatientSupportRotationConcatenatedTransform << std::endl;
+  os << indent << "TableTopEccentricRotationToPatientSupportRotationConcatenatedTransform: " << this->TableTopEccentricRotationToPatientSupportRotationConcatenatedTransform << std::endl;
+  os << indent << "TableTopToTableTopEccentricRotationConcatenatedTransform: " << this->TableTopToTableEccentricRotationConcatenatedTransform << std::endl;
+  os << indent << "PatientToTableTopConcatenatedTransform: " << this->PatientToTableTopConcatenatedTransform << std::endl;
+  os << indent << "RasToPatientConcatenatedTransform: " << this->RasToPatientConcatenatedTransform << std::endl;
 }
 
 //----------------------------------------------------------------------------
@@ -188,8 +214,169 @@ void vtkSlicerIECTransformLogic::UpdatePatientSupportRotationToFixedReferenceTra
 }
 
 //-----------------------------------------------------------------------------
+vtkTransform* vtkSlicerIECTransformLogic::GetElementaryTransformBetween(
+  CoordinateSystemIdentifier fromFrame, CoordinateSystemIdentifier toFrame)
+{
+  std::string requestedTransformName = this->GetTransformNameBetween(fromFrame, toFrame);
+  for (auto& transform : this->ElementaryTransforms)
+  {
+    std::string currentTransformName(transform->GetObjectName());
+    if (currentTransformName == requestedTransformName)
+    {
+      return transform;
+    }
+  }
+
+  vtkErrorMacro("GetElementaryTransformBetween: Elementary transform not found: " << requestedTransformName);
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
 std::string vtkSlicerIECTransformLogic::GetTransformNameBetween(
   CoordinateSystemIdentifier fromFrame, CoordinateSystemIdentifier toFrame)
 {
-  return this->GetCoordinateSystemsMap()[fromFrame] + "To" + this->GetCoordinateSystemsMap()[toFrame] + "Transform";
+  return this->CoordinateSystemsMap[fromFrame] + "To" + this->CoordinateSystemsMap[toFrame] + "Transform";
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerIECTransformLogic::GetTransformBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
+  vtkGeneralTransform* outputTransform, bool transformForBeam/* = true*/)
+{
+  if (!outputTransform)
+  {
+    vtkErrorMacro("GetTransformBetween: Invalid output transform node");
+    return false;
+  }
+
+  vtkSlicerIECTransformLogic::CoordinateSystemsList fromFramePath, toFramePath;
+  if (this->GetPathToRoot(fromFrame, fromFramePath) && this->GetPathFromRoot(toFrame, toFramePath))
+  {
+    std::vector< vtkSlicerIECTransformLogic::CoordinateSystemIdentifier > toFrameVector(toFramePath.size());
+    std::vector< vtkSlicerIECTransformLogic::CoordinateSystemIdentifier > fromFrameVector(fromFramePath.size());
+
+    std::copy(toFramePath.begin(), toFramePath.end(), toFrameVector.begin());
+    std::copy(fromFramePath.begin(), fromFramePath.end(), fromFrameVector.begin());
+
+    outputTransform->Identity();
+    outputTransform->PostMultiply();
+    for (size_t i = 0; i < fromFrameVector.size() - 1; ++i)
+    {
+      vtkSlicerIECTransformLogic::CoordinateSystemIdentifier parent, child;
+      child = fromFrameVector[i];
+      parent = fromFrameVector[i + 1];
+
+      if (child == parent)
+      {
+        continue;
+      }
+
+      vtkTransform* fromTransform = this->GetElementaryTransformBetween(child, parent);
+      if (fromTransform)
+      {
+        outputTransform->Concatenate(fromTransform->GetMatrix());
+      }
+      else
+      {
+        vtkErrorMacro("GetTransformBetween: Transform node is invalid");
+        return false;
+      }
+    }
+
+    for (size_t i = 0; i < toFrameVector.size() - 1; ++i)
+    {
+      vtkSlicerIECTransformLogic::CoordinateSystemIdentifier parent, child;
+      parent = toFrameVector[i];
+      child = toFrameVector[i + 1];
+
+      if (child == parent)
+      {
+        continue;
+      }
+
+      vtkTransform* toTransform = this->GetElementaryTransformBetween(child, parent);
+      if (toTransform)
+      {
+        vtkNew<vtkMatrix4x4> mat;
+        toTransform->GetMatrix(mat);
+        if (!transformForBeam) // Do not invert for beam transformation
+        {
+          mat->Invert();
+        }
+        outputTransform->Concatenate(mat);
+      }
+      else
+      {
+        vtkErrorMacro("GetTransformBetween: Transform node is invalid");
+        return false;
+      }
+    }
+
+    outputTransform->Modified();
+    return true;
+  }
+
+  vtkErrorMacro("GetTransformBetween: Failed to get transform " << this->GetTransformNameBetween(fromFrame, toFrame));
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerIECTransformLogic::GetPathToRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path)
+{
+  if (frame == vtkSlicerIECTransformLogic::CoordinateSystemIdentifier::FixedReference)
+  {
+    path.push_back(vtkSlicerIECTransformLogic::FixedReference);
+    return true;
+  }
+
+  bool found = false;
+  do
+  {
+    for (auto& pair : this->CoordinateSystemsHierarchy)
+    {
+      vtkSlicerIECTransformLogic::CoordinateSystemIdentifier parent = pair.first;
+
+      auto& children = pair.second;
+      auto iter = std::find(children.begin(), children.end(), frame);
+      if (iter != children.end())
+      {
+        vtkSlicerIECTransformLogic::CoordinateSystemIdentifier id = *iter;
+
+        vtkDebugMacro("GetPathToRoot: Checking affine transformation "
+          << "\"" << this->CoordinateSystemsMap[id] << "\" -> "
+          << "\"" << this->CoordinateSystemsMap[parent] << "\"");
+
+        frame = parent;
+        path.push_back(id);
+        if (frame != vtkSlicerIECTransformLogic::FixedReference)
+        {
+          found = true;
+          break;
+        }
+        else
+        {
+          path.push_back(vtkSlicerIECTransformLogic::FixedReference);
+        }
+      }
+      else
+      {
+        found = false;
+      }
+    }
+  } while (found);
+
+  return (path.size() > 0);
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerIECTransformLogic::GetPathFromRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path)
+{
+  if (this->GetPathToRoot(frame, path))
+  {
+    std::reverse(path.begin(), path.end());
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }

--- a/Beams/Logic/vtkSlicerIECTransformLogic.cxx
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.cxx
@@ -240,7 +240,7 @@ std::string vtkSlicerIECTransformLogic::GetTransformNameBetween(
 
 //-----------------------------------------------------------------------------
 bool vtkSlicerIECTransformLogic::GetTransformBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
-  vtkGeneralTransform* outputTransform, bool transformForBeam/* = true*/)
+  vtkGeneralTransform* outputTransform, bool transformForBeam/*=false*/)
 {
   if (!outputTransform)
   {

--- a/Beams/Logic/vtkSlicerIECTransformLogic.h
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.h
@@ -134,7 +134,7 @@ public:
   /// (e.g. transformation from Patient RAS frame to Collimation frame: RAS -> Patient -> TableTop -> Eccentric -> Patient Support -> Fixed reference -> Gantry -> Collimator)  //TODO: Deprecated
   /// \return Success flag (false on any error)
   bool GetTransformBetween(CoordinateSystemIdentifier fromFrame, CoordinateSystemIdentifier toFrame,
-    vtkGeneralTransform* outputTransform, bool transformForBeam = true);
+    vtkGeneralTransform* outputTransform, bool transformForBeam=false);
   //TODO: See this transformForBeam part if still needed
 
   /// @brief Get coordinate system identifiers from root system down to frame system

--- a/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
+++ b/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
@@ -312,7 +312,7 @@ vtkMRMLTableNode* vtkSlicerMLCPositionLogic::CreateMultiLeafCollimatorTableNodeB
   table->SetValue( nofLeafPairs, 1, 0.); // side "1" set last unused value to zero
   table->SetValue( nofLeafPairs, 2, 0.); // side "2" set last unused value to zero
 
-  tableNode->SetUseColumnNameAsColumnHeader(true);
+  tableNode->SetUseColumnTitleAsColumnHeader(true);
   tableNode->SetColumnDescription( "Boundary", "Leaf pair boundary");
   tableNode->SetColumnDescription( "1", "Leaf position on the side \"1\"");
   tableNode->SetColumnDescription( "2", "Leaf position on the side \"2\"");
@@ -430,7 +430,7 @@ bool vtkSlicerMLCPositionLogic::UpdateMultiLeafCollimatorTableNodeBoundaryData( 
   table->SetValue( nofLeafPairs, 1, 0.); // side "1" set last unused value to zero
   table->SetValue( nofLeafPairs, 2, 0.); // side "2" set last unused value to zero
 
-  mlcTable->SetUseColumnNameAsColumnHeader(true);
+  mlcTable->SetUseColumnTitleAsColumnHeader(true);
   mlcTable->SetColumnDescription( "Boundary", "Leaf pair boundary");
   mlcTable->SetColumnDescription( "1", "Leaf position on the side \"1\"");
   mlcTable->SetColumnDescription( "2", "Leaf position on the side \"2\"");

--- a/Beams/Testing/Cxx/CMakeLists.txt
+++ b/Beams/Testing/Cxx/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(KIT qSlicer${MODULE_NAME}Module)
 
 set(KIT_TEST_SRCS
-  vtkSlicerIECTransformLogicTest1.cxx
+  vtkSlicerBeamsModuleLogicTest1.cxx
   )
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
@@ -14,4 +14,4 @@ slicerMacroConfigureModuleCxxTestDriver(
   WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
-simple_test(vtkSlicerIECTransformLogicTest1)
+simple_test(vtkSlicerBeamsModuleLogicTest1)

--- a/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
+++ b/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
@@ -21,7 +21,6 @@
 // Beams includes
 #include "vtkMRMLRTBeamNode.h"
 #include "vtkMRMLRTPlanNode.h"
-#include "vtkSlicerIECTransformLogic.h"
 #include "vtkSlicerBeamsModuleLogic.h"
 
 // MRML includes
@@ -42,7 +41,6 @@ bool GetLinearTransformNodes(
 /// Determine whether a transform node is a beam transform
 bool IsBeamTransformNode(vtkMRMLTransformNode* node);
 
-int GetNumberOfNonIdentityIECTransforms(vtkMRMLScene* mrmlScene);
 void PrintLinearTransformNodeMatrices( vtkMRMLScene* mrmlScene,
   bool includeIdentity=true, bool includeBeamTransforms=true );
 
@@ -53,42 +51,19 @@ bool IsEqual(vtkMatrix4x4* lhs, vtkMatrix4x4* rhs);
 //----------------------------------------------------------------------------
 int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {
-  /*
+  
   // Create scene
-  vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
+  vtkNew<vtkMRMLScene> mrmlScene;
 
   // Create and set up logic classes
-  vtkSmartPointer<vtkSlicerIECTransformLogic> iecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
-  vtkSmartPointer<vtkSlicerBeamsModuleLogic> beamsLogic = vtkSmartPointer<vtkSlicerBeamsModuleLogic>::New();
+  vtkNew<vtkSlicerBeamsModuleLogic> beamsLogic;
   beamsLogic->SetMRMLScene(mrmlScene);
 
-  int expectedNumberOfLinearTransformNodes = 13;
-  int numberOfLinearTransformNodes = mrmlScene->GetNumberOfNodesByClass("vtkMRMLLinearTransformNode");
-  if (numberOfLinearTransformNodes != expectedNumberOfLinearTransformNodes)
-  {
-    std::cerr << __LINE__ << ": Number of linear transform nodes: " << numberOfLinearTransformNodes << " does not match expected value: " << expectedNumberOfLinearTransformNodes << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Print transform nodes in hierarchy
-  std::cout << "Transform hierarchy successfully created (" << numberOfLinearTransformNodes << " transforms):" << std::endl;
-  std::vector<vtkMRMLLinearTransformNode*> transformNodes;
-  GetLinearTransformNodes(mrmlScene, transformNodes);
-  std::vector<vtkMRMLLinearTransformNode*>::iterator trIt;
-  for (trIt=transformNodes.begin(); trIt!=transformNodes.end(); ++trIt)
-  {
-    vtkMRMLLinearTransformNode* node = (*trIt);
-    std::cout << "  " << node->GetName() << std::endl;
-    vtkMRMLTransformNode* parentTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(node)->GetParentTransformNode();
-    std::cout << "    Parent: " << (parentTransformNode?parentTransformNode->GetName():"(none)") << std::endl;
-  }
-  std::cout << std::endl;
-
   // Create beam node
-  vtkSmartPointer<vtkMRMLRTBeamNode> beamNode = vtkSmartPointer<vtkMRMLRTBeamNode>::New();
+  vtkNew<vtkMRMLRTBeamNode> beamNode;
   mrmlScene->AddNode(beamNode);
   // Create parent plan node and add beam to it (setup subject hierarchy)
-  vtkSmartPointer<vtkMRMLRTPlanNode> planNode = vtkSmartPointer<vtkMRMLRTPlanNode>::New();
+  vtkNew<vtkMRMLRTPlanNode> planNode;
   mrmlScene->AddNode(planNode);
   planNode->AddBeam(beamNode);
 
@@ -96,28 +71,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   if (!beamTransformNode)
   {
     std::cerr << __LINE__ << ": Beam node does not have a valid beam transform node" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  //
-  // Test effect of parameter changes on the transform hierarchy
-
-  // Isocenter position, origin
-  int numOfNonIdentityTransforms = 0;
-  int expectedNumOfNonIdentityTransforms = 2;
-  if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
-  {
-    std::cerr << __LINE__ << ": Number of non-identity linear transforms: " << numOfNonIdentityTransforms << " does not match expected value: " << expectedNumOfNonIdentityTransforms << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  double expectedFixedReferenceToRasTransform_Origin_MatrixElements[16] =
-    {  -1, 0, 0, 0,   0, 0, 1, 0,   0, 1, 0, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
-      expectedFixedReferenceToRasTransform_Origin_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": FixedReferenceToRasTransform transform does not match baseline for origin" << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -135,16 +88,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   planNode->SetIsocenterPosition(isocenter);
   beamsLogic->UpdateBeamTransform(beamNode);
 
-  double expectedFixedReferenceToRasTransform_Translated_MatrixElements[16] =
-    {  -1, 0, 0, 1000,   0, 0, 1, 200,   0, 1, 0, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
-      expectedFixedReferenceToRasTransform_Translated_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": FixedReferenceToRasTransform transform does not match baseline for translated isocenter" << std::endl;
-    return EXIT_FAILURE;
-  }
-
   double expectedBeamTransform_IsocenterTranslated_MatrixElements[16] =
     {  -1, 0, 0, 1000,   0, 0, 1, 200,   0, 1, 0, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
@@ -157,21 +100,8 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Gantry angle, -1 degree
   beamNode->SetGantryAngle(-1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  expectedNumOfNonIdentityTransforms = 3;
-  if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
-  {
-    std::cerr << __LINE__ << ": Number of non-identity linear transforms: " << numOfNonIdentityTransforms << " does not match expected value: " << expectedNumOfNonIdentityTransforms << std::endl;
-    return EXIT_FAILURE;
-  }
-  double expectedGantryToFixedReferenceTransformMinus1_MatrixElements[16] =
-    { 0.999848, 0, -0.0174524, 0,   0, 1, 0, 0,   0.0174524, 0, 0.999848, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
-    expectedGantryToFixedReferenceTransformMinus1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for '-1' degree angle" << std::endl;
-    return EXIT_FAILURE;
-  }
+
+  PrintLinearTransformNodeMatrices(mrmlScene, false, true);
 
   double expectedBeamTransform_GantryMinus1_MatrixElements[16] =
     { -0.999848, -1.22465e-16, 0.0174524, 1000,   0.0174524, 0, 0.999848, 200,   -1.22446e-16, 1, 2.1373e-18, 0,   0, 0, 0, 1 };
@@ -185,15 +115,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Gantry angle, 1 degree
   beamNode->SetGantryAngle(1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedGantryToFixedReferenceTransform_1_MatrixElements[16] =
-    {  0.999848, 0, 0.0174524, 0,   0, 1, 0, 0,   -0.0174524, 0, 0.999848, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
-      expectedGantryToFixedReferenceTransform_1_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for 1 degree angle" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_Gantry1_MatrixElements[16] =
     {  -0.999848, 0, -0.0174524, 1000,   -0.0174524, 0, 0.999848, 200,   0, 1, 0, 0,   0, 0, 0, 1  };
@@ -207,15 +128,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Gantry angle, -90 degrees
   beamNode->SetGantryAngle(-90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedGantryToFixedReference_Minus90_MatrixElements[16] =
-    { 0, 0, -1, 0,   0, 1, 0, 0,   1, 0, 0, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
-    expectedGantryToFixedReference_Minus90_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for '-90' degrees angle" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_GantryMinus90_MatrixElements[16] =
     { 0,  -1.22465e-16, 1, 1000,   1, 0, 0, 200,   0, 1, 1.22465e-16, 0,   0, 0, 0, 1 };
@@ -229,15 +141,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Gantry angle, 90 degrees
   beamNode->SetGantryAngle(90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedGantryToFixedReference_90_MatrixElements[16] =
-    {  0, 0, 1, 0,   0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
-      expectedGantryToFixedReference_90_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for 90 degrees angle" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_Gantry90_MatrixElements[16] =
     {  0, 0, -1, 1000,   -1, 0, 0, 200,   0, 1, 0, 0,   0, 0, 0, 1  };
@@ -251,22 +154,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Collimator angle, -1 degree
   beamNode->SetCollimatorAngle(-1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  expectedNumOfNonIdentityTransforms = 4;
-  if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
-  {
-    std::cerr << __LINE__ << ": Number of non-identity linear transforms: " << numOfNonIdentityTransforms << " does not match expected value: " << expectedNumOfNonIdentityTransforms << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  double expectedCollimatorToGantryTransform_Minus1_MatrixElements[16] =
-    { 0.999848, 0.0174524, 0, 0,   -0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
-    expectedCollimatorToGantryTransform_Minus1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_CollimatorMinus1_MatrixElements[16] =
     { 2.1373e-18, -1.22446e-16, -1, 1000,   -0.999848, -0.0174524, 0, 200,   -0.0174524, 0.999848, -1.22465e-16, 0,   0, 0, 0, 1 };
@@ -280,22 +167,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Collimator angle, 1 degree
   beamNode->SetCollimatorAngle(1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  expectedNumOfNonIdentityTransforms = 4;
-  if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
-  {
-    std::cerr << __LINE__ << ": Number of non-identity linear transforms: " << numOfNonIdentityTransforms << " does not match expected value: " << expectedNumOfNonIdentityTransforms << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  double expectedCollimatorToGantryTransform_1_MatrixElements[16] =
-    {  0.999848, -0.0174524, 0, 0,   0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
-      expectedCollimatorToGantryTransform_1_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_Collimator1_MatrixElements[16] =
     {  0, 0, -1, 1000,   -0.999848, 0.0174524, 0, 200,   0.0174524, 0.999848, 0, 0,   0, 0, 0, 1  };
@@ -309,15 +180,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Collimator angle, -90 degrees
   beamNode->SetCollimatorAngle(-90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedCollimatorToGantryTransform_Minus90_MatrixElements[16] =
-    { 0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
-    expectedCollimatorToGantryTransform_Minus90_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_CollimatorMinus90_MatrixElements[16] =
     { 1.22465e-16, 0, -1, 1000,   0, -1, 0, 200,   -1, 0, -1.22465e-16, 0,   0, 0, 0, 1 };
@@ -331,15 +193,6 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Collimator angle, 90 degrees
   beamNode->SetCollimatorAngle(90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedCollimatorToGantryTransform_90_MatrixElements[16] =
-    {  0, -1, 0, 0,   1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
-      expectedCollimatorToGantryTransform_90_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_Collimator90_MatrixElements[16] =
     {  0, 0, -1, 1000,   0, 1, 0, 200,   1, 0, 0, 0,   0, 0, 0, 1  };
@@ -353,46 +206,23 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Patient support angle, -1 degree
   beamNode->SetCouchAngle(-1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  expectedNumOfNonIdentityTransforms = 5;
-  if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
-  {
-    std::cerr << __LINE__ << ": Number of non-identity linear transforms: " << numOfNonIdentityTransforms << " does not match expected value: " << expectedNumOfNonIdentityTransforms << std::endl;
-    return EXIT_FAILURE;
-  }
-  double expectedPatientSupportRotationToFixedReferenceTransformMinus1_MatrixElements[16] =
-    { 0.999848, 0.0174524, 0, 0,   -0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
-    expectedPatientSupportRotationToFixedReferenceTransformMinus1_MatrixElements))
-  {
-    std:cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
+  
   double expectedBeamTransform_PatientSupportMinus1_MatrixElements[16] =
-    { 0.0174524, 0, -0.999848, 1000,   0, 1, 0, 200,   0.999848, 0, 0.0174524, 0,   0, 0, 0, 1 };
+    { -0.0174524, 0, -0.999848, 1000,   0, 1, 0, 200,   0.999848, 0, -0.0174524, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
     beamTransformNode, expectedBeamTransform_PatientSupportMinus1_MatrixElements))
   {
     std::cerr << __LINE__ << ": Beam transform does not match baseline for patient support '-1' degree angle" << std::endl;
+    PrintLinearTransformNodeMatrices(mrmlScene, true, true);
     return EXIT_FAILURE;
   }
 
   // Patient support angle, 1 degree
   beamNode->SetCouchAngle(1.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedPatientSupportRotationToFixedReferenceTransform1_MatrixElements[16] =
-    { 0.999848, -0.0174524, 0, 0,   0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
-      expectedPatientSupportRotationToFixedReferenceTransform1_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_PatientSupport1_MatrixElements[16] =
-    {  -0.0174524, 0, -0.999848, 1000,   0, 1, 0, 200,   0.999848, 0, -0.0174524, 0,   0, 0, 0, 1  };
+    { 0.0174524, 0, -0.999848, 1000,   0, 1, 0, 200,   0.999848, 0, 0.0174524, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
     beamTransformNode, expectedBeamTransform_PatientSupport1_MatrixElements))
   {
@@ -403,18 +233,9 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Patient support angle, -90 degrees
   beamNode->SetCouchAngle(-90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedPatientSupportRotationToFixedReferenceTransformMinus90_MatrixElements[16] =
-    { 0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
-    expectedPatientSupportRotationToFixedReferenceTransformMinus90_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
+  
   double expectedBeamTransform_PatientSupportMinus90_MatrixElements[16] =
-    {  1, 0, -1.22465e-16, 1000,   0, 1, 0, 200,   1.22465e-16, 0, 1, 0,   0, 0, 0, 1  };
+    {  -1, 0, 1.22465e-16, 1000,   0, 1, 0, 200,   -1.22465e-16, 0, -1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
     beamTransformNode, expectedBeamTransform_PatientSupportMinus90_MatrixElements))
   {
@@ -425,18 +246,9 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   // Patient support angle, 90 degrees
   beamNode->SetCouchAngle(90.0);
   beamsLogic->UpdateBeamTransform(beamNode);
-  double expectedPatientSupportRotationToFixedReferenceTransform90_MatrixElements[16] =
-    {  0, -1, 0, 0,   1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if ( !IsTransformMatrixEqualTo(mrmlScene,
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
-      expectedPatientSupportRotationToFixedReferenceTransform90_MatrixElements ) )
-  {
-    std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
 
   double expectedBeamTransform_PatientSupport90_MatrixElements[16] =
-    {  -1, 0, 1.22465e-16, 1000,   0, 1, 0, 200,   -1.22465e-16, 0, -1, 0,   0, 0, 0, 1  };
+    {  1, 0, 1.22465e-16, 1000,   0, 1, 0, 200,   1.22465e-16, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
     beamTransformNode, expectedBeamTransform_PatientSupport90_MatrixElements))
   {
@@ -444,297 +256,12 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
     return EXIT_FAILURE;
   }
 
-  // Table Top (vertical), 1.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical1 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical1 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Vertical1->GetTransformToParent());
-
-  // Lateral, Longitudinal, Vertical
-  double translationArray[3] =
-    { 0, 0, 1 };
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Vertical1;
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical1->SetElement(0, 3, translationArray[0]);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical1->SetElement(1, 3, translationArray[1]);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical1->SetElement(2, 3, translationArray[2]);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical1->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Vertical1);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical1->Modified();
-
-  double expectedTableTopToTableTop_Vertical1_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, 1,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Vertical1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (vertical), -1.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus1 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus1 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus1->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus1;
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus1->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus1->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus1->SetElement(2, 3, -1);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus1->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus1);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus1->Modified();
-
-  double expectedTableTopToTableTop_Vertical_Minus1_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, -1,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Vertical_Minus1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (vertical), 299.0mm
-  // This is the max value for the default Varian machine in this case
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_299 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_299 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Vertical_299->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Vertical_299;
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_299->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_299->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_299->SetElement(2, 3, 299);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_299->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Vertical_299);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_299->Modified();
-
-  double expectedTableTopToTableTop_Vertical_299_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, 299,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Vertical_299_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (vertical), -500.0mm
-  // This is the min value for the default Varian machine in this case
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus500 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus500 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus500->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus500;
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus500->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus500->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus500->SetElement(2, 3, -500);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus500->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Vertical_Minus500);
-  tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus500->Modified();
-
-  double expectedTableTopToTableTop_Vertical_Minus500_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, -500,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Vertical_Minus500_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (longitudinal), 1.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1;
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1->SetElement(1, 3, 1);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1->Modified();
-
-  double expectedTableTopToTableTop_Longitudinal_1_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 1,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Longitudinal_1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (longitudinal), -1.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_Minus1 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_Minus1 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Longitudinal_Minus1->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_Minus1;
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_Minus1->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_Minus1->SetElement(1, 3, -1);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_Minus1->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_Minus1->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_Minus1);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_Minus1->Modified();
-
-  double expectedTableTopToTableTop_Longitudinal_Minus1_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, -1,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Longitudinal_Minus1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (longitudinal), 90.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_90 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_90 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Longitudinal_90->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_90;
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_90->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_90->SetElement(1, 3, 90);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_90->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_90->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_90);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_90->Modified();
-
-  double expectedTableTopToTableTop_Longitudinal_90_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 90,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Longitudinal_90_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (longitudinal), 1000.0mm
-  // This is the max value for the default Varian machine in this case
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1000 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1000 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1000->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1000;
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1000->SetElement(0, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1000->SetElement(1, 3, 1000);
-  tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1000->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1000->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Longitudinal_1000);
-  tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1000->Modified();
-
-  double expectedTableTopToTableTop_Longitudinal_1000_MatrixElements[16] =
-    {  1, 0, 0, 0,   0, 1, 0, 1000,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Longitudinal_1000_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (lateral), 1.0mm
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_1 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_1 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Lateral_1->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Lateral_1;
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_1->SetElement(0, 3, 1);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_1->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_1->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_1->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Lateral_1);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_1->Modified();
-
-  double expectedTableTopToTableTop_Lateral_1_MatrixElements[16] =
-    {  1, 0, 0, 1,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Lateral_1_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (lateral), 230.0mm
-  // This is the max value for the default Varian machine in this case
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_230 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_230 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Lateral_230->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Lateral_230;
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_230->SetElement(0, 3, 230);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_230->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_230->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_230->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Lateral_230);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_230->Modified();
-
-  double expectedTableTopToTableTop_Lateral_230_MatrixElements[16] =
-    {  1, 0, 0, 230,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Lateral_230_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  // Table Top (lateral), -230.0mm
-  // This is the min value for the default Varian machine in this case
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_Minus230 =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_Minus230 = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode_Lateral_Minus230->GetTransformToParent());
-
-
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix_Lateral_Minus230;
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_Minus230->SetElement(0, 3, -230);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_Minus230->SetElement(1, 3, 0);
-  tableTopEccentricRotationToPatientSupportMatrix_Lateral_Minus230->SetElement(2, 3, 0);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_Minus230->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix_Lateral_Minus230);
-  tableTopEccentricRotationToPatientSupportTransform_Lateral_Minus230->Modified();
-
-  double expectedTableTopToTableTop_Lateral_Minus230_MatrixElements[16] =
-    {  1, 0, 0, -230,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
-  if (!IsTransformMatrixEqualTo(mrmlScene,
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
-    expectedTableTopToTableTop_Lateral_Minus230_MatrixElements))
-  {
-    std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-
   //TODO: Test code to print all non-identity transforms (useful to add more test cases)
   //std::cout << "ZZZ after collimator angle 90:" << std::endl;
   //PrintLinearTransformNodeMatrices(mrmlScene, false, true);
-  */
-  std::cout << "IEC logic test passed" << std::endl;
+  
+  std::cout << "Beams logic test passed" << std::endl;
   return EXIT_SUCCESS;
-}
-
-//----------------------------------------------------------------------------
-int GetNumberOfNonIdentityIECTransforms(vtkMRMLScene* mrmlScene)
-{
-  std::vector<vtkMRMLLinearTransformNode*> nonIdentityIECTransforms;
-  if (!GetLinearTransformNodes(mrmlScene, nonIdentityIECTransforms, false, false))
-  {
-    return -1;
-  }
-
-  return nonIdentityIECTransforms.size();
 }
 
 //----------------------------------------------------------------------------
@@ -753,7 +280,7 @@ void PrintLinearTransformNodeMatrices(vtkMRMLScene* mrmlScene,
 
   // Print linear transform node matrices for nodes that fulfill the conditions
   std::vector<vtkMRMLLinearTransformNode*>::iterator trIt;
-  vtkSmartPointer<vtkMatrix4x4> matrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  vtkNew<vtkMatrix4x4> matrix;
   for (trIt=transformNodes.begin(); trIt!=transformNodes.end(); ++trIt)
   {
     vtkMRMLLinearTransformNode* transformNode = (*trIt);
@@ -802,13 +329,13 @@ bool GetLinearTransformNodes(
   transformNodes.clear();
 
   // Create identity matrix for comparison
-  vtkSmartPointer<vtkMatrix4x4> identityMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  vtkNew<vtkMatrix4x4> identityMatrix;
   identityMatrix->Identity();
 
   // Collect transform nodes that fulfill the conditions
   std::vector<vtkMRMLNode*> nodes;
   mrmlScene->GetNodesByClass("vtkMRMLLinearTransformNode", nodes);
-  vtkSmartPointer<vtkMatrix4x4> matrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  vtkNew<vtkMatrix4x4> matrix;
   for (std::vector<vtkMRMLNode*>::iterator nodeIt=nodes.begin(); nodeIt!=nodes.end(); ++nodeIt)
   {
     vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast(*nodeIt);
@@ -845,7 +372,7 @@ bool IsTransformMatrixEqualTo(vtkMRMLScene* mrmlScene, vtkMRMLLinearTransformNod
   {
     for (int j = 0; j < 4; j++)
     {
-      baselineMatrix->SetElement(i,j, baselineElements[4*i+j]);
+      baselineMatrix->SetElement(i, j, baselineElements[4 * i + j]);
     }
   }
 

--- a/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
+++ b/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
@@ -53,6 +53,7 @@ bool IsEqual(vtkMatrix4x4* lhs, vtkMatrix4x4* rhs);
 //----------------------------------------------------------------------------
 int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {
+  /*
   // Create scene
   vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
 
@@ -719,7 +720,7 @@ int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[
   //TODO: Test code to print all non-identity transforms (useful to add more test cases)
   //std::cout << "ZZZ after collimator angle 90:" << std::endl;
   //PrintLinearTransformNodeMatrices(mrmlScene, false, true);
-
+  */
   std::cout << "IEC logic test passed" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
+++ b/Beams/Testing/Cxx/vtkSlicerBeamsModuleLogicTest1.cxx
@@ -51,14 +51,13 @@ bool AreEqualWithTolerance(double a, double b);
 bool IsEqual(vtkMatrix4x4* lhs, vtkMatrix4x4* rhs);
 
 //----------------------------------------------------------------------------
-int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
+int vtkSlicerBeamsModuleLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {
   // Create scene
   vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
 
   // Create and set up logic classes
   vtkSmartPointer<vtkSlicerIECTransformLogic> iecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
-  iecLogic->BuildIECTransformHierarchy();
   vtkSmartPointer<vtkSlicerBeamsModuleLogic> beamsLogic = vtkSmartPointer<vtkSlicerBeamsModuleLogic>::New();
   beamsLogic->SetMRMLScene(mrmlScene);
 

--- a/Beams/Testing/Cxx/vtkSlicerIECTransformLogicTest1.cxx
+++ b/Beams/Testing/Cxx/vtkSlicerIECTransformLogicTest1.cxx
@@ -58,7 +58,6 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Create and set up logic classes
   vtkSmartPointer<vtkSlicerIECTransformLogic> iecLogic = vtkSmartPointer<vtkSlicerIECTransformLogic>::New();
-  iecLogic->SetMRMLScene(mrmlScene);
   iecLogic->BuildIECTransformHierarchy();
   vtkSmartPointer<vtkSlicerBeamsModuleLogic> beamsLogic = vtkSmartPointer<vtkSlicerBeamsModuleLogic>::New();
   beamsLogic->SetMRMLScene(mrmlScene);
@@ -115,7 +114,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedFixedReferenceToRasTransform_Origin_MatrixElements[16] =
     {  -1, 0, 0, 0,   0, 0, 1, 0,   0, 1, 0, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
       expectedFixedReferenceToRasTransform_Origin_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": FixedReferenceToRasTransform transform does not match baseline for origin" << std::endl;
@@ -134,12 +133,12 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Isocenter position, translated
   double isocenter[3] = {1000.0, 200.0, 0.0};
   planNode->SetIsocenterPosition(isocenter);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
 
   double expectedFixedReferenceToRasTransform_Translated_MatrixElements[16] =
     {  -1, 0, 0, 1000,   0, 0, 1, 200,   0, 1, 0, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS),
       expectedFixedReferenceToRasTransform_Translated_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": FixedReferenceToRasTransform transform does not match baseline for translated isocenter" << std::endl;
@@ -157,7 +156,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Gantry angle, -1 degree
   beamNode->SetGantryAngle(-1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   expectedNumOfNonIdentityTransforms = 3;
   if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
   {
@@ -167,7 +166,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedGantryToFixedReferenceTransformMinus1_MatrixElements[16] =
     { 0.999848, 0, -0.0174524, 0,   0, 1, 0, 0,   0.0174524, 0, 0.999848, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
     expectedGantryToFixedReferenceTransformMinus1_MatrixElements))
   {
     std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for '-1' degree angle" << std::endl;
@@ -185,11 +184,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Gantry angle, 1 degree
   beamNode->SetGantryAngle(1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedGantryToFixedReferenceTransform_1_MatrixElements[16] =
     {  0.999848, 0, 0.0174524, 0,   0, 1, 0, 0,   -0.0174524, 0, 0.999848, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
       expectedGantryToFixedReferenceTransform_1_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for 1 degree angle" << std::endl;
@@ -207,11 +206,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Gantry angle, -90 degrees
   beamNode->SetGantryAngle(-90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedGantryToFixedReference_Minus90_MatrixElements[16] =
     { 0, 0, -1, 0,   0, 1, 0, 0,   1, 0, 0, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
     expectedGantryToFixedReference_Minus90_MatrixElements))
   {
     std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for '-90' degrees angle" << std::endl;
@@ -229,11 +228,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Gantry angle, 90 degrees
   beamNode->SetGantryAngle(90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedGantryToFixedReference_90_MatrixElements[16] =
     {  0, 0, 1, 0,   0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference),
       expectedGantryToFixedReference_90_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": GantryToFixedReferenceTransform does not match baseline for 90 degrees angle" << std::endl;
@@ -251,7 +250,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Collimator angle, -1 degree
   beamNode->SetCollimatorAngle(-1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   expectedNumOfNonIdentityTransforms = 4;
   if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
   {
@@ -262,7 +261,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedCollimatorToGantryTransform_Minus1_MatrixElements[16] =
     { 0.999848, 0.0174524, 0, 0,   -0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
     expectedCollimatorToGantryTransform_Minus1_MatrixElements))
   {
     std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
@@ -280,7 +279,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Collimator angle, 1 degree
   beamNode->SetCollimatorAngle(1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   expectedNumOfNonIdentityTransforms = 4;
   if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
   {
@@ -291,7 +290,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedCollimatorToGantryTransform_1_MatrixElements[16] =
     {  0.999848, -0.0174524, 0, 0,   0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
       expectedCollimatorToGantryTransform_1_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
@@ -309,11 +308,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Collimator angle, -90 degrees
   beamNode->SetCollimatorAngle(-90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedCollimatorToGantryTransform_Minus90_MatrixElements[16] =
     { 0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
     expectedCollimatorToGantryTransform_Minus90_MatrixElements))
   {
     std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
@@ -331,11 +330,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Collimator angle, 90 degrees
   beamNode->SetCollimatorAngle(90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedCollimatorToGantryTransform_90_MatrixElements[16] =
     {  0, -1, 0, 0,   1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry),
       expectedCollimatorToGantryTransform_90_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": CollimatorToGantry does not match baseline" << std::endl;
@@ -353,7 +352,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Patient support angle, -1 degree
   beamNode->SetCouchAngle(-1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   expectedNumOfNonIdentityTransforms = 5;
   if ((numOfNonIdentityTransforms = GetNumberOfNonIdentityIECTransforms(mrmlScene)) != expectedNumOfNonIdentityTransforms)
   {
@@ -363,7 +362,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedPatientSupportRotationToFixedReferenceTransformMinus1_MatrixElements[16] =
     { 0.999848, 0.0174524, 0, 0,   -0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
     expectedPatientSupportRotationToFixedReferenceTransformMinus1_MatrixElements))
   {
     std:cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
@@ -381,11 +380,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Patient support angle, 1 degree
   beamNode->SetCouchAngle(1.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedPatientSupportRotationToFixedReferenceTransform1_MatrixElements[16] =
     { 0.999848, -0.0174524, 0, 0,   0.0174524, 0.999848, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
       expectedPatientSupportRotationToFixedReferenceTransform1_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
@@ -403,11 +402,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Patient support angle, -90 degrees
   beamNode->SetCouchAngle(-90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedPatientSupportRotationToFixedReferenceTransformMinus90_MatrixElements[16] =
     { 0, 1, 0, 0,   -1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1 };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
     expectedPatientSupportRotationToFixedReferenceTransformMinus90_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
@@ -425,11 +424,11 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Patient support angle, 90 degrees
   beamNode->SetCouchAngle(90.0);
-  iecLogic->UpdateBeamTransform(beamNode);
+  beamsLogic->UpdateBeamTransform(beamNode);
   double expectedPatientSupportRotationToFixedReferenceTransform90_MatrixElements[16] =
     {  0, -1, 0, 0,   1, 0, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if ( !IsTransformMatrixEqualTo(mrmlScene,
-      iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
+      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference),
       expectedPatientSupportRotationToFixedReferenceTransform90_MatrixElements ) )
   {
     std::cerr << __LINE__ << ": PatientSupportRotationToFixedReference does not match baseline" << std::endl;
@@ -447,7 +446,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (vertical), 1.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical1 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical1 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Vertical1->GetTransformToParent());
 
@@ -465,7 +464,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Vertical1_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, 1,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Vertical1_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
@@ -474,7 +473,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (vertical), -1.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus1 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus1 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus1->GetTransformToParent());
 
@@ -489,7 +488,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Vertical_Minus1_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, -1,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Vertical_Minus1_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
@@ -499,7 +498,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Table Top (vertical), 299.0mm
   // This is the max value for the default Varian machine in this case
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_299 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_299 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Vertical_299->GetTransformToParent());
 
@@ -514,7 +513,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Vertical_299_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, 299,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Vertical_299_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
@@ -524,7 +523,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Table Top (vertical), -500.0mm
   // This is the min value for the default Varian machine in this case
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus500 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Vertical_Minus500 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Vertical_Minus500->GetTransformToParent());
 
@@ -539,7 +538,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Vertical_Minus500_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 0,   0, 0, 1, -500,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Vertical_Minus500_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (vertical) does not match baseline" << std::endl;
@@ -548,7 +547,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (longitudinal), 1.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1->GetTransformToParent());
 
@@ -563,7 +562,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Longitudinal_1_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 1,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Longitudinal_1_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
@@ -572,7 +571,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (longitudinal), -1.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_Minus1 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_Minus1 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Longitudinal_Minus1->GetTransformToParent());
 
@@ -587,7 +586,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Longitudinal_Minus1_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, -1,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Longitudinal_Minus1_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
@@ -596,7 +595,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (longitudinal), 90.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_90 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_90 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Longitudinal_90->GetTransformToParent());
 
@@ -611,7 +610,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Longitudinal_90_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 90,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Longitudinal_90_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
@@ -621,7 +620,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Table Top (longitudinal), 1000.0mm
   // This is the max value for the default Varian machine in this case
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1000 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Longitudinal_1000 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Longitudinal_1000->GetTransformToParent());
 
@@ -636,7 +635,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Longitudinal_1000_MatrixElements[16] =
     {  1, 0, 0, 0,   0, 1, 0, 1000,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Longitudinal_1000_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (longitudinal) does not match baseline" << std::endl;
@@ -645,7 +644,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
 
   // Table Top (lateral), 1.0mm
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_1 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_1 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Lateral_1->GetTransformToParent());
 
@@ -660,7 +659,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Lateral_1_MatrixElements[16] =
     {  1, 0, 0, 1,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Lateral_1_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;
@@ -670,7 +669,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Table Top (lateral), 230.0mm
   // This is the max value for the default Varian machine in this case
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_230 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_230 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Lateral_230->GetTransformToParent());
 
@@ -685,7 +684,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Lateral_230_MatrixElements[16] =
     {  1, 0, 0, 230,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Lateral_230_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;
@@ -695,7 +694,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   // Table Top (lateral), -230.0mm
   // This is the min value for the default Varian machine in this case
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode_Lateral_Minus230 =
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform_Lateral_Minus230 = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode_Lateral_Minus230->GetTransformToParent());
 
@@ -710,7 +709,7 @@ int vtkSlicerIECTransformLogicTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)
   double expectedTableTopToTableTop_Lateral_Minus230_MatrixElements[16] =
     {  1, 0, 0, -230,   0, 1, 0, 0,   0, 0, 1, 0,   0, 0, 0, 1  };
   if (!IsTransformMatrixEqualTo(mrmlScene,
-    iecLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
+    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation),
     expectedTableTopToTableTop_Lateral_Minus230_MatrixElements))
   {
     std::cerr << __LINE__ << ": PatientToTableTopTransform (lateral) does not match baseline" << std::endl;

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -195,7 +195,9 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
   d->SliderWidget_GantryAngle->blockSignals(true);
   d->SliderWidget_GantryAngle->setValue(d->BeamNode->GetGantryAngle());
   d->SliderWidget_GantryAngle->blockSignals(false);
-  d->SliderWidget_CouchAngle->setValue(d->BeamNode->GetCouchAngle());
+  // Set the inverse of the couch angle as now what moves is the room (treatment machine) around the patient,
+  // so the patient support table top (couch) always stays stationary in RAS.
+  d->SliderWidget_CouchAngle->setValue(-d->BeamNode->GetCouchAngle());
 
   d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setMRMLScene(d->BeamNode->GetScene());
 
@@ -1001,8 +1003,11 @@ void qMRMLBeamParametersTabWidget::couchAngleChanged(double value)
     return;
   }
 
-  // Do not disable modifier events as transforms need to be updated
-  d->BeamNode->SetCouchAngle(value);
+  // Do not disable modifier events as transforms need to be updated.
+
+  // Set the inverse of the couch angle as now what moves is the room (treatment machine) around the patient,
+  // so the patient support table top (couch) always stays stationary in RAS.
+  d->BeamNode->SetCouchAngle(-value);
 }
 
 //-----------------------------------------------------------------------------

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.h
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.h
@@ -41,11 +41,8 @@ class vtkCollection;
 class vtkMRMLScalarVolumeNode;
 class vtkMRMLScene;
 class vtkMRMLSegmentationNode;
-class vtkSlicerBeamsModuleLogic;
 class vtkSlicerDICOMLoadable;
 class vtkSlicerDicomReaderBase;
-class vtkSlicerIsodoseModuleLogic;
-class vtkSlicerPlanarImageModuleLogic;
 class vtkStringArray;
 
 /// \ingroup SlicerRt_QtModules_DicomRtImport
@@ -78,14 +75,6 @@ public:
   static void InsertSeriesInSubjectHierarchy(vtkSlicerDicomReaderBase* reader, vtkMRMLScene* scene);
 
 public:
-  /// Set Isodose module logic
-  void SetIsodoseLogic(vtkSlicerIsodoseModuleLogic* isodoseLogic);
-  /// Set Planar Image module logic
-  void SetPlanarImageLogic(vtkSlicerPlanarImageModuleLogic* planarImageLogic);
-  /// Set Beams module logic
-  void SetBeamsLogic(vtkSlicerBeamsModuleLogic* beamsLogic);
-
-public:
   vtkSetMacro(BeamModelsInSeparateBranch, bool);
   vtkGetMacro(BeamModelsInSeparateBranch, bool);
   vtkBooleanMacro(BeamModelsInSeparateBranch, bool);
@@ -109,15 +98,6 @@ private:
   friend class vtkInternal; // For access from the callback function
 
 private:
-  /// Isodose logic instance
-  vtkSlicerIsodoseModuleLogic* IsodoseLogic;
-
-  /// Planar Image logic instance
-  vtkSlicerPlanarImageModuleLogic* PlanarImageLogic;
-
-  /// Beams module logic instance
-  vtkSlicerBeamsModuleLogic* BeamsLogic;
-
   /// Flag determining whether the generated beam models are arranged in a separate subject hierarchy
   /// branch, or each beam model is added under its corresponding isocenter fiducial
   bool BeamModelsInSeparateBranch;

--- a/DicomRtImportExport/qSlicerDicomRtImportExportModule.cxx
+++ b/DicomRtImportExport/qSlicerDicomRtImportExportModule.cxx
@@ -117,42 +117,6 @@ void qSlicerDicomRtImportExportModule::setup()
 
   vtkSlicerDicomRtImportExportModuleLogic* dicomRtImportExportLogic = vtkSlicerDicomRtImportExportModuleLogic::SafeDownCast(this->logic());
 
-  // Set isodose logic to the logic
-  qSlicerAbstractCoreModule* isodoseModule = qSlicerCoreApplication::application()->moduleManager()->module("Isodose");
-  if (isodoseModule)
-  {
-    vtkSlicerIsodoseModuleLogic* isodoseLogic = vtkSlicerIsodoseModuleLogic::SafeDownCast(isodoseModule->logic());
-    dicomRtImportExportLogic->SetIsodoseLogic(isodoseLogic);
-  }
-  else
-  {
-    qCritical() << Q_FUNC_INFO << ": Isodose module is not found";
-  } 
-
-  // Set planar image logic to the logic
-  qSlicerAbstractCoreModule* planarImageModule = qSlicerCoreApplication::application()->moduleManager()->module("PlanarImage");
-  if (planarImageModule)
-  {
-    vtkSlicerPlanarImageModuleLogic* planarImageLogic = vtkSlicerPlanarImageModuleLogic::SafeDownCast(planarImageModule->logic());
-    dicomRtImportExportLogic->SetPlanarImageLogic(planarImageLogic);
-  }
-  else
-  {
-    qCritical() << Q_FUNC_INFO << ": Planar Image module is not found";
-  } 
-
-  // Set beams logic to the logic
-  qSlicerAbstractCoreModule* beamsModule = qSlicerCoreApplication::application()->moduleManager()->module("Beams");
-  if (beamsModule)
-  {
-    vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(beamsModule->logic());
-    dicomRtImportExportLogic->SetBeamsLogic(beamsLogic);
-  }
-  else
-  {
-    qCritical() << Q_FUNC_INFO << ": Beams module is not found";
-  } 
-
   // Register Subject Hierarchy plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyRtImagePlugin());
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyRtDoseVolumePlugin());

--- a/DrrImageComputation/Logic/CMakeLists.txt
+++ b/DrrImageComputation/Logic/CMakeLists.txt
@@ -20,6 +20,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicerBeamsModuleLogic
   vtkSlicerPlanarImageModuleLogic
+  vtkSlicerRoomsEyeViewModuleLogic
   vtkSlicerMarkupsModuleMRML
   vtkSlicerRtCommon
   vtkPlmCommon

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -1655,10 +1655,9 @@ vtkMRMLLinearTransformNode* vtkSlicerDrrImageComputationLogic::UpdateImageTransf
   }
 
   vtkNew<vtkSlicerIECTransformLogic> iecLogic;
-  iecLogic->SetMRMLScene(scene);
 
   // Update transforms in IEC logic from beam node parameters
-  iecLogic->UpdateIECTransformsFromBeam(beamNode);
+  BeamsLogic->UpdateIECTransformsFromBeam(beamNode);
   // (a BUG?) For RT Image correct orientation PatientSupport -> Fixed Reference MUST have a negative sign
   iecLogic->UpdatePatientSupportRotationToFixedReferenceTransform(-1. * beamNode->GetCouchAngle());
 
@@ -1667,7 +1666,7 @@ vtkMRMLLinearTransformNode* vtkSlicerDrrImageComputationLogic::UpdateImageTransf
   // Gantry -> FixedReference -> PatientSupport -> TableTopEccentricRotation -> TableTop -> Patient -> RAS
   using IEC = vtkSlicerIECTransformLogic::CoordinateSystemIdentifier;
   vtkNew<vtkGeneralTransform> generalTransform;
-  if (iecLogic->GetTransformBetween( IEC::Gantry, IEC::RAS, generalTransform))
+  if (REVLogic->GetTransformNodeBetween( IEC::Gantry, IEC::RAS, generalTransform))
   {
     // Convert general transform to linear
     // This call also makes hard copy of the transform so that it doesn't change when other beam transforms change
@@ -1699,10 +1698,9 @@ bool vtkSlicerDrrImageComputationLogic::GetRtImageTransformMatrixFromBeam(vtkMRM
   }
 
   vtkNew<vtkSlicerIECTransformLogic> iecLogic;
-  iecLogic->SetMRMLScene(scene);
 
   // Update transforms in IEC logic from beam node parameters
-  iecLogic->UpdateIECTransformsFromBeam(beamNode);
+  BeamsLogic->UpdateIECTransformsFromBeam(beamNode);
   // (a BUG?) For RT Image correct orientation PatientSupport -> Fixed Reference MUST have a negative sign
   iecLogic->UpdatePatientSupportRotationToFixedReferenceTransform(-1. * beamNode->GetCouchAngle());
 
@@ -1711,7 +1709,7 @@ bool vtkSlicerDrrImageComputationLogic::GetRtImageTransformMatrixFromBeam(vtkMRM
   // Gantry -> FixedReference -> PatientSupport -> TableTopEccentricRotation -> TableTop -> Patient -> RAS
   using IEC = vtkSlicerIECTransformLogic::CoordinateSystemIdentifier;
   vtkNew<vtkGeneralTransform> generalTransform;
-  if (iecLogic->GetTransformBetween( IEC::Gantry, IEC::RAS, generalTransform))
+  if (REVLogic->GetTransformNodeBetween( IEC::Gantry, IEC::RAS, generalTransform))
   {
     // Convert general transform to linear
     // This call also makes hard copy of the transform so that it doesn't change when other beam transforms change

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -1677,7 +1677,7 @@ vtkMRMLLinearTransformNode* vtkSlicerDrrImageComputationLogic::UpdateImageTransf
   // Gantry -> FixedReference -> PatientSupport -> TableTopEccentricRotation -> TableTop -> Patient -> RAS
   using IEC = vtkSlicerIECTransformLogic::CoordinateSystemIdentifier;
   vtkNew<vtkGeneralTransform> generalTransform;
-  if (iecLogic->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform))
+  if (iecLogic->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform, true))
   {
     // Convert general transform to linear
     // This call also makes hard copy of the transform so that it doesn't change when other beam transforms change
@@ -1727,7 +1727,7 @@ bool vtkSlicerDrrImageComputationLogic::GetRtImageTransformMatrixFromBeam(vtkMRM
   // Gantry -> FixedReference -> PatientSupport -> TableTopEccentricRotation -> TableTop -> Patient -> RAS
   using IEC = vtkSlicerIECTransformLogic::CoordinateSystemIdentifier;
   vtkNew<vtkGeneralTransform> generalTransform;
-  if (iecLogic->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform))
+  if (iecLogic->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform, true))
   {
     // Convert general transform to linear
     // This call also makes hard copy of the transform so that it doesn't change when other beam transforms change

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
@@ -33,6 +33,7 @@
 #include <cstdlib>
 
 #include "vtkSlicerDrrImageComputationModuleLogicExport.h"
+#include <vtkSlicerRoomsEyeViewModuleLogic.h>
 
 class vtkMRMLVolumeNode;
 class vtkMRMLScalarVolumeNode;
@@ -198,6 +199,8 @@ private:
   vtkSlicerCLIModuleLogic* PlastimatchDRRComputationLogic;
   /// Beams logic instance
   vtkSlicerBeamsModuleLogic* BeamsLogic;
+  /// Rooms eye view logic instance
+  vtkSlicerRoomsEyeViewModuleLogic* REVLogic;
 };
 
 #endif

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.h
@@ -79,12 +79,8 @@ public:
   /// Show/hide markups
   void ShowMarkupsNodes(bool toggled = false);
 
-  /// Set Planar Image module logic
-  void SetPlanarImageLogic(vtkSlicerPlanarImageModuleLogic* planarImageLogic);
   /// Set Plastimatch DRR CLI module logic
   void SetDRRComputationLogic(vtkSlicerCLIModuleLogic* plastimatchDrrLogic);
-  /// Set Beams module logic
-  void SetBeamsLogic(vtkSlicerBeamsModuleLogic* beamsLogic);
 
   /// Compute DRR image
   /// \param parameterNode - parameters of DRR image computation
@@ -199,8 +195,6 @@ private:
   vtkSlicerCLIModuleLogic* PlastimatchDRRComputationLogic;
   /// Beams logic instance
   vtkSlicerBeamsModuleLogic* BeamsLogic;
-  /// Rooms eye view logic instance
-  vtkSlicerRoomsEyeViewModuleLogic* REVLogic;
 };
 
 #endif

--- a/DrrImageComputation/qSlicerDrrImageComputationModule.cxx
+++ b/DrrImageComputation/qSlicerDrrImageComputationModule.cxx
@@ -113,18 +113,6 @@ void qSlicerDrrImageComputationModule::setup()
 
   vtkSlicerDrrImageComputationLogic* drrImageComputationLogic = vtkSlicerDrrImageComputationLogic::SafeDownCast(this->logic());
 
-  // Set planar image logic to the logic
-  qSlicerAbstractCoreModule* planarImageModule = qSlicerCoreApplication::application()->moduleManager()->module("PlanarImage");
-  if (planarImageModule && drrImageComputationLogic)
-  {
-    vtkSlicerPlanarImageModuleLogic* planarImageLogic = vtkSlicerPlanarImageModuleLogic::SafeDownCast(planarImageModule->logic());
-    drrImageComputationLogic->SetPlanarImageLogic(planarImageLogic);
-  }
-  else
-  {
-    qCritical() << Q_FUNC_INFO << ": Planar Image module is not found";
-  }
-
   // Set plastimatch DRR computation logic to the logic
   qSlicerAbstractCoreModule* plastimatchDrrModule = qSlicerCoreApplication::application()->moduleManager()->module("plastimatch_slicer_drr");
   if (plastimatchDrrModule && drrImageComputationLogic)
@@ -135,18 +123,6 @@ void qSlicerDrrImageComputationModule::setup()
   else
   {
     qCritical() << Q_FUNC_INFO << ": Plastimatch DRR module is not found";
-  }
-
-  // Set beams logic to the logic
-  qSlicerAbstractCoreModule* beamsModule = qSlicerCoreApplication::application()->moduleManager()->module("Beams");
-  if (beamsModule && drrImageComputationLogic)
-  {
-    vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(beamsModule->logic());
-    drrImageComputationLogic->SetBeamsLogic(beamsLogic);
-  }
-  else
-  {
-    qCritical() << Q_FUNC_INFO << ": Beams module is not found";
   }
 }
 

--- a/RoomsEyeView/CMakeLists.txt
+++ b/RoomsEyeView/CMakeLists.txt
@@ -49,6 +49,7 @@ set(MODULE_TARGET_LIBRARIES
   qSlicerSegmentationsModuleWidgets
   qSlicerSubjectHierarchyModuleWidgets
   vtkSlicerBeamsModuleMRML
+  vtkSlicerBeamsModuleLogic
   qSlicerBeamsModuleWidgets
   )
 

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
@@ -80,11 +80,6 @@ vtkMRMLRoomsEyeViewNode::vtkMRMLRoomsEyeViewNode()
   , VerticalTableTopDisplacement(0.0)
   , LongitudinalTableTopDisplacement(0.0)
   , LateralTableTopDisplacement(0.0)
-  , AdditionalModelVerticalDisplacement(0.0)
-  , AdditionalModelLongitudinalDisplacement(0.0)
-  , AdditionalModelLateralDisplacement(0.0)
-  , ApplicatorHolderVisibility(0)
-  , ElectronApplicatorVisibility(0)
 {
   this->SetSingletonTag("IEC");
 }
@@ -111,13 +106,8 @@ void vtkMRMLRoomsEyeViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(VerticalTableTopDisplacement, VerticalTableTopDisplacement);
   vtkMRMLWriteXMLFloatMacro(LongitudinalTableTopDisplacement, LongitudinalTableTopDisplacement);
   vtkMRMLWriteXMLFloatMacro(LateralTableTopDisplacement, LateralTableTopDisplacement);
-  vtkMRMLWriteXMLFloatMacro(AdditionalModelVerticalDisplacement, AdditionalModelVerticalDisplacement);
-  vtkMRMLWriteXMLFloatMacro(AdditionalModelLongitudinalDisplacement, AdditionalModelLongitudinalDisplacement);
-  vtkMRMLWriteXMLFloatMacro(AdditionalModelLateralDisplacement, AdditionalModelLateralDisplacement);
   vtkMRMLWriteXMLStringMacro(PatientBodySegmentID, PatientBodySegmentID);
   vtkMRMLWriteXMLStringMacro(TreatmentMachineDescriptorFilePath, TreatmentMachineDescriptorFilePath);
-  vtkMRMLWriteXMLIntMacro(ApplicatorHolderVisibility, ApplicatorHolderVisibility);
-  vtkMRMLWriteXMLIntMacro(ElectronApplicatorVisibility, ElectronApplicatorVisibility);
   vtkMRMLWriteXMLEndMacro(); 
 }
 
@@ -136,13 +126,8 @@ void vtkMRMLRoomsEyeViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(VerticalTableTopDisplacement, VerticalTableTopDisplacement);
   vtkMRMLReadXMLFloatMacro(LongitudinalTableTopDisplacement, LongitudinalTableTopDisplacement);
   vtkMRMLReadXMLFloatMacro(LateralTableTopDisplacement, LateralTableTopDisplacement);
-  vtkMRMLReadXMLFloatMacro(AdditionalModelVerticalDisplacement, AdditionalModelVerticalDisplacement);
-  vtkMRMLReadXMLFloatMacro(AdditionalModelLongitudinalDisplacement, AdditionalModelLongitudinalDisplacement);
-  vtkMRMLReadXMLFloatMacro(AdditionalModelLateralDisplacement, AdditionalModelLateralDisplacement);
   vtkMRMLReadXMLStringMacro(PatientBodySegmentID, PatientBodySegmentID);
   vtkMRMLReadXMLStringMacro(TreatmentMachineDescriptorFilePath, TreatmentMachineDescriptorFilePath);
-  vtkMRMLReadXMLIntMacro(ApplicatorHolderVisibility, ApplicatorHolderVisibility);
-  vtkMRMLReadXMLIntMacro(ElectronApplicatorVisibility, ElectronApplicatorVisibility);
   vtkMRMLReadXMLEndMacro(); 
 
   this->EndModify(disabledModify);
@@ -168,13 +153,8 @@ void vtkMRMLRoomsEyeViewNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyFloatMacro(VerticalTableTopDisplacement);
   vtkMRMLCopyFloatMacro(LongitudinalTableTopDisplacement);
   vtkMRMLCopyFloatMacro(LateralTableTopDisplacement);
-  vtkMRMLCopyFloatMacro(AdditionalModelVerticalDisplacement);
-  vtkMRMLCopyFloatMacro(AdditionalModelLongitudinalDisplacement);
-  vtkMRMLCopyFloatMacro(AdditionalModelLateralDisplacement);
   vtkMRMLCopyStringMacro(PatientBodySegmentID);
   vtkMRMLCopyStringMacro(TreatmentMachineDescriptorFilePath);
-  vtkMRMLCopyIntMacro(ApplicatorHolderVisibility);
-  vtkMRMLCopyIntMacro(ElectronApplicatorVisibility);
   vtkMRMLCopyEndMacro(); 
 
   this->EndModify(disabledModify);
@@ -194,13 +174,8 @@ void vtkMRMLRoomsEyeViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(VerticalTableTopDisplacement);
   vtkMRMLPrintFloatMacro(LongitudinalTableTopDisplacement);
   vtkMRMLPrintFloatMacro(LateralTableTopDisplacement);
-  vtkMRMLPrintFloatMacro(AdditionalModelVerticalDisplacement);
-  vtkMRMLPrintFloatMacro(AdditionalModelLongitudinalDisplacement);
-  vtkMRMLPrintFloatMacro(AdditionalModelLateralDisplacement);
   vtkMRMLPrintStringMacro(PatientBodySegmentID);
   vtkMRMLPrintStringMacro(TreatmentMachineDescriptorFilePath);
-  vtkMRMLPrintIntMacro(ApplicatorHolderVisibility);
-  vtkMRMLPrintIntMacro(ElectronApplicatorVisibility);
   vtkMRMLPrintEndMacro(); 
 }
 
@@ -214,10 +189,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetGantryToFixedReferenceTr
 void vtkMRMLRoomsEyeViewNode::SetAndObserveGantryToFixedReferenceTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(GANTRY_TO_FIXEDREFERENCE_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -232,10 +207,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetCollimatorToFixedReferen
 void vtkMRMLRoomsEyeViewNode::SetAndObserveCollimatorToFixedReferenceIsocenterTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(COLLIMATOR_TO_FIXEDREFERENCEISOCENTER_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -250,10 +225,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetFixedReferenceIsocenterT
 void vtkMRMLRoomsEyeViewNode::SetAndObserveFixedReferenceIsocenterToCollimatorRotatedTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(FIXEDREFERENCEISOCENTER_TO_COLLIMATORROTATED_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -268,10 +243,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetCollimatorToGantryTransf
 void vtkMRMLRoomsEyeViewNode::SetAndObserveCollimatorToGantryTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(COLLIMATOR_TO_GANTRY_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -285,10 +260,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetAdditionalCollimatorDevi
 void vtkMRMLRoomsEyeViewNode::SetAndObserveAdditionalCollimatorDevicesToCollimatorTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(ADDITIONALCOLLIMATORDEVICES_TO_COLLIMATOR_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -303,10 +278,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetLeftImagingPanelToLeftIm
 void vtkMRMLRoomsEyeViewNode::SetAndObserveLeftImagingPanelToLeftImagingPanelFixedReferenceIsocenterTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(LEFTIMAGINGPANEL_TO_LEFTIMAGINGPANELFIXEDREFERENCEISOCENTER_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -321,10 +296,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetLeftImagingPanelFixedRef
 void vtkMRMLRoomsEyeViewNode::SetAndObserveLeftImagingPanelFixedReferenceIsocenterToLeftImagingPanelRotatedTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(LEFTIMAGINGPANELFIXEDREFERENCEISOCENTER_TO_LEFTIMAGINGPANELROTATED_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -339,10 +314,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetLeftImagingPanelRotatedT
 void vtkMRMLRoomsEyeViewNode::SetAndObserveLeftImagingPanelRotatedToGantryTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(LEFTIMAGINGPANELROTATED_TO_GANTRY_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -356,10 +331,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetLeftImagingPanelTranslat
 void vtkMRMLRoomsEyeViewNode::SetAndObserveLeftImagingPanelTranslationTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(LEFTIMAGINGPANELTRANSLATION_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -374,10 +349,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetRightImagingPanelToRight
 void vtkMRMLRoomsEyeViewNode::SetAndObserveRightImagingPanelToRightImagingPanelFixedReferenceIsocenterTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(RIGHTIMAGINGPANEL_TO_RIGHTIMAGINGPANELFIXEDREFERENCEISOCENTER_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -392,10 +367,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetRightImagingPanelFixedRe
 void vtkMRMLRoomsEyeViewNode::SetAndObserveRightImagingPanelFixedReferenceIsocenterToRightImagingPanelRotatedTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(RIGHTIMAGINGPANELFIXEDREFERENCEISOCENTER_TO_RIGHTIMAGINGPANELROTATED_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -410,10 +385,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetRightImagingPanelRotated
 void vtkMRMLRoomsEyeViewNode::SetAndObserveRightImagingPanelRotatedToGantryTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(RIGHTIMAGINGPANELROTATED_TO_GANTRY_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -428,10 +403,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetRightImagingPanelTransla
 void vtkMRMLRoomsEyeViewNode::SetAndObserveRightImagingPanelTranslationTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(RIGHTIMAGINGPANELTRANSLATION_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -446,10 +421,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetPatientSupportToFixedRef
 void vtkMRMLRoomsEyeViewNode::SetAndObservePatientSupportToFixedReferenceTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(PATIENTSUPPORT_TO_FIXEDREFERENCE_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -464,10 +439,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetPatientSupportScaledByTa
 void vtkMRMLRoomsEyeViewNode::SetAndObservePatientSupportScaledByTableTopVerticalMovementTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(PATIENTSUPPORTSCALEDBYTABLETOPVERTICALMOVEMENT_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -482,10 +457,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetPatientSupportPositiveVe
 void vtkMRMLRoomsEyeViewNode::SetAndObservePatientSupportPositiveVerticalTranslationTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(PATIENTSUPPORTPOSITIVEVERTICALTRANSLATION_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -500,10 +475,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetPatientSupportScaledTran
 void vtkMRMLRoomsEyeViewNode::SetAndObservePatientSupportScaledTranslatedToTableTopVerticalTranslationTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(PATIENTSUPPORTSCALEDTRANSLATED_TO_TABLETOPVERTICALTRANSLATION_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -518,10 +493,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetTableTopToTableTopEccent
 void vtkMRMLRoomsEyeViewNode::SetAndObserveTableTopToTableTopEccentricRotationTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(TABLETOP_TO_TABLETOPECCENTRICROTATION_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -536,10 +511,10 @@ vtkMRMLLinearTransformNode* vtkMRMLRoomsEyeViewNode::GetTableTopEccentricRotatio
 void vtkMRMLRoomsEyeViewNode::SetAndObserveTableTopEccentricRotationToPatientSupportTransformNode(vtkMRMLLinearTransformNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(TABLETOPECCENTRICROTATION_TO_PATIENTSUPPORT_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -554,10 +529,10 @@ vtkMRMLSegmentationNode* vtkMRMLRoomsEyeViewNode::GetPatientBodySegmentationNode
 void vtkMRMLRoomsEyeViewNode::SetAndObservePatientBodySegmentationNode(vtkMRMLSegmentationNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(PATIENT_BODY_SEGMENTATION_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
@@ -572,10 +547,10 @@ vtkMRMLRTBeamNode* vtkMRMLRoomsEyeViewNode::GetBeamNode()
 void vtkMRMLRoomsEyeViewNode::SetAndObserveBeamNode(vtkMRMLRTBeamNode* node)
 {
   if (node && this->Scene != node->GetScene())
-    {
+  {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
-    }
+  }
 
   this->SetNodeReferenceID(BEAM_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
@@ -157,21 +157,6 @@ public:
   vtkGetMacro(LateralTableTopDisplacement, double);
   vtkSetMacro(LateralTableTopDisplacement, double);
 
-  vtkGetMacro(AdditionalModelLongitudinalDisplacement, double);
-  vtkSetMacro(AdditionalModelLongitudinalDisplacement, double);
-
-  vtkGetMacro(AdditionalModelVerticalDisplacement, double);
-  vtkSetMacro(AdditionalModelVerticalDisplacement, double);
-
-  vtkGetMacro(AdditionalModelLateralDisplacement, double);
-  vtkSetMacro(AdditionalModelLateralDisplacement, double);
-
-  vtkGetMacro(ApplicatorHolderVisibility, int);
-  vtkSetMacro(ApplicatorHolderVisibility, int);
-
-  vtkGetMacro(ElectronApplicatorVisibility, int);
-  vtkSetMacro(ElectronApplicatorVisibility, int);
-
 protected:
   vtkMRMLRoomsEyeViewNode();
   ~vtkMRMLRoomsEyeViewNode();

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -432,6 +432,24 @@ vtkMRMLLinearTransformNode* vtkSlicerRoomsEyeViewModuleLogic::GetTransformNodeBe
 }
 
 //---------------------------------------------------------------------------
+vtkSlicerBeamsModuleLogic* vtkSlicerRoomsEyeViewModuleLogic::GetBeamsLogic()
+{
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
+  if (beamsLogic)
+  {
+    return beamsLogic;
+  }
+
+  if (this->BeamsLogic != nullptr)
+  {
+    return this->BeamsLogic;
+  }
+
+  vtkErrorMacro("GetBeamsLogic: Beams logic cannot be accessed from the application and is not set externally either");
+  return nullptr;
+}
+
+//---------------------------------------------------------------------------
 void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
@@ -440,7 +458,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Invalid MRML scene");
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
   if (!beamsLogic)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Beams logic cannot be accessed");
@@ -682,6 +700,12 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     vtkErrorMacro("SetupTreatmentMachineModels: Invalid scene");
     return std::vector<TreatmentMachinePartType>();
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("SetupTreatmentMachineModels: Beams logic cannot be accessed");
+    return std::vector<TreatmentMachinePartType>();
+  }
 
   std::vector<TreatmentMachinePartType> loadedParts;
   std::map<TreatmentMachinePartType, unsigned int> loadedPartsNumTriangles;
@@ -827,6 +851,12 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
   if (!scene)
   {
     vtkErrorMacro("UpdateTreatmentOrientationMarker: Invalid scene");
+    return nullptr;
+  }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateTreatmentOrientationMarker: Beams logic cannot be accessed");
     return nullptr;
   }
 
@@ -1025,10 +1055,16 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateGantryToFixedReferenceTransform(vtk
     vtkErrorMacro("UpdateGantryToFixedReferenceTransform: Invalid parameter set node");
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateGantryToFixedReferenceTransform: Beams logic cannot be accessed");
+    return;
+  }
 
   this->IECLogic->UpdateGantryToFixedReferenceTransform(parameterNode->GetGantryRotationAngle());
   vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
-  gantryToFixedReferenceTransformNode->Modified();
+  gantryToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
 }
 
 //----------------------------------------------------------------------------
@@ -1039,10 +1075,16 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateCollimatorToGantryTransform(vtkMRML
     vtkErrorMacro("UpdateCollimatorToGantryTransform: Invalid parameter set node");
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateCollimatorToGantryTransform: Beams logic cannot be accessed");
+    return;
+  }
 
   this->IECLogic->UpdateCollimatorToGantryTransform(parameterNode->GetCollimatorRotationAngle());
   vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
-  collimatorToGantryTransformNode->Modified();
+  collimatorToGantryTransformNode->Modified(); // Modified call is needed because it does not update display in app
 }
 
 //-----------------------------------------------------------------------------
@@ -1051,6 +1093,12 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateLeftImagingPanelToGantryTransform(v
   if (!parameterNode)
   {
     vtkErrorMacro("UpdateLeftImagingPanelToGantryTransform: Invalid parameter set node");
+    return;
+  }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateLeftImagingPanelToGantryTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1125,6 +1173,12 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateRightImagingPanelToGantryTransform(
   if (!parameterNode)
   {
     vtkErrorMacro("UpdateRightImagingPanelToGantryTransform: Invalid parameter set node");
+    return;
+  }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateRightImagingPanelToGantryTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1212,10 +1266,16 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportRotationToFixedRefere
     vtkErrorMacro("UpdatePatientSupportRotationToFixedReferenceTransform: Invalid parameter set node");
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdatePatientSupportRotationToFixedReferenceTransform: Beams logic cannot be accessed");
+    return;
+  }
 
   this->IECLogic->UpdatePatientSupportRotationToFixedReferenceTransform(parameterNode->GetPatientSupportRotationAngle());
   vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference);
-  patientSupportRotationToFixedReferenceTransformNode->Modified();
+  patientSupportRotationToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
 }
 
 //-----------------------------------------------------------------------------
@@ -1224,6 +1284,12 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportToPatientSupportRotat
   if (!parameterNode)
   {
     vtkErrorMacro("UpdatePatientSupportToPatientSupportRotationTransform: Invalid parameter set node");
+    return;
+  }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdatePatientSupportToPatientSupportRotationTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1262,7 +1328,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportToPatientSupportRotat
   vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
     this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
   patientSupportToPatientSupportRotationTransformNode->SetAndObserveTransformToParent(patientSupportScalingTransform);
-  patientSupportToPatientSupportRotationTransformNode->Modified();
+  patientSupportToPatientSupportRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
 }
 
 //-----------------------------------------------------------------------------
@@ -1279,6 +1345,12 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopToTableTopEccentricRotation
     vtkErrorMacro("UpdateTableTopToTableTopEccentricRotationTransform: Invalid parameter set node");
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("UpdateTableTopToTableTopEccentricRotationTransform: Beams logic cannot be accessed");
+    return;
+  }
 
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
     this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
@@ -1293,7 +1365,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopToTableTopEccentricRotation
   tableTopEccentricRotationToPatientSupportMatrix->SetElement(1,3, translationArray[1]);
   tableTopEccentricRotationToPatientSupportMatrix->SetElement(2,3, translationArray[2]);
   tableTopEccentricRotationToPatientSupportTransform->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix);
-  tableTopEccentricRotationToPatientSupportTransform->Modified();
+  tableTopEccentricRotationToPatientSupportTransform->Modified(); // Modified call is needed because it does not update display in app
 }
 
 //-----------------------------------------------------------------------------
@@ -1303,6 +1375,12 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
   {
     vtkErrorMacro("CheckForCollisions: Invalid parameter set node");
     return "Invalid parameters";
+  }
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("CheckForCollisions: Beams logic cannot be accessed");
+    return "No Beams module";
   }
 
   if (!parameterNode->GetCollisionDetectionEnabled())

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -417,6 +417,20 @@ void vtkSlicerRoomsEyeViewModuleLogic::SetMRMLSceneInternal(vtkMRMLScene* newSce
   this->Superclass::SetMRMLSceneInternal(newScene);
 }
 
+//-----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkSlicerRoomsEyeViewModuleLogic::GetTransformNodeBetween(
+  vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame)
+{
+  if (!this->GetMRMLScene())
+  {
+    vtkErrorMacro("GetTransformNodeBetween: Invalid MRML scene");
+    return nullptr;
+  }
+
+  return vtkMRMLLinearTransformNode::SafeDownCast(
+    this->GetMRMLScene()->GetFirstNodeByName(this->IECLogic->GetTransformNameBetween(fromFrame, toFrame).c_str()));
+}
+
 //---------------------------------------------------------------------------
 void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
 {
@@ -452,14 +466,15 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
 
   // Organize transform nodes into hierarchy based on IEC Standard 61217 (duplicate IEC logic in MRML).
   // Set and observe individual transforms from IEC logic to the MRML nodes.
-  vtkMRMLLinearTransformNode* fixedReferenceToRASTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS);
+  vtkMRMLLinearTransformNode* fixedReferenceToRASTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS);
   if (fixedReferenceToRASTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Fixed reference to RAS transform");
     return;
   }
+  fixedReferenceToRASTransformNode->SetAndObserveTransformToParent(this->IECLogic->GetElementaryTransformBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS));
 
-  vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
+  vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
   if (gantryToFixedReferenceTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Gantry to Fixed reference transform");
@@ -469,7 +484,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   gantryToFixedReferenceTransformNode->SetAndObserveTransformNodeID(fixedReferenceToRASTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
+  vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
   if (collimatorToGantryTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Collimator to Gantry transform");
@@ -479,7 +494,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   collimatorToGantryTransformNode->SetAndObserveTransformNodeID(gantryToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* wedgeFilterToCollimatorTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::WedgeFilter, vtkSlicerIECTransformLogic::Collimator);
+  vtkMRMLLinearTransformNode* wedgeFilterToCollimatorTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::WedgeFilter, vtkSlicerIECTransformLogic::Collimator);
   if (wedgeFilterToCollimatorTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Wedge filter to Collimator transform");
@@ -489,7 +504,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   wedgeFilterToCollimatorTransformNode->SetAndObserveTransformNodeID(collimatorToGantryTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* leftImagingPanelToGantryTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+  vtkMRMLLinearTransformNode* leftImagingPanelToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
   if (leftImagingPanelToGantryTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Left imaging panel to Gantry transform");
@@ -499,7 +514,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   leftImagingPanelToGantryTransformNode->SetAndObserveTransformNodeID(gantryToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* rightImagingPanelToGantryTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+  vtkMRMLLinearTransformNode* rightImagingPanelToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
   if (rightImagingPanelToGantryTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Right imaging panel to Gantry transform");
@@ -509,7 +524,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   rightImagingPanelToGantryTransformNode->SetAndObserveTransformNodeID(gantryToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* flatPanelToGantryTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
+  vtkMRMLLinearTransformNode* flatPanelToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
   if (flatPanelToGantryTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Flat panel to Gantry transform");
@@ -519,7 +534,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   flatPanelToGantryTransformNode->SetAndObserveTransformNodeID(gantryToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference);
+  vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference);
   if (patientSupportRotationToFixedReferenceTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Patient support rotation to Fixed reference transform");
@@ -529,7 +544,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   patientSupportRotationToFixedReferenceTransformNode->SetAndObserveTransformNodeID(fixedReferenceToRASTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
+  vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
   if (patientSupportToPatientSupportRotationTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Patient support to Patient support rotation transform");
@@ -539,7 +554,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   patientSupportToPatientSupportRotationTransformNode->SetAndObserveTransformNodeID(patientSupportRotationToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* tableTopEccentricRotationToPatientSupportRotationTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTopEccentricRotation, vtkSlicerIECTransformLogic::PatientSupportRotation);
+  vtkMRMLLinearTransformNode* tableTopEccentricRotationToPatientSupportRotationTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTopEccentricRotation, vtkSlicerIECTransformLogic::PatientSupportRotation);
   if (tableTopEccentricRotationToPatientSupportRotationTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Table top eccentric rotation to Patient support rotation transform");
@@ -549,7 +564,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   tableTopEccentricRotationToPatientSupportRotationTransformNode->SetAndObserveTransformNodeID(patientSupportRotationToFixedReferenceTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+  vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   if (tableTopToTableTopEccentricRotationTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Table top to Table top eccentric rotation transform");
@@ -559,7 +574,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   tableTopToTableTopEccentricRotationTransformNode->SetAndObserveTransformNodeID(tableTopEccentricRotationToPatientSupportRotationTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* patientToTableTopTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Patient, vtkSlicerIECTransformLogic::TableTop);
+  vtkMRMLLinearTransformNode* patientToTableTopTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Patient, vtkSlicerIECTransformLogic::TableTop);
   if (patientToTableTopTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access Patient to Table top transform");
@@ -569,7 +584,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
   patientToTableTopTransformNode->SetAndObserveTransformNodeID(tableTopToTableTopEccentricRotationTransformNode->GetID());
 
 
-  vtkMRMLLinearTransformNode* rasToPatientTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RAS, vtkSlicerIECTransformLogic::Patient);
+  vtkMRMLLinearTransformNode* rasToPatientTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RAS, vtkSlicerIECTransformLogic::Patient);
   if (rasToPatientTransformNode == nullptr)
   {
     vtkErrorMacro("BuildRoomsEyeViewTransformHierarchy: Failed to access RAS to Patient transform");
@@ -667,12 +682,6 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     vtkErrorMacro("SetupTreatmentMachineModels: Invalid scene");
     return std::vector<TreatmentMachinePartType>();
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("SetupTreatmentMachineModels: Beams logic cannot be accessed");
-    return std::vector<TreatmentMachinePartType>();
-  }
 
   std::vector<TreatmentMachinePartType> loadedParts;
   std::map<TreatmentMachinePartType, unsigned int> loadedPartsNumTriangles;
@@ -721,7 +730,7 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     if (partIdx == Collimator)
     {
       vtkMRMLLinearTransformNode* collimatorToGantryTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
       partModel->SetAndObserveTransformNodeID(collimatorToGantryTransformNode->GetID());
       this->CollimatorTableTopCollisionDetection->SetInputData(0, partModel->GetPolyData());
       // Patient model is set when calculating collisions, as it can be changed dynamically
@@ -730,7 +739,7 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     else if (partIdx == Gantry)
     {
       vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
       partModel->SetAndObserveTransformNodeID(gantryToFixedReferenceTransformNode->GetID());
       this->GantryTableTopCollisionDetection->SetInputData(0, partModel->GetPolyData());
       this->GantryPatientSupportCollisionDetection->SetInputData(0, partModel->GetPolyData());
@@ -740,14 +749,14 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     else if (partIdx == PatientSupport)
     {
       vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
       partModel->SetAndObserveTransformNodeID(patientSupportToPatientSupportRotationTransformNode->GetID());
       this->GantryPatientSupportCollisionDetection->SetInputData(1, partModel->GetPolyData());
     }
     else if (partIdx == TableTop)
     {
       vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
       partModel->SetAndObserveTransformNodeID(tableTopToTableTopEccentricRotationTransformNode->GetID());
       this->GantryTableTopCollisionDetection->SetInputData(1, partModel->GetPolyData());
       this->CollimatorTableTopCollisionDetection->SetInputData(1, partModel->GetPolyData());
@@ -755,25 +764,25 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
     else if (partIdx == Body)
     {
       vtkMRMLLinearTransformNode* fixedReferenceToRasTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FixedReference, vtkSlicerIECTransformLogic::RAS);
       partModel->SetAndObserveTransformNodeID(fixedReferenceToRasTransformNode->GetID());
     }
     else if (partIdx == ImagingPanelLeft)
     {
       vtkMRMLLinearTransformNode* leftImagingPanelToGantryTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
       partModel->SetAndObserveTransformNodeID(leftImagingPanelToGantryTransformNode->GetID());
     }
     else if (partIdx == ImagingPanelRight)
     {
       vtkMRMLLinearTransformNode* rightImagingPanelToGantryTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
       partModel->SetAndObserveTransformNodeID(rightImagingPanelToGantryTransformNode->GetID());
     }
     else if (partIdx == FlatPanel)
     {
       vtkMRMLLinearTransformNode* flatPanelToGantryTransformNode =
-        beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
+        this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
       partModel->SetAndObserveTransformNodeID(flatPanelToGantryTransformNode->GetID());
     }
     //TODO: ApplicatorHolder, ElectronApplicator?
@@ -820,12 +829,6 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
     vtkErrorMacro("UpdateTreatmentOrientationMarker: Invalid scene");
     return nullptr;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateTreatmentOrientationMarker: Beams logic cannot be accessed");
-    return nullptr;
-  }
 
   std::string machineType = this->Internal->GetTreatmentMachineFileNameWithoutExtension(parameterNode);
 
@@ -851,7 +854,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
   gantryModelPolyData->DeepCopy(gantryModel->GetPolyData());
 
   vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
   vtkNew<vtkTransformFilter> gantryTransformFilter;
   gantryTransformFilter->SetInputData(gantryModelPolyData);
   vtkNew<vtkGeneralTransform> gantryToFixedReferenceTransform;
@@ -867,7 +870,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
   collimatorModelPolyData->DeepCopy(collimatorModel->GetPolyData());
 
   vtkMRMLLinearTransformNode* collimatorToGantryTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
   vtkNew<vtkTransformFilter> collimatorTransformFilter;
   collimatorTransformFilter->SetInputData(collimatorModelPolyData);
   vtkNew<vtkGeneralTransform> collimatorToGantryTransform;
@@ -883,7 +886,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
   patientSupportModelPolyData->DeepCopy(patientSupportModel->GetPolyData());
 
   vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
   vtkNew<vtkTransformFilter> patientSupportTransformFilter;
   patientSupportTransformFilter->SetInputData(patientSupportModelPolyData);
   vtkNew<vtkGeneralTransform> patientSupportToPatientSupportRotationTransform;
@@ -899,7 +902,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
   tableTopModelPolyData->DeepCopy(tableTopModel->GetPolyData());
 
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkNew<vtkTransformFilter> tableTopTransformFilter;
   tableTopTransformFilter->SetInputData(tableTopModelPolyData);
   vtkNew<vtkGeneralTransform> tableTopModelTransform;
@@ -918,7 +921,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
     leftImagingPanelModelPolyData->DeepCopy(imagingPanelLeftModel->GetPolyData());
 
     vtkMRMLLinearTransformNode* leftImagingPanelToGantryTransformNode =
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+      this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
     vtkNew<vtkTransformFilter> leftImagingPanelTransformFilter;
     leftImagingPanelTransformFilter->SetInputData(leftImagingPanelModelPolyData);
     vtkNew<vtkGeneralTransform> leftImagingPanelToGantryTransform;
@@ -937,7 +940,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
     rightImagingPanelModelPolyData->DeepCopy(imagingPanelRightModel->GetPolyData());
 
     vtkMRMLLinearTransformNode* rightImagingPanelToGantryTransformNode =
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+      this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
     vtkNew<vtkTransformFilter> rightImagingPanelTransformFilter;
     rightImagingPanelTransformFilter->SetInputData(rightImagingPanelModelPolyData);
     vtkNew<vtkGeneralTransform> rightImagingPanelToGantryTransform;
@@ -956,7 +959,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::UpdateTreatmentOrientationMa
     flatPanelModelPolyData->DeepCopy(flatPanelModel->GetPolyData());
 
     vtkMRMLLinearTransformNode* flatPanelToGantryTransformNode =
-      beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
+      this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::FlatPanel, vtkSlicerIECTransformLogic::Gantry);
     vtkNew<vtkTransformFilter> flatPanelTransformFilter;
     flatPanelTransformFilter->SetInputData(flatPanelModelPolyData);
     vtkNew<vtkGeneralTransform> flatPanelToGantryTransform;
@@ -1022,15 +1025,9 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateGantryToFixedReferenceTransform(vtk
     vtkErrorMacro("UpdateGantryToFixedReferenceTransform: Invalid parameter set node");
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateGantryToFixedReferenceTransform: Beams logic cannot be accessed");
-    return;
-  }
 
   this->IECLogic->UpdateGantryToFixedReferenceTransform(parameterNode->GetGantryRotationAngle());
-  vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
+  vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
   gantryToFixedReferenceTransformNode->Modified();
 }
 
@@ -1042,15 +1039,9 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateCollimatorToGantryTransform(vtkMRML
     vtkErrorMacro("UpdateCollimatorToGantryTransform: Invalid parameter set node");
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateCollimatorToGantryTransform: Beams logic cannot be accessed");
-    return;
-  }
 
   this->IECLogic->UpdateCollimatorToGantryTransform(parameterNode->GetCollimatorRotationAngle());
-  vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
+  vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
   collimatorToGantryTransformNode->Modified();
 }
 
@@ -1060,12 +1051,6 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateLeftImagingPanelToGantryTransform(v
   if (!parameterNode)
   {
     vtkErrorMacro("UpdateLeftImagingPanelToGantryTransform: Invalid parameter set node");
-    return;
-  }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateLeftImagingPanelToGantryTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1124,7 +1109,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateLeftImagingPanelToGantryTransform(v
 
   // Assemble transform and update node
   vtkMRMLLinearTransformNode* leftImagingPanelToGantryTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::LeftImagingPanel, vtkSlicerIECTransformLogic::Gantry);
   vtkNew<vtkTransform> leftImagingPanelToGantryTransform;
   leftImagingPanelToGantryTransform->PostMultiply();
   leftImagingPanelToGantryTransform->Concatenate(leftImagingPanelToRasTransform);
@@ -1140,12 +1125,6 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateRightImagingPanelToGantryTransform(
   if (!parameterNode)
   {
     vtkErrorMacro("UpdateRightImagingPanelToGantryTransform: Invalid parameter set node");
-    return;
-  }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateRightImagingPanelToGantryTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1202,7 +1181,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateRightImagingPanelToGantryTransform(
 
   // Assemble transform and update node
   vtkMRMLLinearTransformNode* rightImagingPanelToGantryTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::RightImagingPanel, vtkSlicerIECTransformLogic::Gantry);
   vtkNew<vtkTransform> rightImagingPanelToGantryTransform;
   rightImagingPanelToGantryTransform->PostMultiply();
   rightImagingPanelToGantryTransform->Concatenate(rightImagingPanelToRasTransform);
@@ -1233,15 +1212,9 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportRotationToFixedRefere
     vtkErrorMacro("UpdatePatientSupportRotationToFixedReferenceTransform: Invalid parameter set node");
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdatePatientSupportRotationToFixedReferenceTransform: Beams logic cannot be accessed");
-    return;
-  }
 
   this->IECLogic->UpdatePatientSupportRotationToFixedReferenceTransform(parameterNode->GetPatientSupportRotationAngle());
-  vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference);
+  vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupportRotation, vtkSlicerIECTransformLogic::FixedReference);
   patientSupportRotationToFixedReferenceTransformNode->Modified();
 }
 
@@ -1251,12 +1224,6 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportToPatientSupportRotat
   if (!parameterNode)
   {
     vtkErrorMacro("UpdatePatientSupportToPatientSupportRotationTransform: Invalid parameter set node");
-    return;
-  }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdatePatientSupportToPatientSupportRotationTransform: Beams logic cannot be accessed");
     return;
   }
 
@@ -1293,7 +1260,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportToPatientSupportRotat
   patientSupportScalingTransform->Translate(patientSupportTranslationFromOrigin);
 
   vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
   patientSupportToPatientSupportRotationTransformNode->SetAndObserveTransformToParent(patientSupportScalingTransform);
   patientSupportToPatientSupportRotationTransformNode->Modified();
 }
@@ -1312,15 +1279,9 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopToTableTopEccentricRotation
     vtkErrorMacro("UpdateTableTopToTableTopEccentricRotationTransform: Invalid parameter set node");
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("UpdateTableTopToTableTopEccentricRotationTransform: Beams logic cannot be accessed");
-    return;
-  }
 
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
   vtkTransform* tableTopEccentricRotationToPatientSupportTransform = vtkTransform::SafeDownCast(
     tableTopToTableTopEccentricRotationTransformNode->GetTransformToParent() );
 
@@ -1343,12 +1304,6 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
     vtkErrorMacro("CheckForCollisions: Invalid parameter set node");
     return "Invalid parameters";
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(this->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    vtkErrorMacro("CheckForCollisions: Beams logic cannot be accessed");
-    return "No Beams module";
-  }
 
   if (!parameterNode->GetCollisionDetectionEnabled())
   {
@@ -1359,13 +1314,13 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
 
   // Get transforms used in the collision detection filters
   vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Gantry, vtkSlicerIECTransformLogic::FixedReference);
   vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::PatientSupport, vtkSlicerIECTransformLogic::PatientSupportRotation);
   vtkMRMLLinearTransformNode* collimatorToGantryTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry);
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
-    beamsLogic->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
+    this->GetTransformNodeBetween(vtkSlicerIECTransformLogic::TableTop, vtkSlicerIECTransformLogic::TableTopEccentricRotation);
 
   if ( !gantryToFixedReferenceTransformNode || !patientSupportToPatientSupportRotationTransformNode
     || !collimatorToGantryTransformNode || !tableTopToTableTopEccentricRotationTransformNode )

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -580,7 +580,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
 
 
   // Make sure the fixed reference to RAS is correct
-  beamsLogic->UpdateRASRelatedTransforms();
+  beamsLogic->UpdateRASRelatedTransforms(this->IECLogic);
 }
 
 //----------------------------------------------------------------------------

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -123,19 +123,6 @@ public:
   /// \return string indicating whether collision occurred
   std::string CheckForCollisions(vtkMRMLRoomsEyeViewNode* parameterNode);
 
-// Additional device related methods
-public:
-  /// Load basic additional devices (deployed with SlicerRT)
-  void LoadBasicCollimatorMountedDevices();
-  /// Set up the IEC transforms and model properties on the basic additional device models
-  void SetupBasicCollimatorMountedDeviceModels();
-
-  ///TODO:
-  void UpdateAdditionalCollimatorDevicesToCollimatorTransforms(vtkMRMLRoomsEyeViewNode* parameterNode);
-
-  ///TODO:
-  void UpdateAdditionalDevicesVisibility(vtkMRMLRoomsEyeViewNode* parameterNode);
-
 // Get treatment machine properties from descriptor file
 public:
   /// Get part name for part type in the currently loaded treatment machine description
@@ -164,19 +151,17 @@ public:
   vtkGetObjectMacro(GantryPatientSupportCollisionDetection, vtkCollisionDetectionFilter);
   vtkGetObjectMacro(CollimatorPatientCollisionDetection, vtkCollisionDetectionFilter);
   vtkGetObjectMacro(CollimatorTableTopCollisionDetection, vtkCollisionDetectionFilter);
-  vtkGetObjectMacro(AdditionalModelsTableTopCollisionDetection, vtkCollisionDetectionFilter);
-  vtkGetObjectMacro(AdditionalModelsPatientSupportCollisionDetection, vtkCollisionDetectionFilter);
 
 public:
-  /// Get transform from one coordinate frame to another
-  /// @param fromFrame - start transformation from frame
-  /// @param toFrame - proceed transformation to frame
-  /// @param outputTransform - General (linear) transform matrix fromFrame -> toFrame. Matrix is correct if return flag is true.  
-  /// @param transformForBeam - calculate dynamic transformation for beam model or other models
-  /// (e.g. transformation from Patient RAS frame to Collimation frame: RAS -> Patient -> TableTop -> Eccentric -> Patient Support -> Fixed reference -> Gantry -> Collimator)  //TODO: Deprecated
-  /// \return Success flag (false on any error)
-  bool GetTransformNodeBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
-    vtkGeneralTransform* outputTransform, bool transformForBeam = true);
+  ///// Get transform from one coordinate frame to another
+  ///// @param fromFrame - start transformation from frame
+  ///// @param toFrame - proceed transformation to frame
+  ///// @param outputTransform - General (linear) transform matrix fromFrame -> toFrame. Matrix is correct if return flag is true.  
+  ///// @param transformForBeam - calculate dynamic transformation for beam model or other models
+  ///// (e.g. transformation from Patient RAS frame to Collimation frame: RAS -> Patient -> TableTop -> Eccentric -> Patient Support -> Fixed reference -> Gantry -> Collimator)  //TODO: Deprecated
+  ///// \return Success flag (false on any error)
+  //bool GetTransformNodeBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
+  //  vtkGeneralTransform* outputTransform, bool transformForBeam = true);
 
 protected:
   /// Get patient body closed surface poly data from segmentation node and segment selection in the parameter node
@@ -191,18 +176,6 @@ protected:
 
   vtkCollisionDetectionFilter* CollimatorPatientCollisionDetection;
   vtkCollisionDetectionFilter* CollimatorTableTopCollisionDetection;
-
-  vtkCollisionDetectionFilter* AdditionalModelsTableTopCollisionDetection;
-  vtkCollisionDetectionFilter* AdditionalModelsPatientSupportCollisionDetection;
-
-protected:
-  /// @brief Get coordinate system identifiers from frame system up to root system
-  /// Root system = FixedReference system, see IEC 61217:2011 hierarchy
-  bool GetPathToRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path);
-
-  /// @brief Get coordinate system identifiers from root system down to frame system
-  /// Root system = FixedReference system, see IEC 61217:2011 hierarchy
-  bool GetPathFromRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path);
 
 protected:
   vtkSlicerRoomsEyeViewModuleLogic();

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -44,8 +44,6 @@ class vtkVector3d;
 
 class vtkMRMLRoomsEyeViewNode;
 class vtkMRMLModelNode;
-class vtkSlicerIECTransformLogic;
-class vtkSlicerBeamsModuleLogic;
 
 /// \ingroup SlicerRt_QtModules_RoomsEyeView
 class VTK_SLICER_ROOMSEYEVIEW_LOGIC_EXPORT vtkSlicerRoomsEyeViewModuleLogic : public vtkSlicerModuleLogic
@@ -146,6 +144,9 @@ public:
 
   vtkGetObjectMacro(IECLogic, vtkSlicerIECTransformLogic);
 
+  /// Possibility to set Beams logic externally. This allows automated tests to run, when we do not have the whole application
+  vtkSetObjectMacro(BeamsLogic, vtkSlicerBeamsModuleLogic);
+
   vtkGetObjectMacro(GantryPatientCollisionDetection, vtkCollisionDetectionFilter);
   vtkGetObjectMacro(GantryTableTopCollisionDetection, vtkCollisionDetectionFilter);
   vtkGetObjectMacro(GantryPatientSupportCollisionDetection, vtkCollisionDetectionFilter);
@@ -165,8 +166,12 @@ protected:
   /// Get patient body closed surface poly data from segmentation node and segment selection in the parameter node
   bool GetPatientBodyPolyData(vtkMRMLRoomsEyeViewNode* parameterNode, vtkPolyData* patientBodyPolyData);
 
+  /// Get Beams logic from the application if possible, otherwise return the externally set Beams logic (e.g. when running test)
+  vtkSlicerBeamsModuleLogic* GetBeamsLogic();
+
 protected:
   vtkSlicerIECTransformLogic* IECLogic;
+  vtkSlicerBeamsModuleLogic* BeamsLogic{nullptr};
 
   vtkCollisionDetectionFilter* GantryPatientCollisionDetection;
   vtkCollisionDetectionFilter* GantryTableTopCollisionDetection;

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -153,15 +153,13 @@ public:
   vtkGetObjectMacro(CollimatorTableTopCollisionDetection, vtkCollisionDetectionFilter);
 
 public:
-  ///// Get transform from one coordinate frame to another
-  ///// @param fromFrame - start transformation from frame
-  ///// @param toFrame - proceed transformation to frame
-  ///// @param outputTransform - General (linear) transform matrix fromFrame -> toFrame. Matrix is correct if return flag is true.  
-  ///// @param transformForBeam - calculate dynamic transformation for beam model or other models
-  ///// (e.g. transformation from Patient RAS frame to Collimation frame: RAS -> Patient -> TableTop -> Eccentric -> Patient Support -> Fixed reference -> Gantry -> Collimator)  //TODO: Deprecated
-  ///// \return Success flag (false on any error)
-  //bool GetTransformNodeBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
-  //  vtkGeneralTransform* outputTransform, bool transformForBeam = true);
+  /// Get transform node between two coordinate systems is exists
+  /// \param fromFrame - start transformation from frame
+  /// \param toFrame - proceed transformation to frame
+  /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
+  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
+  vtkMRMLLinearTransformNode* GetTransformNodeBetween(
+    vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame);
 
 protected:
   /// Get patient body closed surface poly data from segmentation node and segment selection in the parameter node

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -34,6 +34,8 @@
 
 // Slicer includes
 #include <vtkSlicerModuleLogic.h>
+#include <vtkSlicerIECTransformLogic.h>
+#include <vtkSlicerBeamsModuleLogic.h>
 
 class vtkCollisionDetectionFilter;
 class vtkMatrix4x4;
@@ -43,10 +45,10 @@ class vtkVector3d;
 class vtkMRMLRoomsEyeViewNode;
 class vtkMRMLModelNode;
 class vtkSlicerIECTransformLogic;
+class vtkSlicerBeamsModuleLogic;
 
 /// \ingroup SlicerRt_QtModules_RoomsEyeView
-class VTK_SLICER_ROOMSEYEVIEW_LOGIC_EXPORT vtkSlicerRoomsEyeViewModuleLogic :
-  public vtkSlicerModuleLogic
+class VTK_SLICER_ROOMSEYEVIEW_LOGIC_EXPORT vtkSlicerRoomsEyeViewModuleLogic : public vtkSlicerModuleLogic
 {
 public:
   /// Treatment machine part types
@@ -165,6 +167,17 @@ public:
   vtkGetObjectMacro(AdditionalModelsTableTopCollisionDetection, vtkCollisionDetectionFilter);
   vtkGetObjectMacro(AdditionalModelsPatientSupportCollisionDetection, vtkCollisionDetectionFilter);
 
+public:
+  /// Get transform from one coordinate frame to another
+  /// @param fromFrame - start transformation from frame
+  /// @param toFrame - proceed transformation to frame
+  /// @param outputTransform - General (linear) transform matrix fromFrame -> toFrame. Matrix is correct if return flag is true.  
+  /// @param transformForBeam - calculate dynamic transformation for beam model or other models
+  /// (e.g. transformation from Patient RAS frame to Collimation frame: RAS -> Patient -> TableTop -> Eccentric -> Patient Support -> Fixed reference -> Gantry -> Collimator)  //TODO: Deprecated
+  /// \return Success flag (false on any error)
+  bool GetTransformNodeBetween(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkSlicerIECTransformLogic::CoordinateSystemIdentifier toFrame,
+    vtkGeneralTransform* outputTransform, bool transformForBeam = true);
+
 protected:
   /// Get patient body closed surface poly data from segmentation node and segment selection in the parameter node
   bool GetPatientBodyPolyData(vtkMRMLRoomsEyeViewNode* parameterNode, vtkPolyData* patientBodyPolyData);
@@ -181,6 +194,15 @@ protected:
 
   vtkCollisionDetectionFilter* AdditionalModelsTableTopCollisionDetection;
   vtkCollisionDetectionFilter* AdditionalModelsPatientSupportCollisionDetection;
+
+protected:
+  /// @brief Get coordinate system identifiers from frame system up to root system
+  /// Root system = FixedReference system, see IEC 61217:2011 hierarchy
+  bool GetPathToRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path);
+
+  /// @brief Get coordinate system identifiers from root system down to frame system
+  /// Root system = FixedReference system, see IEC 61217:2011 hierarchy
+  bool GetPathFromRoot(vtkSlicerIECTransformLogic::CoordinateSystemIdentifier frame, vtkSlicerIECTransformLogic::CoordinateSystemsList& path);
 
 protected:
   vtkSlicerRoomsEyeViewModuleLogic();

--- a/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
+++ b/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>379</width>
-    <height>538</height>
+    <width>306</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,29 +32,6 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <item row="8" column="0">
-    <widget class="QPushButton" name="BeamsEyeViewButton">
-     <property name="text">
-      <string>Beam's eye view</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="6" column="0">
     <widget class="ctkCollapsibleButton" name="TransformsCollapsibleButton">
      <property name="text">
@@ -234,129 +211,6 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="ctkCollapsibleButton" name="AdditionalTreatmentModelsCollapsibleButton">
-     <property name="text">
-      <string>Additional device models</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <property name="spacing">
-       <number>4</number>
-      </property>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Visibility:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="ApplicatorHolderCheckBox">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Applicator holder</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="ElectronApplicatorCheckBox">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Electron applicator</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="BrainLabSRSCheckBox">
-          <property name="text">
-           <string>BrainLab SRS frame</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_4"/>
-      </item>
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QPushButton" name="LoadBasicCollimatorMountedDeviceButton">
-          <property name="text">
-           <string>Load basic collimator-mounted devices</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="LoadCustomCollimatorMountedDeviceButton">
-          <property name="text">
-           <string>Load custom collimator-mounted device</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <layout class="QGridLayout" name="gridLayout_9">
-        <property name="spacing">
-         <number>4</number>
-        </property>
-        <item row="1" column="0">
-         <widget class="QLabel" name="AdditionalModelsLongitudinalTranslationLabel">
-          <property name="text">
-           <string>Longitudinal translation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="ctkSliderWidget" name="VerticalTranslationSliderWidget"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="AdditionalModelsVerticalTranslationLabel">
-          <property name="text">
-           <string>Vertical translation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="AdditionalModelsLateralTranslationLabel">
-          <property name="text">
-           <string>Lateral translation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="ctkSliderWidget" name="LongitudinalTranslationSliderWidget"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="ctkSliderWidget" name="LateralTranslationSliderWidget"/>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="5" column="0">
     <widget class="ctkCollapsibleButton" name="CollisionDetectionCollapsibleButton">
      <property name="text">
@@ -416,6 +270,29 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0">
+    <widget class="QPushButton" name="BeamsEyeViewButton">
+     <property name="text">
+      <string>Beam's eye view</string>
+     </property>
     </widget>
    </item>
    <item row="0" column="0">

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -266,9 +266,6 @@ void qSlicerRoomsEyeViewModuleWidget::setParameterNode(vtkMRMLNode *node)
     {
       paramNode->SetPatientBodySegmentID(d->SegmentSelectorWidget_PatientBody->currentSegmentID().toUtf8().constData());
     }
-
-    paramNode->SetApplicatorHolderVisibility(0);
-    paramNode->SetElectronApplicatorVisibility(0);
   }
 
   this->updateWidgetFromMRML();
@@ -299,15 +296,10 @@ void qSlicerRoomsEyeViewModuleWidget::updateWidgetFromMRML()
     d->GantryRotationSlider->setValue(paramNode->GetGantryRotationAngle());
     d->CollimatorRotationSlider->setValue(paramNode->GetCollimatorRotationAngle());
     d->PatientSupportRotationSlider->setValue(paramNode->GetPatientSupportRotationAngle());
-    d->ImagingPanelMovementSlider->setValue(paramNode->GetImagingPanelMovement());
     d->VerticalTableTopDisplacementSlider->setValue(paramNode->GetVerticalTableTopDisplacement());
-    d->LateralTableTopDisplacementSlider->setValue(paramNode->GetLateralTableTopDisplacement());
     d->LongitudinalTableTopDisplacementSlider->setValue(paramNode->GetLongitudinalTableTopDisplacement());
-    d->VerticalTranslationSliderWidget->setValue(paramNode->GetAdditionalModelVerticalDisplacement());
-    d->LongitudinalTranslationSliderWidget->setValue(paramNode->GetAdditionalModelLongitudinalDisplacement());
-    d->LateralTranslationSliderWidget->setValue(paramNode->GetAdditionalModelLateralDisplacement());
-    d->ApplicatorHolderCheckBox->setChecked(paramNode->GetApplicatorHolderVisibility());
-    d->ElectronApplicatorCheckBox->setChecked(paramNode->GetElectronApplicatorVisibility());
+    d->LateralTableTopDisplacementSlider->setValue(paramNode->GetLateralTableTopDisplacement());
+    d->ImagingPanelMovementSlider->setValue(paramNode->GetImagingPanelMovement());
   }
 }
 
@@ -343,17 +335,6 @@ void qSlicerRoomsEyeViewModuleWidget::setup()
   connect(d->LongitudinalTableTopDisplacementSlider, SIGNAL(valueChanged(double)), this, SLOT(onLongitudinalTableTopDisplacementSliderValueChanged(double)));
   connect(d->LateralTableTopDisplacementSlider, SIGNAL(valueChanged(double)), this, SLOT(onLateralTableTopDisplacementSliderValueChanged(double)));
 
-  // Additional devices
-  connect(d->LoadBasicCollimatorMountedDeviceButton, SIGNAL(clicked()), this, SLOT(onLoadBasicCollimatorMountedDeviceButtonClicked()));
-  connect(d->LoadCustomCollimatorMountedDeviceButton, SIGNAL(clicked()), this, SLOT(onLoadCustomCollimatorMountedDeviceButtonClicked()));
-  //TODO:
-  //connect(d->ApplicatorHolderCheckBox, SIGNAL(stateChanged(int)), this, SLOT(onAdditionalCollimatorMountedDevicesChecked(int)));
-  //connect(d->ElectronApplicatorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(onAdditionalCollimatorMountedDevicesChecked(int)));
-  //TODO: BrainLabSRSCheckBox
-  connect(d->LateralTranslationSliderWidget, SIGNAL(valueChanged(double)), this, SLOT(onAdditionalModelLateralDisplacementSliderValueChanged(double)));
-  connect(d->LongitudinalTranslationSliderWidget, SIGNAL(valueChanged(double)), this, SLOT(onAdditionalModelLongitudinalDisplacementSliderValueChanged(double)));
-  connect(d->VerticalTranslationSliderWidget, SIGNAL(valueChanged(double)), this, SLOT(onAdditionalModelVerticalDisplacementSliderValueChanged(double)));
-  
   connect(d->BeamsEyeViewButton, SIGNAL(clicked()), this, SLOT(onBeamsEyeViewButtonClicked()));
 
   connect(d->MRMLNodeComboBox_Beam, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this, SLOT(onBeamNodeChanged(vtkMRMLNode*)));
@@ -368,9 +349,6 @@ void qSlicerRoomsEyeViewModuleWidget::setup()
   d->LongitudinalTableTopDisplacementSlider->setEnabled(false);
   d->LateralTableTopDisplacementSlider->setEnabled(false);
   d->ImagingPanelMovementSlider->setEnabled(false);
-
-  //TODO: Hide additional device models section until reinstated
-  d->AdditionalTreatmentModelsCollapsibleButton->setVisible(false);
 
   // Handle scene change event if occurs
   qvtkConnect(d->logic(), vtkCommand::ModifiedEvent, this, SLOT(onLogicModified()));
@@ -767,7 +745,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
 
   // Update IEC transform
   d->logic()->UpdatePatientSupportRotationToFixedReferenceTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
 
   // Update beam parameter
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
@@ -802,7 +780,7 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
 
   d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -829,7 +807,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -858,125 +836,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
-
-  this->checkForCollisions();
-  this->updateTreatmentOrientationMarker();
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onLoadBasicCollimatorMountedDeviceButtonClicked()
-{
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-
-  d->logic()->LoadBasicCollimatorMountedDevices();
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onLoadCustomCollimatorMountedDeviceButtonClicked()
-{
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    return;
-  }
-
-  qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
-  vtkSmartPointer<vtkCollection> loadedModelsCollection = vtkSmartPointer<vtkCollection>::New();
-  ioManager->openDialog("ModelFile", qSlicerDataDialog::Read, qSlicerIO::IOProperties(), loadedModelsCollection);
-  
-  for (int modelIndex=0; modelIndex<loadedModelsCollection->GetNumberOfItems(); ++modelIndex)
-  {
-    vtkMRMLModelNode* loadedModelNode = vtkMRMLModelNode::SafeDownCast(
-      loadedModelsCollection->GetItemAsObject(modelIndex) );
-    vtkMRMLLinearTransformNode* collimatorModelTransforms = beamsLogic->GetTransformNodeBetween(
-      vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry );
-    loadedModelNode->SetAndObserveTransformNodeID(collimatorModelTransforms->GetID());
-  }
-
-  //TODO: Add function UpdateTreatmentOrientationMarker that merges the treatment machine components into a model that can be set as orientation marker,
-  //TODO: Add new option 'Treatment room' to orientation marker choices and merged model with actual colors (surface scalars?)
-  /**qSlicerApplication* slicerApplication = qSlicerApplication::application();
-  qSlicerLayoutManager* layoutManager = slicerApplication->layoutManager();
-  qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
-  vtkMRMLViewNode* viewNode = threeDView->mrmlViewNode();
-  viewNode->SetOrientationMarkerHumanModelNodeID(this->mrmlScene()->GetFirstNodeByName("EBRTOrientationMarkerModel")->GetID());**/
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onAdditionalCollimatorMountedDevicesChecked(int state)
-{
-  
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
-  if (!paramNode || !d->ModuleWindowInitialized)
-  {
-    return;
-  }
-  paramNode->SetApplicatorHolderVisibility(state);
-  paramNode->SetElectronApplicatorVisibility(state);
-  d->logic()->UpdateAdditionalDevicesVisibility(paramNode);
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onAdditionalModelLateralDisplacementSliderValueChanged(double value)
-{
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-
-  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
-  if (!paramNode || !d->ModuleWindowInitialized)
-  {
-    return;
-  }
-
-  paramNode->DisableModifiedEventOn();
-  paramNode->SetAdditionalModelLateralDisplacement(value);
-  paramNode->DisableModifiedEventOff();
-
-  d->logic()->UpdateAdditionalCollimatorDevicesToCollimatorTransforms(paramNode);
-
-  this->checkForCollisions();
-  this->updateTreatmentOrientationMarker();
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onAdditionalModelLongitudinalDisplacementSliderValueChanged(double value)
-{
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-
-  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
-  if (!paramNode || !d->ModuleWindowInitialized)
-  {
-    return;
-  }
-
-  paramNode->DisableModifiedEventOn();
-  paramNode->SetAdditionalModelLongitudinalDisplacement(value);
-  paramNode->DisableModifiedEventOff();
-
-  d->logic()->UpdateAdditionalCollimatorDevicesToCollimatorTransforms(paramNode);
-
-  this->checkForCollisions();
-  this->updateTreatmentOrientationMarker();
-}
-//-----------------------------------------------------------------------------
-void qSlicerRoomsEyeViewModuleWidget::onAdditionalModelVerticalDisplacementSliderValueChanged(double value)
-{
-  Q_D(qSlicerRoomsEyeViewModuleWidget);
-
-  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
-  if (!paramNode || !d->ModuleWindowInitialized)
-  {
-    return;
-  }
-
-  paramNode->DisableModifiedEventOn();
-  paramNode->SetAdditionalModelVerticalDisplacement(value);
-  paramNode->DisableModifiedEventOff();
-
-  d->logic()->UpdateAdditionalCollimatorDevicesToCollimatorTransforms(paramNode);
+  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -745,7 +745,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
 
   // Update IEC transform
   d->logic()->UpdatePatientSupportRotationToFixedReferenceTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
 
   // Update beam parameter
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
@@ -780,7 +780,7 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
 
   d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -807,7 +807,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -836,7 +836,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -755,6 +755,11 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
   {
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
+  if (!beamsLogic)
+  {
+    return;
+  }
 
   paramNode->DisableModifiedEventOn();
   paramNode->SetPatientSupportRotationAngle(value);
@@ -762,7 +767,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
 
   // Update IEC transform
   d->logic()->UpdatePatientSupportRotationToFixedReferenceTransform(paramNode);
-  d->logic()->GetIECLogic()->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
 
   // Update beam parameter
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
@@ -785,6 +790,11 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
   {
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
+  if (!beamsLogic)
+  {
+    return;
+  }
 
   paramNode->DisableModifiedEventOn();
   paramNode->SetVerticalTableTopDisplacement(value);
@@ -792,7 +802,7 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
 
   d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  d->logic()->GetIECLogic()->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -808,13 +818,18 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   {
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
+  if (!beamsLogic)
+  {
+    return;
+  }
 
   paramNode->DisableModifiedEventOn();
   paramNode->SetLongitudinalTableTopDisplacement(value);
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  d->logic()->GetIECLogic()->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -832,13 +847,18 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   {
     return;
   }
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
+  if (!beamsLogic)
+  {
+    return;
+  }
 
   paramNode->DisableModifiedEventOn();
   paramNode->SetLateralTableTopDisplacement(d->LateralTableTopDisplacementSlider->value());
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  d->logic()->GetIECLogic()->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->currentPlanNode(paramNode));
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -857,6 +877,12 @@ void qSlicerRoomsEyeViewModuleWidget::onLoadCustomCollimatorMountedDeviceButtonC
 {
   Q_D(qSlicerRoomsEyeViewModuleWidget);
 
+  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
+  if (!beamsLogic)
+  {
+    return;
+  }
+
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
   vtkSmartPointer<vtkCollection> loadedModelsCollection = vtkSmartPointer<vtkCollection>::New();
   ioManager->openDialog("ModelFile", qSlicerDataDialog::Read, qSlicerIO::IOProperties(), loadedModelsCollection);
@@ -865,7 +891,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLoadCustomCollimatorMountedDeviceButtonC
   {
     vtkMRMLModelNode* loadedModelNode = vtkMRMLModelNode::SafeDownCast(
       loadedModelsCollection->GetItemAsObject(modelIndex) );
-    vtkMRMLLinearTransformNode* collimatorModelTransforms = d->logic()->GetIECLogic()->GetTransformNodeBetween(
+    vtkMRMLLinearTransformNode* collimatorModelTransforms = beamsLogic->GetTransformNodeBetween(
       vtkSlicerIECTransformLogic::Collimator, vtkSlicerIECTransformLogic::Gantry );
     loadedModelNode->SetAndObserveTransformNodeID(collimatorModelTransforms->GetID());
   }

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
@@ -69,13 +69,6 @@ protected slots:
   void onLongitudinalTableTopDisplacementSliderValueChanged(double);
   void onLateralTableTopDisplacementSliderValueChanged(double);
 
-  void onLoadBasicCollimatorMountedDeviceButtonClicked();
-  void onLoadCustomCollimatorMountedDeviceButtonClicked();
-  void onAdditionalCollimatorMountedDevicesChecked(int);
-  void onAdditionalModelLateralDisplacementSliderValueChanged(double);
-  void onAdditionalModelLongitudinalDisplacementSliderValueChanged(double);
-  void onAdditionalModelVerticalDisplacementSliderValueChanged(double);
-
   void onBeamsEyeViewButtonClicked();
   
   void onBeamNodeChanged(vtkMRMLNode*);

--- a/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
+++ b/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
@@ -378,7 +378,7 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeDiceStatistics(vtkMRML
   vtkMRMLTableNode* tableNode = parameterNode->GetDiceTableNode();
   if (tableNode)
   {
-    tableNode->SetUseColumnNameAsColumnHeader(true);
+    tableNode->SetUseColumnTitleAsColumnHeader(true);
     tableNode->RemoveAllColumns();
     vtkStringArray* header = vtkStringArray::SafeDownCast(tableNode->AddColumn());
     header->SetName("Metric name");
@@ -500,7 +500,7 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeHausdorffDistances(vtk
   vtkMRMLTableNode* tableNode = parameterNode->GetHausdorffTableNode();
   if (tableNode)
   {
-    tableNode->SetUseColumnNameAsColumnHeader(true);
+    tableNode->SetUseColumnTitleAsColumnHeader(true);
     tableNode->RemoveAllColumns();
     vtkStringArray* header = vtkStringArray::SafeDownCast(tableNode->AddColumn());
     header->SetName("Metric name");


### PR DESCRIPTION
Make it independent in order to be able to use it separately. Remove all the MRML based functions and move it to vtkSlicerBeamsModuleLogic, vtkSlicerRoomsEyeViewModuleLogic.