### PR TITLE
BUG: DoseEngines and PlanOptimizers now import correctly

### DIFF
--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
@@ -130,8 +130,11 @@ bool qSlicerScriptedDoseEngine::setPythonSource(const QString newPythonSource)
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
+  // Prefix module name with "DoseEngines." for correct Python module import, without it the import would not work
+  QByteArray fullModuleName = "DoseEngines." + moduleName.toUtf8();
+
   // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  PyObject * module = PyImport_AddModule(fullModuleName.constData());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;

--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedPlanOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedPlanOptimizer.cxx
@@ -122,8 +122,11 @@ bool qSlicerScriptedPlanOptimizer::setPythonSource(const QString newPythonSource
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
+  // Prefix module name with "PlanOptimizers." for correct Python module import, without it the import would not work
+  QByteArray fullModuleName = "PlanOptimizers." + moduleName.toUtf8();
+
   // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  PyObject * module = PyImport_AddModule(fullModuleName.constData());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;


### PR DESCRIPTION
`ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx` `ExternalBeamPlanning/Widgets/qSlicerScriptedPlanOptimizer.cxx`

Both of these files had a problem in their `setPythonSource` method. The methods attempted to import the modules without using the full module name. For example, when importing the `MockDoseEngine`, it was being imported as: `MockDoseEngine`. However, the correct way would be to import: `DoseEngines.MockDoseEngine`.

Same thing happened with the plan optimizers, but instead of adding `DoseEngines.` to the module import, it should be `PlanOptimizers.`

Re #284