### PR TITLE
FIX: prevent nullptr access if GetSegmentCenterRAS returns null (None segment selected back)

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -886,6 +886,11 @@ bool vtkMRMLRTPlanNode::ComputeTargetVolumeCenter(double center[3])
   }
 
   double* centerRas = segmentationNode->GetSegmentCenterRAS(this->TargetSegmentID);
+  if (!centerRas)
+  {
+    vtkErrorMacro("ComputeTargetVolumeCenter: No target segment center");
+    return false;
+  }
   center[0] = centerRas[0];
   center[1] = centerRas[1];
   center[2] = centerRas[2];


### PR DESCRIPTION
@LiBu981 does this PR fix the crash you found?

Closes https://github.com/SlicerRt/SlicerRT/issues/282

fyi @cpinter