### PR TITLE
COMP: Fix Linux deployment of IEC logic library

### DIFF
--- a/SuperBuild/External_vtkIECTransformLogic.cmake
+++ b/SuperBuild/External_vtkIECTransformLogic.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_LIB_DIR}
       -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
       # Install directories
-      # NA
+      -DvtkIECTransformLogic_INSTALL_LIB_DIR:PATH=${Slicer_THIRDPARTY_LIB_DIR}
       # Dependencies (satisfied by Slicer)
       -DVTK_DIR:STRING=${VTK_DIR}
       # Options


### PR DESCRIPTION
On Linux the IEC transform logic binary was deployed to it's own directory instead of Slicer-5.7/qt-loadable-modules. With this update the packaging works correctly and the IEC logic is deployed in the qt-loadable-modules folder.

Re #262