### PR TITLE
ENH: Let user turn ON/OFF collision detection

### DIFF
--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
@@ -72,7 +72,7 @@ vtkMRMLNodeNewMacro(vtkMRMLRoomsEyeViewNode);
 vtkMRMLRoomsEyeViewNode::vtkMRMLRoomsEyeViewNode()
   : PatientBodySegmentID(nullptr)
   , TreatmentMachineDescriptorFilePath(nullptr)
-  , CollisionDetectionEnabled(false)
+  , CollisionDetectionEnabled(true)
   , GantryRotationAngle(0.0)
   , CollimatorRotationAngle(0.0)
   , ImagingPanelMovement(-68.50)

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
@@ -72,7 +72,7 @@ vtkMRMLNodeNewMacro(vtkMRMLRoomsEyeViewNode);
 vtkMRMLRoomsEyeViewNode::vtkMRMLRoomsEyeViewNode()
   : PatientBodySegmentID(nullptr)
   , TreatmentMachineDescriptorFilePath(nullptr)
-  , CollisionDetectionEnabled(true)
+  , CollisionDetectionEnabled(false)
   , GantryRotationAngle(0.0)
   , CollimatorRotationAngle(0.0)
   , ImagingPanelMovement(-68.50)

--- a/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
+++ b/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
@@ -258,7 +258,7 @@
       <item row="2" column="0" colspan="3">
        <widget class="QLabel" name="CollisionDetectionStatusLabel">
         <property name="text">
-         <string>Collision computation disabled</string>
+         <string>Collision computation enabled</string>
         </property>
        </widget>
       </item>
@@ -282,6 +282,9 @@
        <widget class="QCheckBox" name="ActivateCollisionComputationCheckBox">
         <property name="text">
          <string>Enable computation</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
+++ b/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
@@ -258,7 +258,7 @@
       <item row="2" column="0" colspan="3">
        <widget class="QLabel" name="CollisionDetectionStatusLabel">
         <property name="text">
-         <string>No collisions detected.</string>
+         <string>Collision computation disabled</string>
         </property>
        </widget>
       </item>
@@ -278,14 +278,21 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="ActivateCollisionComputationCheckBox">
+        <property name="text">
+         <string>Enable computation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Patient body:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="qMRMLSegmentSelectorWidget" name="SegmentSelectorWidget_PatientBody" native="true">
         <property name="noneEnabled" stdset="0">
          <bool>true</bool>

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -392,6 +392,9 @@ void qSlicerRoomsEyeViewModuleWidget::setup()
   // 3D camera control
   connect(d->FixedCameraCheckBox, SIGNAL(toggled(bool)), this, SLOT(setFixedReferenceCameraEnabled(bool)));
 
+  // Collision detection control
+  connect(d->ActivateCollisionComputationCheckBox, SIGNAL(toggled(bool)), this, SLOT(setCollisionComputationEnabled(bool)));
+
   // Disable treatment machine geometry controls until a machine is loaded
   d->GantryRotationSlider->setEnabled(false);
   d->CollimatorRotationSlider->setEnabled(false);
@@ -1004,7 +1007,7 @@ void qSlicerRoomsEyeViewModuleWidget::checkForCollisions()
   Q_D(qSlicerRoomsEyeViewModuleWidget);
 
   vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
-  if (!paramNode || !d->ModuleWindowInitialized)
+  if (!paramNode || !d->ModuleWindowInitialized|| !paramNode->GetCollisionDetectionEnabled())
   {
     return;
   }
@@ -1092,4 +1095,15 @@ void qSlicerRoomsEyeViewModuleWidget::setFixedReferenceCameraEnabled(bool toggle
     return;
   }
   cameraNode->SetAndObserveTransformNodeID(nullptr);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerRoomsEyeViewModuleWidget::setCollisionComputationEnabled(bool toggled)
+{
+  Q_D(qSlicerRoomsEyeViewModuleWidget);
+  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
+  paramNode->SetCollisionDetectionEnabled(toggled);
+  QString collisionsMessage(toggled ? tr("Collision computation enabled") : tr("Collision computation disabled"));
+  d->CollisionDetectionStatusLabel->setText(collisionsMessage);
+  d->CollisionDetectionStatusLabel->setStyleSheet("color: black");
 }

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
@@ -68,6 +68,7 @@ public slots:
   void updateTreatmentOrientationMarker();
 
   void setFixedReferenceCameraEnabled(bool);
+  void setCollisionComputationEnabled(bool);
 
 protected slots:
   void onLoadTreatmentMachineButtonClicked();


### PR DESCRIPTION
@cpinter: In many laptops, the algorithm eats up a lot of RAM and freezes the computer for some seconds. So disable it by default, and only turn it on actively by the user, so that he/she sees why this is happening. Also, this change is fundamental since the collision detection is, at the moment, freezing the GUI rather than running in the background.

In some cases, we do not want to calculate collisions, just to play around and show functionality as well as quickly visually see where there might be collisions. Once beam angle is decided, we can activate numerical collision detection, and get more accurate results.

Thanks in advance for the review!