### PR TITLE
BUG: Removed singleton tag for DRR markups

### DIFF
--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -642,9 +642,12 @@ vtkMRMLMarkupsPlaneNode* vtkSlicerDrrImageComputationLogic::CreateImagerBoundary
     return nullptr;
   }
   imagerMarkupsNode->SetHideFromEditors(1);
-  std::string singletonTag = std::string("RTIMAGE_") + IMAGER_BOUNDARY_MARKUPS_NODE_NAME;
-  imagerMarkupsNode->SetSingletonTag(singletonTag.c_str());
   imagerMarkupsNode->LockedOn();
+  vtkMRMLMarkupsDisplayNode* imagerMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(imagerMarkupsNode->GetDisplayNode());
+  if (imagerMarkupsDisplayNode)
+  {
+    imagerMarkupsDisplayNode->SetScaleHandleVisibility(false);
+  }
 
   if (parameterNode)
   {
@@ -707,9 +710,12 @@ vtkMRMLMarkupsPlaneNode* vtkSlicerDrrImageComputationLogic::CreateImageWindow(vt
     return nullptr;
   }
   imageWindowMarkupsNode->SetHideFromEditors(1);
-  std::string singletonTag = std::string("RTIMAGE_") + IMAGE_WINDOW_MARKUPS_NODE_NAME;
-  imageWindowMarkupsNode->SetSingletonTag(singletonTag.c_str());
   imageWindowMarkupsNode->LockedOn();
+  vtkMRMLMarkupsDisplayNode* imageWindowMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(imageWindowMarkupsNode->GetDisplayNode());
+  if (imageWindowMarkupsDisplayNode)
+  {
+    imageWindowMarkupsDisplayNode->SetScaleHandleVisibility(false);
+  }
 
   if (parameterNode)
   {
@@ -783,9 +789,12 @@ vtkMRMLMarkupsLineNode* vtkSlicerDrrImageComputationLogic::CreateImagerNormal(vt
     return nullptr;
   }
   vectorMarkupsNode->SetHideFromEditors(1);
-  std::string singletonTag = std::string("RTIMAGE_") + NORMAL_VECTOR_MARKUPS_NODE_NAME;
-  vectorMarkupsNode->SetSingletonTag(singletonTag.c_str());
   vectorMarkupsNode->LockedOn();
+  vtkMRMLMarkupsDisplayNode* vectorMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(vectorMarkupsNode->GetDisplayNode());
+  if (vectorMarkupsDisplayNode)
+  {
+    vectorMarkupsDisplayNode->SetScaleHandleVisibility(false);
+  }
 
   if (parameterNode)
   {
@@ -830,9 +839,12 @@ vtkMRMLMarkupsLineNode* vtkSlicerDrrImageComputationLogic::CreateImagerVUP(vtkMR
     return nullptr;
   }
   vectorMarkupsNode->SetHideFromEditors(1);
-  std::string singletonTag = std::string("RTIMAGE_") + VUP_VECTOR_MARKUPS_NODE_NAME;
-  vectorMarkupsNode->SetSingletonTag(singletonTag.c_str());
   vectorMarkupsNode->LockedOn();
+  vtkMRMLMarkupsDisplayNode* vectorMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(vectorMarkupsNode->GetDisplayNode());
+  if (vectorMarkupsDisplayNode)
+  {
+    vectorMarkupsDisplayNode->SetScaleHandleVisibility(false);
+  }
 
   if (parameterNode)
   {
@@ -889,9 +901,12 @@ vtkMRMLMarkupsFiducialNode* vtkSlicerDrrImageComputationLogic::CreateFiducials(v
     return nullptr;
   }
   pointsMarkupsNode->SetHideFromEditors(1);
-  std::string singletonTag = std::string("RTIMAGE_") + FIDUCIALS_MARKUPS_NODE_NAME;
-  pointsMarkupsNode->SetSingletonTag(singletonTag.c_str());
   pointsMarkupsNode->LockedOn();
+  vtkMRMLMarkupsDisplayNode* pointsMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(pointsMarkupsNode->GetDisplayNode());
+  if (pointsMarkupsDisplayNode)
+  {
+    pointsMarkupsDisplayNode->SetScaleHandleVisibility(false);
+  }
 
   if (parameterNode)
   {
@@ -1657,7 +1672,7 @@ vtkMRMLLinearTransformNode* vtkSlicerDrrImageComputationLogic::UpdateImageTransf
     transformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::New();
     transformNode->SetName(RTIMAGE_TRANSFORM_NODE_NAME);
     transformNode->SetHideFromEditors(1);
-    transformNode->SetSingletonTag("RTIMAGE_Transform");
+//    transformNode->SetSingletonTag("RTIMAGE_Transform");
     scene->AddNode(transformNode);
   }
   else

--- a/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
+++ b/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
@@ -238,7 +238,7 @@ void qSlicerDrrImageComputationModuleWidget::setMRMLScene(vtkMRMLScene* scene)
     {
       this->setParameterNode(d->MRMLNodeComboBox_ParameterSet->currentNode());
     }
-    else if (vtkMRMLNode* node = scene->GetNthNodeByClass( 0, "vtkMRMLDrrImageComputationNode"))
+    else if (vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLDrrImageComputationNode"))
     {
       this->setParameterNode(node);
     }


### PR DESCRIPTION
That fixes a bug when markups don't show up after the scene has been closed, and a new data loaded.

Mouse interaction with DRR markups is disabled also.