### PR TITLE
BUG: SourceAxisDistance (SAD) is absent in copy parameters method

### DIFF
--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -188,6 +188,7 @@ void vtkMRMLRTBeamNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyFloatMacro(X2Jaw);
   vtkMRMLCopyFloatMacro(Y1Jaw);
   vtkMRMLCopyFloatMacro(Y2Jaw);
+  vtkMRMLCopyFloatMacro(SAD);
   vtkMRMLCopyFloatMacro(SourceToJawsDistanceX);
   vtkMRMLCopyFloatMacro(SourceToJawsDistanceY);
   vtkMRMLCopyFloatMacro(SourceToMultiLeafCollimatorDistance);
@@ -224,6 +225,7 @@ void vtkMRMLRTBeamNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
   vtkMRMLCopyFloatMacro(X2Jaw);
   vtkMRMLCopyFloatMacro(Y1Jaw);
   vtkMRMLCopyFloatMacro(Y2Jaw);
+  vtkMRMLCopyFloatMacro(SAD);
   vtkMRMLCopyFloatMacro(SourceToJawsDistanceX);
   vtkMRMLCopyFloatMacro(SourceToJawsDistanceY);
   vtkMRMLCopyFloatMacro(SourceToMultiLeafCollimatorDistance);


### PR DESCRIPTION
SAD parameter isn't copied correctly, so incorrect SAD parameter was represented in BeamParametersTable

Discourse topic and comment: https://discourse.slicer.org/t/generate-digitally-reconstructed-radiograph-from-an-3dct-how-to-choose-different-controllpoints-of-an-arc-beam/44798/7?u=mik