### PR TITLE
BUG: Fix patient support rotation angle to fixed reference

### DIFF
--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
@@ -397,7 +397,9 @@ void vtkSlicerBeamsModuleLogic::UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* b
   // Set beam angles to IEC logic
   this->IECLogic->UpdateGantryToFixedReferenceTransform(beamNode->GetGantryAngle());
   this->IECLogic->UpdateCollimatorToGantryTransform(beamNode->GetCollimatorAngle());
-  this->IECLogic->UpdatePatientSupportRotationToFixedReferenceTransform(beamNode->GetCouchAngle());
+  // Set the inverse of the couch angle as now what moves is the room (treatment machine) around the patient,
+  // so the patient support table top (couch) always stays stationary in RAS.
+  this->IECLogic->UpdatePatientSupportRotationToFixedReferenceTransform(-1. * beamNode->GetCouchAngle());
 
   // Update fixed reference to RAS transform as well
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -194,10 +194,8 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
   d->SliderWidget_CollimatorAngle->setValue(d->BeamNode->GetCollimatorAngle());
   d->SliderWidget_GantryAngle->blockSignals(true);
   d->SliderWidget_GantryAngle->setValue(d->BeamNode->GetGantryAngle());
+  d->SliderWidget_CouchAngle->setValue(d->BeamNode->GetCouchAngle());
   d->SliderWidget_GantryAngle->blockSignals(false);
-  // Set the inverse of the couch angle as now what moves is the room (treatment machine) around the patient,
-  // so the patient support table top (couch) always stays stationary in RAS.
-  d->SliderWidget_CouchAngle->setValue(-d->BeamNode->GetCouchAngle());
 
   d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setMRMLScene(d->BeamNode->GetScene());
 
@@ -1002,10 +1000,7 @@ void qMRMLBeamParametersTabWidget::couchAngleChanged(double value)
   }
 
   // Do not disable modifier events as transforms need to be updated.
-
-  // Set the inverse of the couch angle as now what moves is the room (treatment machine) around the patient,
-  // so the patient support table top (couch) always stays stationary in RAS.
-  d->BeamNode->SetCouchAngle(-value);
+  d->BeamNode->SetCouchAngle(value);
 }
 
 //-----------------------------------------------------------------------------

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -809,7 +809,16 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
   if (beamNode)
   {
-    beamNode->SetCouchAngle(value);
+    // since slider range [-180, 180], then negative patient support angles must be
+    // transformed into positive one
+    if (value < 0.)
+    {
+      beamNode->SetCouchAngle(360. + value);
+    }
+    else
+    {
+      beamNode->SetCouchAngle(value);
+    }
   }
 
   this->checkForCollisions();


### PR DESCRIPTION
How to test:

1. Load [https://github.com/SlicerRt/SlicerRtData/tree/master/xio-4.64-phantom-prostate-beams-allnonzero](https://github.com/SlicerRt/SlicerRtData/tree/master/xio-4.64-phantom-prostate-beams-allnonzero) from SlicerRtData. That dataset has predefined nonzero angles of beam orientation: gantry, couch, collimator.

2. Check that dose distribution lays within beam's model borders.

3. In "Beams" module check that beam orientation parameters are as follows:
  Gantry angle = 20 deg;
  Collimator angle = 350 deg;
  Couch angle = 300 deg.

4. In "Room's Eye View" module, load Varian machine and set required parameters for the machine sliders:
  Gantry angle = 20 deg;
  Collimator angle = 350 deg;
  Patient support rotation = -60 deg. (since slider range is from -180 up to 180 deg)

5. Go back to the "Beams" module and check that beam orientation parameters are the same:
  Gantry angle = 20 deg;
  Collimator angle = 350 deg;
  Couch angle = 300 deg.