### PR TITLE
BUG: Fix plastimatch 1.10 and DCMTK 3.6.8 linking problems after updates

### DIFF
--- a/DicomRtImportExport/Logic/CMakeLists.txt
+++ b/DicomRtImportExport/Logic/CMakeLists.txt
@@ -37,7 +37,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicerIsodoseModuleLogic
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
-  ${DCMTK_LIBRARIES}
+#  ${DCMTK_LIBRARIES}
   vtkSlicerVolumesModuleLogic
   vtkSlicerBeamsModuleLogic
   vtkSlicerPlanarImageModuleLogic

--- a/DicomSroImportExport/Logic/CMakeLists.txt
+++ b/DicomSroImportExport/Logic/CMakeLists.txt
@@ -18,7 +18,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${VTK_LIBRARIES}
-  ${DCMTK_LIBRARIES}
+#  ${DCMTK_LIBRARIES}
   vtkSlicerRtCommon
   vtkSlicerDicomRtImportExportModuleLogic
   )

--- a/SuperBuild/External_Plastimatch.cmake
+++ b/SuperBuild/External_Plastimatch.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "436aebba99f2405deadec4d9186a6bee91a7bf10" # Fix to prevent compilation error after recent ITK and VTK update
+    "c2f802812ea9914894efde50fee1e99bdc98455f" # Plastimatch version 1.10
     QUIET
     )
 
@@ -105,6 +105,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DPLMLIB_CONFIG_ENABLE_REGISTER:BOOL=TRUE
       -DPLMLIB_CONFIG_ENABLE_RECONSTRUCT:BOOL=TRUE
       -DPLMLIB_CONFIG_ENABLE_DOSE:BOOL=TRUE
+      -DPLMLIB_CONFIG_ENABLE_QT:BOOL=FALSE
       ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
       ${PYTHON_VARS}
     INSTALL_COMMAND ""


### PR DESCRIPTION
Possible solution for recent compilation problems.