### PR TITLE
FIX: buffer overflow in integer when setting to 1e10 and enhance documentation

### DIFF
--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -69,7 +69,7 @@
 // Constants
 const char* vtkSlicerRoomsEyeViewModuleLogic::ORIENTATION_MARKER_MODEL_NODE_NAME = "RoomsEyeViewOrientationMarker";
 const char* vtkSlicerRoomsEyeViewModuleLogic::TREATMENT_MACHINE_DESCRIPTOR_FILE_PATH_ATTRIBUTE_NAME = "TreatmentMachineDescriptorFilePath";
-unsigned int vtkSlicerRoomsEyeViewModuleLogic::MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS = 1e10;
+unsigned long vtkSlicerRoomsEyeViewModuleLogic::MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS = 1e10;
 
 static rapidjson::Value JSON_EMPTY_VALUE;
 
@@ -812,21 +812,21 @@ vtkSlicerRoomsEyeViewModuleLogic::SetupTreatmentMachineModels(vtkMRMLRoomsEyeVie
   }
 
   // Disable collision detection if product of number of triangles of the two models is above threshold
-  if (loadedPartsNumTriangles[Gantry] * loadedPartsNumTriangles[TableTop] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
+  if (long(loadedPartsNumTriangles[Gantry]) * loadedPartsNumTriangles[TableTop] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
   {
     vtkWarningMacro("Too many combined triangles (product = " << loadedPartsNumTriangles[Gantry] * loadedPartsNumTriangles[TableTop]
       << ") detected between gantry and table top. Collision detection may take a very long time.");
     this->GantryTableTopCollisionDetection->SetInputData(0, nullptr);
     this->GantryTableTopCollisionDetection->SetInputData(1, nullptr);
   }
-  if (loadedPartsNumTriangles[Gantry] * loadedPartsNumTriangles[PatientSupport] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
+  if (long(loadedPartsNumTriangles[Gantry]) * loadedPartsNumTriangles[PatientSupport] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
   {
     vtkWarningMacro("Too many combined triangles (product = " << loadedPartsNumTriangles[Gantry] * loadedPartsNumTriangles[PatientSupport]
       << ") detected between gantry and patient support. Collision detection may take a very long time.");
     this->GantryPatientSupportCollisionDetection->SetInputData(0, nullptr);
     this->GantryPatientSupportCollisionDetection->SetInputData(1, nullptr);
   }
-  if (loadedPartsNumTriangles[Collimator] * loadedPartsNumTriangles[TableTop] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
+  if (long(loadedPartsNumTriangles[Collimator]) * loadedPartsNumTriangles[TableTop] > MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS && !forceEnableCollisionDetection)
   {
     vtkWarningMacro("Too many combined triangles (product = " << loadedPartsNumTriangles[Collimator] * loadedPartsNumTriangles[TableTop]
       << ") detected between collimator and table top. Collision detection may take a very long time.");

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -84,7 +84,7 @@ public:
   std::vector<TreatmentMachinePartType> LoadTreatmentMachine(vtkMRMLRoomsEyeViewNode* parameterNode);
   /// Set up the IEC transforms and model properties on the treatment machine models.
   /// \param forceEnableCollisionDetection Enable collision detection between parts even if calculation is potentially
-  ///        lengthy absed on the number of triangles of the parts.
+  ///        lengthy based on the number of triangles of the parts.
   /// \return List of parts that were successfully set up.
   std::vector<TreatmentMachinePartType> SetupTreatmentMachineModels(
     vtkMRMLRoomsEyeViewNode* parameterNode, bool forceEnableCollisionDetection=false);

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -156,7 +156,7 @@ public:
   vtkGetObjectMacro(CollimatorTableTopCollisionDetection, vtkCollisionDetectionFilter);
 
 public:
-  /// Get transform node between two coordinate systems is exists
+  /// Get transform node between two coordinate systems if exists
   /// \param fromFrame - start transformation from frame
   /// \param toFrame - proceed transformation to frame
   /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -111,7 +111,7 @@ public:
   void UpdatePatientSupportToPatientSupportRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
 
   /// Update TableTopEccentricRotationToPatientSupportRotation based on table top eccentric rotation parameter
-  /// NOTE: This rotation is currently not supported (only rotate table top on the patient support)
+  /// \note This rotation is currently not supported (only rotate table top on the patient support)
   void UpdateTableTopEccentricRotationToPatientSupportRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
   /// Update TableTopToTableTopEccentricRotation based on all three table top translations
   void UpdateTableTopToTableTopEccentricRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
@@ -160,7 +160,7 @@ public:
   /// \param fromFrame - start transformation from frame
   /// \param toFrame - proceed transformation to frame
   /// \return Transform node if there is a direct transform between the specified coordinate frames, nullptr otherwise
-  ///   Note: If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
+  /// \note If IEC does not specify a transform between the given coordinate frames, then there will be no node with the returned name.
   vtkMRMLLinearTransformNode* GetTransformNodeBetween(
     vtkIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkIECTransformLogic::CoordinateSystemIdentifier toFrame);
 

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -17,7 +17,7 @@
   Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
 
   The collision detection module was partly supported by Conselleria de
-  Educación, Investigación, Cultura y Deporte (Generalitat Valenciana), Spain
+  EducaciÃ³n, InvestigaciÃ³n, Cultura y Deporte (Generalitat Valenciana), Spain
   under grant number CDEIGENT/2019/011.
 
 ==============================================================================*/
@@ -70,7 +70,7 @@ public:
 
   static const char* ORIENTATION_MARKER_MODEL_NODE_NAME;
   static const char* TREATMENT_MACHINE_DESCRIPTOR_FILE_PATH_ATTRIBUTE_NAME;
-  static unsigned int MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS;
+  static unsigned long MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS;
 
 public:
   static vtkSlicerRoomsEyeViewModuleLogic *New();


### PR DESCRIPTION
@cpinter It caused the value to be randomly cut to int (MAX_INT<1e10) (undefined behavior, platform dependent).

Convert underlying data type to long to avoid this truncation. Cast also multiplication to long, since int ^ 2 can easily surpass the limits of int.