### PR TITLE
BUG: Fix DRR image vup and normal vectors update after recent IEC logic refactoring

### DIFF
--- a/Beams/Logic/vtkSlicerIECTransformLogic.cxx
+++ b/Beams/Logic/vtkSlicerIECTransformLogic.cxx
@@ -30,6 +30,8 @@
 
 // STD includes
 #include <array>
+#include <algorithm>
+
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerIECTransformLogic);

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -1664,20 +1664,15 @@ vtkMRMLLinearTransformNode* vtkSlicerDrrImageComputationLogic::UpdateImageTransf
       scene->GetFirstNodeByName(RTIMAGE_TRANSFORM_NODE_NAME));
   }
 
-  vtkNew<vtkSlicerIECTransformLogic> iecLogic;
-
   // Update transforms in IEC logic from beam node parameters
   beamsLogic->UpdateIECTransformsFromBeam(beamNode);
-
-  //TODO: (a BUG?) For RT Image correct orientation PatientSupport -> Fixed Reference MUST have a negative sign
-  iecLogic->UpdatePatientSupportRotationToFixedReferenceTransform(-1. * beamNode->GetCouchAngle());
 
   // Dynamic transform from Gantry to RAS
   // Transformation path:
   // Gantry -> FixedReference -> PatientSupport -> TableTopEccentricRotation -> TableTop -> Patient -> RAS
   using IEC = vtkSlicerIECTransformLogic::CoordinateSystemIdentifier;
   vtkNew<vtkGeneralTransform> generalTransform;
-  if (iecLogic->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform, true))
+  if (beamsLogic->GetIECLogic()->GetTransformBetween(IEC::Gantry, IEC::RAS, generalTransform, true))
   {
     // Convert general transform to linear
     // This call also makes hard copy of the transform so that it doesn't change when other beam transforms change


### PR DESCRIPTION
There are minor changes in logic file, where we are updating view-up and normal vectors of the imager.
Fix for PR #250.