### PR TITLE
ENH: Ipopt added to superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/8/87/Slic
 set(EXTENSION_STATUS "Beta")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated list or 'NA' if any
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
+set(EXTENSION_BUILDS_IPOPT OFF)
 
 set(SUPERBUILD_TOPLEVEL_PROJECT inner)
 
@@ -52,6 +53,12 @@ endif()
 # Extension dependencies
 find_package(Slicer COMPONENTS ConfigurePrerequisites REQUIRED)
 project(SlicerRT)
+
+# Enable Fortran for MUMPS/LAPACK support in external projects (if optimization is enabled)
+if(EXTENSION_BUILDS_IPOPT AND UNIX)
+  enable_language(Fortran)
+endif()
+
 find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
 mark_as_superbuild(Slicer_DIR)
@@ -128,6 +135,20 @@ endif()
 #-----------------------------------------------------------------------------
 set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
 list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkIECTransformLogic_DIR};vtkIECTransformLogic;RuntimeLibraries;/")
+
+# Add optimization runtime libraries if enabled
+if(EXTENSION_BUILDS_IPOPT)
+  if(DEFINED Mumps_DIR AND UNIX)
+    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Mumps_DIR};Mumps;RuntimeLibraries;/")
+  endif()
+  if(DEFINED HSL_DIR AND UNIX)
+    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${HSL_DIR};HSL;RuntimeLibraries;/")
+  endif()
+  if(DEFINED Ipopt_DIR)
+    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Ipopt_DIR};Ipopt;RuntimeLibraries;/")
+  endif()
+endif()
+
 set(${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS "${EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS}" CACHE STRING "List of external projects to install" FORCE)
 list(APPEND CPACK_INSTALL_CMAKE_PROJECTS "${CMAKE_BINARY_DIR};${EXTENSION_NAME};ALL;/")
 list(APPEND CPACK_INSTALL_CMAKE_PROJECTS "${${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS}")

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -22,6 +22,21 @@ set(${proj}_DEPENDS
   vtkIECTransformLogic
   )
 
+# Add linear equation solver dependencies (MUMPS, HSL) if enabled and on UNIX
+if(EXTENSION_BUILDS_IPOPT AND UNIX)
+  list(APPEND ${proj}_DEPENDS
+    Mumps
+    HSL
+  )
+endif()
+
+# Add optimization dependencies Ipopt if enabled
+if(EXTENSION_BUILDS_IPOPT)
+  list(APPEND ${proj}_DEPENDS
+    Ipopt
+  )
+endif()
+
 ExternalProject_Include_Dependencies(${proj}
   PROJECT_VAR proj
   SUPERBUILD_VAR ${EXTENSION_NAME}_SUPERBUILD
@@ -52,6 +67,10 @@ ExternalProject_Add(${proj}
     # Superbuild
     -D${EXTENSION_NAME}_SUPERBUILD:BOOL=OFF
     -DEXTENSION_SUPERBUILD_BINARY_DIR:PATH=${${EXTENSION_NAME}_BINARY_DIR}
+    -DIpopt_INCLUDE_DIR:PATH=${Ipopt_INCLUDE_DIR}
+    -DIpopt_LIBRARY_DIR:PATH=${Ipopt_LIBRARY_DIR}
+    -DIpopt_DLL_DIR:PATH=${Ipopt_DLL_DIR}
+    -DIpopt_DLL:FILEPATH=${Ipopt_DLL}
   DEPENDS
     ${${proj}_DEPENDS}
   )

--- a/SuperBuild/External_HSL.cmake
+++ b/SuperBuild/External_HSL.cmake
@@ -1,0 +1,105 @@
+set(proj HSL)
+
+# HSL (Harwell Subroutines Library) - High-performance linear solvers for Ipopt
+# HSL can provide better performance than MUMPS for some optimization problems
+#
+# Note: HSL requires manual download of source code due to licensing restrictions
+# This configuration assumes you have obtained HSL sources from:
+# https://licences.stfc.ac.uk/product/coin-hsl
+#
+# Instructions:
+# 1. Download the Coin-HSL archive from the link above
+# 2. Extract it to a 'coinhsl' directory in the HSL source directory
+# 3. The build system will automatically detect and use the HSL solvers
+
+# HSL requires optimization flag to be enabled and Unix-like system
+if(NOT EXTENSION_BUILDS_IPOPT)
+  message(STATUS "HSL build skipped. Enable with EXTENSION_BUILDS_IPOPT=ON")
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+if(WIN32)
+  message(WARNING "HSL build is only supported on Unix-like systems (Linux, macOS). Skipping on Windows.")
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+# Set dependency list
+set(${proj}_DEPENDS "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED HSL_DIR AND NOT EXISTS ${HSL_DIR})
+  message(FATAL_ERROR "HSL_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
+    "https://github.com/coin-or-tools/ThirdParty-HSL.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
+    "stable/2.2"
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  # Configure CFLAGS and CXXFLAGS for the build
+  set(EP_C_FLAGS "${ep_common_c_flags}")
+  set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
+
+  # Handle LAPACK dependencies
+  # Use standard LAPACK/BLAS libraries (same as MUMPS)
+  set(HSL_CONFIGURE_ARGS "--with-lapack-lflags=-llapack -lblas")
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CONFIGURE_COMMAND
+      ${CMAKE_COMMAND} -E env
+        CC=${CMAKE_C_COMPILER}
+        CXX=${CMAKE_CXX_COMPILER}
+        FC=gfortran
+        F77=gfortran
+        CFLAGS=${EP_C_FLAGS}
+        CXXFLAGS=${EP_CXX_FLAGS}
+        FFLAGS=-fPIC
+      <SOURCE_DIR>/configure
+        --prefix=<INSTALL_DIR>
+        --enable-shared=no
+        --enable-static=yes
+        ${HSL_CONFIGURE_ARGS}
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) install
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+  set(${proj}_DIR ${EP_INSTALL_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+mark_as_superbuild(${proj}_DIR:PATH)

--- a/SuperBuild/External_Ipopt.cmake
+++ b/SuperBuild/External_Ipopt.cmake
@@ -1,0 +1,148 @@
+set(proj Ipopt)
+
+# IPOPT - Interior Point Optimizer
+# Ipopt is configured with both MUMPS and HSL linear solvers for optimal performance.
+#
+# UNIX: This configuration supports Linux and macOS systems
+# and uses autotools build system with system LAPACK/BLAS libraries.
+#
+# Included Linear Solvers:
+# - MUMPS: Open-source, automatically downloaded and built
+# - HSL (Harwell Subroutines Library): High-performance solvers
+#   * Requires manual download due to licensing (free for academic use)
+#   * Download from: https://licences.stfc.ac.uk/product/coin-hsl
+#   * Extract to 'coinhsl' directory in HSL source tree
+#   * HSL provides MA27, MA57, MA77, MA86, MA97 solvers
+#
+# WINDOWS: Prebuilt binaries are downloaded and extracted, MUMPS included.
+#
+# For more information see: https://coin-or.github.io/Ipopt/INSTALL.html
+
+# Ipopt requires optimization flag to be enabled and Unix-like system
+if(NOT EXTENSION_BUILDS_IPOPT)
+  message(STATUS "Ipopt build skipped. Enable with EXTENSION_BUILDS_IPOPT=ON")
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+# Windows: Download and extract prebuilt Ipopt binaries
+if(WIN32)
+  set(IPOPT_WIN_URL "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.14.19/Ipopt-3.14.19-win64-msvs2022-md.zip")
+  set(IPOPT_WIN_ZIP "${CMAKE_BINARY_DIR}/Ipopt-3.14.19-win64-msvs2022-md.zip")
+  set(IPOPT_WIN_DIR "${CMAKE_BINARY_DIR}/Ipopt-3.14.19-win64-msvs2022-md")
+
+  ExternalProject_Add(${proj}
+    URL ${IPOPT_WIN_URL}
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND
+    "${CMAKE_COMMAND};-E;remove_directory;${IPOPT_WIN_DIR}"
+    "${CMAKE_COMMAND};-E;make_directory;${IPOPT_WIN_DIR}"
+    "${CMAKE_COMMAND};-E;tar;xvf;${IPOPT_WIN_ZIP};--directory=${IPOPT_WIN_DIR}"
+    LOG_DOWNLOAD ON
+    LOG_INSTALL ON
+  )
+
+  set(IPOPT_WIN_REAL_DIR "${CMAKE_BINARY_DIR}/Ipopt-prefix/src/Ipopt")
+
+  set(${proj}_DIR ${IPOPT_WIN_REAL_DIR})
+  set(${proj}_INCLUDE_DIR "${IPOPT_WIN_REAL_DIR}/include/coin-or")
+  set(${proj}_LIBRARY_DIR "${IPOPT_WIN_REAL_DIR}/lib")
+  set(${proj}_DLL_DIR "${IPOPT_WIN_REAL_DIR}/bin")
+  set(${proj}_DLL "${IPOPT_WIN_REAL_DIR}/bin/ipopt-3.dll")
+
+  # Cache variables for downstream use
+  set(Ipopt_DIR "${${proj}_DIR}" CACHE PATH "Ipopt root directory")
+  set(Ipopt_INCLUDE_DIR "${${proj}_INCLUDE_DIR}" CACHE PATH "Ipopt include directory")
+  set(Ipopt_LIBRARY_DIR "${${proj}_LIBRARY_DIR}" CACHE PATH "Ipopt library directory")
+  set(Ipopt_DLL_DIR "${${proj}_DLL_DIR}" CACHE PATH "Ipopt DLL directory")
+  set(Ipopt_DLL "${${proj}_DLL}" CACHE FILEPATH "Ipopt DLL file")
+
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+# Set dependency list
+set(${proj}_DEPENDS "")
+if(DEFINED Slicer_SOURCE_DIR)
+  list(APPEND ${proj}_DEPENDS
+    Mumps
+    HSL
+    )
+endif()
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED Ipopt_DIR AND NOT EXISTS ${Ipopt_DIR})
+  message(FATAL_ERROR "Ipopt_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
+    "https://github.com/coin-or/Ipopt.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
+    "releases/3.14.19"
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  # Configure CFLAGS and CXXFLAGS for the build
+  set(EP_C_FLAGS "${ep_common_c_flags}")
+  set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CONFIGURE_COMMAND
+      ${CMAKE_COMMAND} -E env
+        CC=${CMAKE_C_COMPILER}
+        CXX=${CMAKE_CXX_COMPILER}
+        FC=gfortran
+        F77=gfortran
+        CFLAGS=${EP_C_FLAGS}
+        CXXFLAGS=${EP_CXX_FLAGS}
+        FFLAGS=-fPIC
+      <SOURCE_DIR>/configure
+        --prefix=<INSTALL_DIR>
+        --enable-shared=no
+        --enable-static=yes
+        --with-mumps-incdir=${Mumps_DIR}/include
+        --with-mumps-lib=${Mumps_DIR}/lib/libcoinmumps.a
+        --with-hsl-incdir=${HSL_DIR}/include
+        --with-hsl-lib=${HSL_DIR}/lib/libcoinhsl.a
+        --disable-linear-solver-loader
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) install
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+  set(${proj}_DIR ${EP_INSTALL_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+mark_as_superbuild(${proj}_DIR:PATH)

--- a/SuperBuild/External_Ipopt.cmake
+++ b/SuperBuild/External_Ipopt.cmake
@@ -109,6 +109,11 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(EP_C_FLAGS "${ep_common_c_flags}")
   set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
 
+  # Set up linker flags as variables
+  set(MUMPS_LFLAGS "-L${Mumps_DIR}/lib -lcoinmumps -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+  # Uncomment the following lines when HSL is available:
+  # set(HSL_LFLAGS "-L${HSL_DIR}/lib -lcoinhsl -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
@@ -129,10 +134,11 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
         --prefix=<INSTALL_DIR>
         --enable-shared=no
         --enable-static=yes
-        --with-mumps-incdir=${Mumps_DIR}/include
-        --with-mumps-lib=${Mumps_DIR}/lib/libcoinmumps.a
-        --with-hsl-incdir=${HSL_DIR}/include
-        --with-hsl-lib=${HSL_DIR}/lib/libcoinhsl.a
+        --with-mumps-cflags=-I${Mumps_DIR}/include/coin-or/mumps
+        --with-mumps-lflags=${MUMPS_LFLAGS}
+        # Uncomment the following lines when HSL is available:
+        # --with-hsl-cflags=-I${HSL_DIR}/include/coin-or
+        # --with-hsl-lflags=${HSL_LFLAGS}
         --disable-linear-solver-loader
     BUILD_COMMAND $(MAKE)
     INSTALL_COMMAND $(MAKE) install

--- a/SuperBuild/External_Mumps.cmake
+++ b/SuperBuild/External_Mumps.cmake
@@ -1,0 +1,95 @@
+set(proj Mumps)
+
+# MUMPS requires optimization flag to be enabled and Unix-like system
+if(NOT EXTENSION_BUILDS_IPOPT)
+  message(STATUS "MUMPS build skipped. Enable with EXTENSION_BUILDS_IPOPT=ON")
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+if(WIN32)
+  message(WARNING "MUMPS build is only supported on Unix-like systems (Linux, macOS). Skipping on Windows.")
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
+# Set dependency list
+set(${proj}_DEPENDS "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED Mumps_DIR AND NOT EXISTS ${Mumps_DIR})
+  message(FATAL_ERROR "Mumps_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
+    "https://github.com/coin-or-tools/ThirdParty-Mumps.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
+    "stable/3.0"
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  # Configure CFLAGS and CXXFLAGS for the build
+  set(EP_C_FLAGS "${ep_common_c_flags}")
+  set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
+
+  # Handle LAPACK dependencies
+  # Use standard LAPACK/BLAS libraries
+  set(MUMPS_CONFIGURE_ARGS "--with-lapack-lflags=-llapack -lblas")
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CONFIGURE_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./get.Mumps
+      COMMAND
+      ${CMAKE_COMMAND} -E env
+        CC=${CMAKE_C_COMPILER}
+        CXX=${CMAKE_CXX_COMPILER}
+        FC=gfortran
+        F77=gfortran
+        CFLAGS=${EP_C_FLAGS}
+        CXXFLAGS=${EP_CXX_FLAGS}
+        FFLAGS=-fPIC
+      <SOURCE_DIR>/configure
+        --prefix=<INSTALL_DIR>
+        --enable-shared=no
+        --enable-static=yes
+        ${MUMPS_CONFIGURE_ARGS}
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) install
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+  set(${proj}_DIR ${EP_INSTALL_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+mark_as_superbuild(${proj}_DIR:PATH)

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,3 +1,6 @@
 if(Slicer_USE_PYTHONQT)
   add_subdirectory(Python)
 endif()
+
+# Add C++ tests
+add_subdirectory(Cxx)

--- a/Testing/Cxx/CMakeLists.txt
+++ b/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,169 @@
+# Ipopt test executable
+set(IPOPT_TEST_SRCS
+  IpoptTest.cxx
+  MyNLP.cpp
+)
+
+# Only build Ipopt test if Ipopt is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  # Find Ipopt installation
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
+    set(IPOPT_LIBRARIES "${Ipopt_LIBRARY_DIR}/ipopt.dll.lib")
+    set(IPOPT_DLL "${Ipopt_DLL}")
+  else()
+    # Unix systems use built libraries
+    find_path(IPOPT_INCLUDE_DIRS
+      NAMES IpIpoptApplication.hpp
+      PATHS
+        ${Ipopt_DIR}/include/coin-or
+        ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH
+    )
+
+    find_library(IPOPT_LIBRARIES
+      NAMES ipopt libipopt
+      PATHS
+        ${Ipopt_DIR}/lib
+        ${CMAKE_BINARY_DIR}/Ipopt-install/lib
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_INCLUDE_DIRS AND IPOPT_LIBRARIES)
+    # Create the test executable
+    add_executable(IpoptTest ${IPOPT_TEST_SRCS})
+
+    # Set include directories
+    target_include_directories(IpoptTest PRIVATE ${IPOPT_INCLUDE_DIRS})
+
+    # Link libraries
+    target_link_libraries(IpoptTest ${IPOPT_LIBRARIES})
+
+    # Add additional system libraries that Ipopt might need
+    if(UNIX)
+      # Link Fortran runtime and METIS with explicit linker flags
+      target_link_options(IpoptTest PRIVATE "-Wl,--no-as-needed")
+      target_link_libraries(IpoptTest gfortran quadmath gcc_s metis)
+
+      # Find and link all required dependencies
+      set(IPOPT_DEPS)
+
+      # System math libraries
+      find_library(DL_LIBRARY dl)
+      if(DL_LIBRARY)
+        list(APPEND IPOPT_DEPS ${DL_LIBRARY})
+      endif()
+
+      find_library(M_LIBRARY m)
+      if(M_LIBRARY)
+        list(APPEND IPOPT_DEPS ${M_LIBRARY})
+      endif()
+
+      find_library(PTHREAD_LIBRARY pthread)
+      if(PTHREAD_LIBRARY)
+        list(APPEND IPOPT_DEPS ${PTHREAD_LIBRARY})
+      endif()
+
+      # Fortran runtime - use full library paths
+      find_library(GFORTRAN_LIBRARY NAMES gfortran PATHS /usr/lib/gcc/x86_64-linux-gnu/11 /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
+      if(GFORTRAN_LIBRARY)
+        list(APPEND IPOPT_DEPS ${GFORTRAN_LIBRARY})
+      else()
+        list(APPEND IPOPT_DEPS gfortran)
+      endif()
+
+      find_library(QUADMATH_LIBRARY NAMES quadmath PATHS /usr/lib/gcc/x86_64-linux-gnu/11 /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
+      if(QUADMATH_LIBRARY)
+        list(APPEND IPOPT_DEPS ${QUADMATH_LIBRARY})
+      else()
+        list(APPEND IPOPT_DEPS quadmath)
+      endif()
+
+      # Add gcc runtime for Fortran support
+      find_library(GCC_S_LIBRARY NAMES gcc_s PATHS /usr/lib/gcc/x86_64-linux-gnu/11 /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
+      if(GCC_S_LIBRARY)
+        list(APPEND IPOPT_DEPS ${GCC_S_LIBRARY})
+      endif()
+
+      # BLAS/LAPACK
+      find_package(BLAS QUIET)
+      if(BLAS_FOUND)
+        list(APPEND IPOPT_DEPS ${BLAS_LIBRARIES})
+      endif()
+
+      find_package(LAPACK QUIET)
+      if(LAPACK_FOUND)
+        list(APPEND IPOPT_DEPS ${LAPACK_LIBRARIES})
+      endif()
+
+      # MUMPS library (focus on getting this right first)
+      find_library(MUMPS_LIBRARY
+        NAMES coinmumps libcoinmumps
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+        NO_DEFAULT_PATH
+      )
+      if(MUMPS_LIBRARY)
+        list(APPEND IPOPT_DEPS ${MUMPS_LIBRARY})
+        message(STATUS "Found MUMPS library: ${MUMPS_LIBRARY}")
+      else()
+        message(STATUS "MUMPS library not found. Searched in:")
+        message(STATUS "  ${CMAKE_BINARY_DIR}/Mumps-install/lib")
+        message(STATUS "  ${Mumps_DIR}/lib")
+      endif()
+
+      # Remove HSL for now as it is not configured properly yet
+      # # HSL library
+      # find_library(HSL_LIBRARY
+      #   NAMES coinhsl libcoinhsl
+      #   PATHS
+      #     ${CMAKE_BINARY_DIR}/HSL-install/lib
+      #     ${HSL_DIR}/lib
+      #   NO_DEFAULT_PATH
+      # )
+      # if(HSL_LIBRARY)
+      #   list(APPEND IPOPT_DEPS ${HSL_LIBRARY})
+      # endif()
+
+      # Link all dependencies
+      if(IPOPT_DEPS)
+        target_link_libraries(IpoptTest ${IPOPT_DEPS})
+      endif()
+    endif()
+
+    # Add the test
+    add_test(
+      NAME IpoptBasicTest
+      COMMAND IpoptTest
+    )
+
+    # Set test properties
+    set_tests_properties(IpoptBasicTest
+      PROPERTIES
+        PASS_REGULAR_EXPRESSION "The problem solved in .* iterations"
+        FAIL_REGULAR_EXPRESSION "Error;ERROR"
+    )
+
+    # Copy DLL on Windows if needed
+    if(WIN32 AND IPOPT_DLL)
+      # Copy all DLLs from Ipopt_DLL_DIR to the test output directory
+      file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
+      foreach(DLL_FILE ${IPOPT_DLLS})
+        add_custom_command(TARGET IpoptTest POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DLL_FILE}"
+            "$<TARGET_FILE_DIR:IpoptTest>"
+        )
+      endforeach()
+    endif()
+
+    message(STATUS "Ipopt test configured successfully")
+  else()
+    message(WARNING "Ipopt libraries not found. Ipopt test will be skipped.")
+  endif()
+else()
+  message(STATUS "Ipopt test skipped. Enable with EXTENSION_BUILDS_IPOPT=ON")
+endif()

--- a/Testing/Cxx/IpoptTest.cxx
+++ b/Testing/Cxx/IpoptTest.cxx
@@ -1,0 +1,52 @@
+// Copyright (C) 2004, 2009 International Business Machines and others.
+// All Rights Reserved.
+// This code is published under the Eclipse Public License.
+//
+// Authors:  Carl Laird, Andreas Waechter     IBM    2004-11-05
+
+#include "IpIpoptApplication.hpp"
+#include "IpSolveStatistics.hpp"
+#include "MyNLP.hpp"
+
+#include <iostream>
+
+using namespace Ipopt;
+
+int main(
+   int,
+   char**
+)
+{
+   // Create an instance of your nlp...
+   SmartPtr<TNLP> mynlp = new MyNLP();
+
+   // Create an instance of the IpoptApplication
+   //
+   // We are using the factory, since this allows us to compile this
+   // example with an Ipopt Windows DLL
+   SmartPtr<IpoptApplication> app = IpoptApplicationFactory();
+
+   // Initialize the IpoptApplication and process the options
+   ApplicationReturnStatus status;
+   status = app->Initialize();
+   if( status != Solve_Succeeded )
+   {
+      std::cout << std::endl << std::endl << "*** Error during initialization!" << std::endl;
+      return (int) status;
+   }
+
+   status = app->OptimizeTNLP(mynlp);
+
+   if( status == Solve_Succeeded )
+   {
+      // Retrieve some statistics about the solve
+      Index iter_count = app->Statistics()->IterationCount();
+      std::cout << std::endl << std::endl << "*** The problem solved in " << iter_count << " iterations!" << std::endl;
+
+      Number final_obj = app->Statistics()->FinalObjective();
+      std::cout << std::endl << std::endl << "*** The final value of the objective function is " << final_obj << '.'
+                << std::endl;
+   }
+
+   return (int) status;
+}

--- a/Testing/Cxx/MyNLP.cpp
+++ b/Testing/Cxx/MyNLP.cpp
@@ -1,0 +1,254 @@
+// Copyright (C) 2004, 2009 International Business Machines and others.
+// All Rights Reserved.
+// This code is published under the Eclipse Public License.
+//
+// Authors:  Carl Laird, Andreas Waechter     IBM    2004-11-05
+
+#include <cassert>
+#include <iostream>
+
+#include "MyNLP.hpp"
+
+using namespace Ipopt;
+
+// constructor
+MyNLP::MyNLP()
+{}
+
+// destructor
+MyNLP::~MyNLP()
+{}
+
+// returns the size of the problem
+bool MyNLP::get_nlp_info(
+   Index&          n,
+   Index&          m,
+   Index&          nnz_jac_g,
+   Index&          nnz_h_lag,
+   IndexStyleEnum& index_style
+)
+{
+   // The problem described in MyNLP.hpp has 2 variables, x1, & x2,
+   n = 2;
+
+   // one equality constraint,
+   m = 1;
+
+   // 2 nonzeros in the jacobian (derivative of g w.r.t. x)
+   nnz_jac_g = 2;
+
+   // and 2 nonzeros in the hessian of the lagrangian
+   // (derivative of sigma*f + lambda*g w.r.t. x)
+   nnz_h_lag = 2;
+
+   // We use the standard fortran index style for row/col entries
+   index_style = TNLP::FORTRAN_STYLE;
+
+   return true;
+}
+
+// returns the variable bounds
+bool MyNLP::get_bounds_info(
+   Index   n,
+   Number* x_l,
+   Number* x_u,
+   Index   m,
+   Number* g_l,
+   Number* g_u
+)
+{
+   // here, the n and m we gave IPOPT in get_nlp_info are passed back to us.
+   // If desired, we could assert to make sure they are what we think they are.
+   assert(n == 2);
+   assert(m == 1);
+
+   // x1 has bounds [-1, 1]
+   x_l[0] = -1.0;
+   x_u[0] = 1.0;
+
+   // x2 has no bounds
+   x_l[1] = -1.0e19;
+   x_u[1] = +1.0e19;
+
+   // the constraint 0 = x1^2 + x2 - 1
+   g_l[0] = g_u[0] = 0.0;
+
+   return true;
+}
+
+// returns the initial point for the problem
+bool MyNLP::get_starting_point(
+   Index   n,
+   bool    init_x,
+   Number* x,
+   bool    init_z,
+   Number* z_L,
+   Number* z_U,
+   Index   m,
+   bool    init_lambda,
+   Number* lambda
+)
+{
+   // Here, we assume we only have starting values for x, if you code
+   // your own NLP, you can provide starting values for the others if
+   // you wish.
+   assert(init_x == true);
+   assert(init_z == false);
+   assert(init_lambda == false);
+
+   // we initialize x in bounds, in the upper right quadrant
+   x[0] = 0.5;
+   x[1] = 1.5;
+
+   return true;
+}
+
+// returns the value of the objective function
+bool MyNLP::eval_f(
+   Index         n,
+   const Number* x,
+   bool          new_x,
+   Number&       obj_value
+)
+{
+   assert(n == 2);
+
+   obj_value = -(x[1] - 2.0) * (x[1] - 2.0);
+
+   return true;
+}
+
+// return the gradient of the objective function grad_{x} f(x)
+bool MyNLP::eval_grad_f(
+   Index         n,
+   const Number* x,
+   bool          new_x,
+   Number*       grad_f
+)
+{
+   assert(n == 2);
+
+   grad_f[0] = 0.0;
+   grad_f[1] = -2.0 * (x[1] - 2.0);
+
+   return true;
+}
+
+// return the value of the constraints: g(x)
+bool MyNLP::eval_g(
+   Index         n,
+   const Number* x,
+   bool          new_x,
+   Index         m,
+   Number*       g
+)
+{
+   assert(n == 2);
+   assert(m == 1);
+
+   g[0] = x[0] * x[0] + x[1] - 1.0;
+
+   return true;
+}
+
+// return the structure or values of the jacobian
+bool MyNLP::eval_jac_g(
+   Index         n,
+   const Number* x,
+   bool          new_x,
+   Index         m,
+   Index         nele_jac,
+   Index*        iRow,
+   Index*        jCol,
+   Number*       values
+)
+{
+   assert(n == 2);
+   assert(m == 1);
+   assert(nele_jac == 2);
+
+   if( values == NULL )
+   {
+      // return the structure of the jacobian of the constraints
+
+      // constraint 0 depends on x0 and x1
+      iRow[0] = 1;
+      jCol[0] = 1;
+      iRow[1] = 1;
+      jCol[1] = 2;
+   }
+   else
+   {
+      // return the values of the jacobian of the constraints
+      values[0] = 2.0 * x[0]; // derivative of g w.r.t. x1
+      values[1] = 1.0;        // derivative of g w.r.t. x2
+   }
+
+   return true;
+}
+
+// return the structure or values of the hessian
+bool MyNLP::eval_h(
+   Index         n,
+   const Number* x,
+   bool          new_x,
+   Number        obj_factor,
+   Index         m,
+   const Number* lambda,
+   bool          new_lambda,
+   Index         nele_hess,
+   Index*        iRow,
+   Index*        jCol,
+   Number*       values
+)
+{
+   assert(n == 2);
+   assert(m == 1);
+   assert(nele_hess == 2);
+
+   if( values == NULL )
+   {
+      // return the structure. This is a symmetric matrix, fill the lower left
+      // triangle only.
+
+      // the hessian for this problem is actually dense
+      iRow[0] = 1;
+      jCol[0] = 1;
+      iRow[1] = 2;
+      jCol[1] = 2;
+   }
+   else
+   {
+      // return the values. This is a symmetric matrix, fill the lower left
+      // triangle only
+
+      // fill the objective portion
+      values[0] = 0.0;                // 2nd derivative of f w.r.t. x1
+      values[1] = obj_factor * (-2.0); // 2nd derivative of f w.r.t. x2
+
+      // add the portion for the constraint
+      values[0] += lambda[0] * 2.0; // 2nd derivative of g w.r.t. x1
+      values[1] += 0.0;             // 2nd derivative of g w.r.t. x2
+   }
+
+   return true;
+}
+
+void MyNLP::finalize_solution(
+   SolverReturn               status,
+   Index                      n,
+   const Number*              x,
+   const Number*              z_L,
+   const Number*              z_U,
+   Index                      m,
+   const Number*              g,
+   const Number*              lambda,
+   Number                     obj_value,
+   const IpoptData*           ip_data,
+   IpoptCalculatedQuantities* ip_cq
+)
+{
+   // here is where we would store the solution to variables, or write to a file, etc
+   // so we could use the solution. Since the solution is displayed to the console,
+   // we currently do nothing here.
+}

--- a/Testing/Cxx/MyNLP.hpp
+++ b/Testing/Cxx/MyNLP.hpp
@@ -1,0 +1,166 @@
+// Copyright (C) 2004, 2009 International Business Machines and others.
+// All Rights Reserved.
+// This code is published under the Eclipse Public License.
+//
+// Authors:  Carl Laird, Andreas Waechter     IBM    2004-11-05
+
+#ifndef __MYNLP_HPP__
+#define __MYNLP_HPP__
+
+#include "IpTNLP.hpp"
+
+using namespace Ipopt;
+
+/** C++ Example NLP for interfacing a problem with IPOPT.
+ *  MyNLP implements a C++ example showing how to interface with IPOPT
+ *  through the TNLP interface. This example solves the problem
+ *
+ *     min_x f(x) = -(x2-2)^2
+ *  s.t.       0 = x1^2 + x2 - 1
+ *             -1 <= x1 <= 1
+ *
+ */
+class MyNLP : public TNLP
+{
+public:
+   /** default constructor */
+   MyNLP();
+
+   /** default destructor */
+   virtual ~MyNLP();
+
+   /**@name Overloaded from TNLP */
+   //@{
+   /** Method to return some info about the nlp */
+   virtual bool get_nlp_info(
+      Index&          n,
+      Index&          m,
+      Index&          nnz_jac_g,
+      Index&          nnz_h_lag,
+      IndexStyleEnum& index_style
+   );
+
+   /** Method to return the bounds for my problem */
+   virtual bool get_bounds_info(
+      Index   n,
+      Number* x_l,
+      Number* x_u,
+      Index   m,
+      Number* g_l,
+      Number* g_u
+   );
+
+   /** Method to return the starting point for the algorithm */
+   virtual bool get_starting_point(
+      Index   n,
+      bool    init_x,
+      Number* x,
+      bool    init_z,
+      Number* z_L,
+      Number* z_U,
+      Index   m,
+      bool    init_lambda,
+      Number* lambda
+   );
+
+   /** Method to return the objective value */
+   virtual bool eval_f(
+      Index         n,
+      const Number* x,
+      bool          new_x,
+      Number&       obj_value
+   );
+
+   /** Method to return the gradient of the objective */
+   virtual bool eval_grad_f(
+      Index         n,
+      const Number* x,
+      bool          new_x,
+      Number*       grad_f
+   );
+
+   /** Method to return the constraint residuals */
+   virtual bool eval_g(
+      Index         n,
+      const Number* x,
+      bool          new_x,
+      Index         m,
+      Number*       g
+   );
+
+   /** Method to return:
+    *   1) The structure of the jacobian (if "values" is NULL)
+    *   2) The values of the jacobian (if "values" is not NULL)
+    */
+   virtual bool eval_jac_g(
+      Index         n,
+      const Number* x,
+      bool          new_x,
+      Index         m,
+      Index         nele_jac,
+      Index*        iRow,
+      Index*        jCol,
+      Number*       values
+   );
+
+   /** Method to return:
+    *   1) The structure of the hessian of the lagrangian (if "values" is NULL)
+    *   2) The values of the hessian of the lagrangian (if "values" is not NULL)
+    */
+   virtual bool eval_h(
+      Index         n,
+      const Number* x,
+      bool          new_x,
+      Number        obj_factor,
+      Index         m,
+      const Number* lambda,
+      bool          new_lambda,
+      Index         nele_hess,
+      Index*        iRow,
+      Index*        jCol,
+      Number*       values
+   );
+
+   //@}
+
+   /** @name Solution Methods */
+   //@{
+   /** This method is called when the algorithm is complete so the TNLP can store/write the solution */
+   virtual void finalize_solution(
+      SolverReturn               status,
+      Index                      n,
+      const Number*              x,
+      const Number*              z_L,
+      const Number*              z_U,
+      Index                      m,
+      const Number*              g,
+      const Number*              lambda,
+      Number                     obj_value,
+      const IpoptData*           ip_data,
+      IpoptCalculatedQuantities* ip_cq
+   );
+   //@}
+
+private:
+   /**@name Methods to block default compiler methods.
+    *
+    * The compiler automatically generates the following three methods.
+    *  Since the default compiler implementation is generally not what
+    *  you want (for all but the most simple classes), we usually
+    *  put the declarations of these methods in the private section
+    *  and never implement them. This prevents the compiler from
+    *  implementing an incorrect "default" behavior without us
+    *  knowing. (See Scott Meyers book, "Effective C++")
+    */
+   //@{
+   MyNLP(
+      const MyNLP&
+   );
+
+   MyNLP& operator=(
+      const MyNLP&
+   );
+   //@}
+};
+
+#endif


### PR DESCRIPTION
- Added support for Ipopt library
- Added support for MUMPS linear solver dependency
- Added support for HSL linear solver dependency: 
    Requires manual download due to licensing (free for academic use) 
    Download from: https://licences.stfc.ac.uk/product/coin-hsl 
    Extract to 'coinhsl' directory in HSL source tree HSL provides MA27, MA57, MA77, MA86, MA97 solvers

Re #291