### PR TITLE
COMP: Fix AUTOMOC by updating the minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 #-----------------------------------------------------------------------------
 set(EXTENSION_NAME SlicerRT)


### PR DESCRIPTION
When building against current Slicer we see many of this type of warning: 

``` cmake
CMake Warning (dev) in Beams/Widgets/CMakeLists.txt:
    Policy CMP0071 is not set: Let AUTOMOC and AUTOUIC process GENERATED files.
    Run "cmake --help-policy CMP0071" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.
  
    For compatibility, CMake is excluding the GENERATED source file(s):
  
      "D:/srt-broken/inner-build/Beams/Widgets/generated_cpp/osm_qSlicerBeamsModuleWidgets/osm_qSlicerBeamsModuleWidgets_init.cpp"
      "D:/srt-broken/inner-build/Beams/Widgets/generated_cpp/osm_qSlicerBeamsModuleWidgets/osm_qSlicerBeamsModuleWidgets_module_init.cpp"
      "D:/srt-broken/inner-build/Beams/Widgets/generated_cpp/osm_qSlicerBeamsModuleWidgets/osm_qSlicerBeamsModuleWidgets.h"
  
    from processing by AUTOMOC.  If any of the files should be processed, set
    CMP0071 to NEW.  If any of the files should not be processed, explicitly
    exclude them by setting the source file property SKIP_AUTOMOC:
  
      set_property(SOURCE file.h PROPERTY SKIP_AUTOMOC ON)
  
  This warning is for project developers.  Use -Wno-dev to suppress it.
```

We then later see errors of this type:

```
Creating library D:/srt-broken/inner-build/lib/Slicer-5.11/qt-loadable-modules/Release/qSlicerBeamsModuleWidgetsPythonQt.lib and object D:/srt-broken/inner-build/lib/Slicer-5.11/qt-loadable-modules/Release/qSlicerBeamsModuleWidgetsPythonQt.exp
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual struct QMetaObject const * __cdecl PythonQtWrapper_qMRMLBeamParametersTabWidget::metaObject(void)const " (?metaObject@PythonQtWrapper_qMRMLBeamParametersTabWidget@@UEBAPEBUQMetaObject@@XZ) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual void * __cdecl PythonQtWrapper_qMRMLBeamParametersTabWidget::qt_metacast(char const *)" (?qt_metacast@PythonQtWrapper_qMRMLBeamParametersTabWidget@@UEAAPEAXPEBD@Z) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual int __cdecl PythonQtWrapper_qMRMLBeamParametersTabWidget::qt_metacall(enum QMetaObject::Call,int,void * *)" (?qt_metacall@PythonQtWrapper_qMRMLBeamParametersTabWidget@@UEAAHW4Call@QMetaObject@@HPEAPEAX@Z) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual struct QMetaObject const * __cdecl PythonQtWrapper_qMRMLBeamsTableView::metaObject(void)const " (?metaObject@PythonQtWrapper_qMRMLBeamsTableView@@UEBAPEBUQMetaObject@@XZ) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual void * __cdecl PythonQtWrapper_qMRMLBeamsTableView::qt_metacast(char const *)" (?qt_metacast@PythonQtWrapper_qMRMLBeamsTableView@@UEAAPEAXPEBD@Z) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
osm_qSlicerBeamsModuleWidgets_init.obj : error LNK2001: unresolved external symbol "public: virtual int __cdecl PythonQtWrapper_qMRMLBeamsTableView::qt_metacall(enum QMetaObject::Call,int,void * *)" (?qt_metacall@PythonQtWrapper_qMRMLBeamsTableView@@UEAAHW4Call@QMetaObject@@HPEAPEAX@Z) [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
D:\srt-broken\inner-build\lib\Slicer-5.11\qt-loadable-modules\Release\qSlicerBeamsModuleWidgetsPythonQt.pyd : fatal error LNK1120: 6 unresolved externals [D:\srt-broken\inner-build\Beams\Widgets\qSlicerBeamsModuleWidgetsPythonQt.vcxproj] [D:\srt-broken\inner.vcxproj]
```

By explicitly setting CMP0071 to new for the extension, these errors seem to resolve