### PR TITLE
ENH: Added qSlicerIpoptOptimizer and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,21 @@ set(EXTENSION_STATUS "Beta")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated list or 'NA' if any
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
 set(EXTENSION_BUILDS_IPOPT OFF)
+set(EXTENSION_HSL_SOURCE_DIR "") # Linux/macOS: path to Coin-HSL source; get from https://licences.stfc.ac.uk/product/coin-hsl
+set(EXTENSION_HSL_DLL_DIR "")   # Windows: path to directory containing libhsl.dll from the same Coin-HSL download
+if(WIN32)
+  if(EXTENSION_HSL_DLL_DIR AND EXISTS "${EXTENSION_HSL_DLL_DIR}")
+    set(EXTENSION_USES_HSL ON)
+  else()
+    set(EXTENSION_USES_HSL OFF)
+  endif()
+else()
+  if(EXTENSION_HSL_SOURCE_DIR AND EXISTS "${EXTENSION_HSL_SOURCE_DIR}")
+    set(EXTENSION_USES_HSL ON)
+  else()
+    set(EXTENSION_USES_HSL OFF)
+  endif()
+endif()
 set(EXTENSION_BUILDS_ADAPTIVE_CPP OFF) # Whether to build AdaptiveCpp external project
 
 set(SUPERBUILD_TOPLEVEL_PROJECT inner)

--- a/ExternalBeamPlanning/CMakeLists.txt
+++ b/ExternalBeamPlanning/CMakeLists.txt
@@ -31,6 +31,19 @@ set(MODULE_INCLUDE_DIRECTORIES
   ${qSlicerBeamsModuleWidgets_INCLUDE_DIRS}
   )
 
+if(EXTENSION_BUILDS_IPOPT)
+  if(WIN32)
+    list(APPEND MODULE_INCLUDE_DIRECTORIES "${Ipopt_INCLUDE_DIR}")
+  else()
+    find_path(_ipopt_inc IpIpoptApplication.hpp
+      PATHS ${Ipopt_DIR}/include/coin-or ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH)
+    if(_ipopt_inc)
+      list(APPEND MODULE_INCLUDE_DIRECTORIES "${_ipopt_inc}")
+    endif()
+  endif()
+endif()
+
 set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.cxx
   qSlicer${MODULE_NAME}Module.h
@@ -78,6 +91,11 @@ slicerMacroBuildLoadableModule(
   )
 
 #-----------------------------------------------------------------------------
-# if(BUILD_TESTING)
-#   add_subdirectory(Testing)
-# endif()
+if(EXTENSION_BUILDS_IPOPT)
+  target_compile_definitions(qSlicer${MODULE_NAME}Module PRIVATE EXTENSION_BUILDS_IPOPT)
+endif()
+
+#-----------------------------------------------------------------------------
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/ExternalBeamPlanning/CMakeLists.txt
+++ b/ExternalBeamPlanning/CMakeLists.txt
@@ -78,6 +78,6 @@ slicerMacroBuildLoadableModule(
   )
 
 #-----------------------------------------------------------------------------
-# if(BUILD_TESTING)
-#   add_subdirectory(Testing)
-# endif()
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/ExternalBeamPlanning/CMakeLists.txt
+++ b/ExternalBeamPlanning/CMakeLists.txt
@@ -31,6 +31,19 @@ set(MODULE_INCLUDE_DIRECTORIES
   ${qSlicerBeamsModuleWidgets_INCLUDE_DIRS}
   )
 
+if(EXTENSION_BUILDS_IPOPT)
+  if(WIN32)
+    list(APPEND MODULE_INCLUDE_DIRECTORIES "${Ipopt_INCLUDE_DIR}")
+  else()
+    find_path(_ipopt_inc IpIpoptApplication.hpp
+      PATHS ${Ipopt_DIR}/include/coin-or ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH)
+    if(_ipopt_inc)
+      list(APPEND MODULE_INCLUDE_DIRECTORIES "${_ipopt_inc}")
+    endif()
+  endif()
+endif()
+
 set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.cxx
   qSlicer${MODULE_NAME}Module.h
@@ -76,6 +89,11 @@ slicerMacroBuildLoadableModule(
   RESOURCES ${MODULE_RESOURCES}
   # WITH_GENERIC_TESTS # TODO: enable this when module directories are properly added in the slicerMacroBuildScriptedModule macro
   )
+
+#-----------------------------------------------------------------------------
+if(EXTENSION_BUILDS_IPOPT)
+  target_compile_definitions(qSlicer${MODULE_NAME}Module PRIVATE EXTENSION_BUILDS_IPOPT)
+endif()
 
 #-----------------------------------------------------------------------------
 if(BUILD_TESTING)

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -505,6 +505,291 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_IpoptAdvancedSettings" native="true">
+     <property name="text" stdset="0">
+      <string>IPOPT Advanced Settings</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_IpoptSettings">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_iter">
+        <property name="text">
+         <string>Max iterations:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_max_iter">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>10000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_cpu_time">
+        <property name="text">
+         <string>Max CPU time (s):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_Ipopt_max_cpu_time">
+        <property name="minimum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>86400.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>60.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>3600.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_Ipopt_tol">
+        <property name="text">
+         <string>NLP tolerance:</string>
+        </property>
+        <property name="toolTip">
+         <string>Overall NLP convergence tolerance (tol). Enter in scientific notation, e.g. 1e-10.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="lineEdit_Ipopt_tol">
+        <property name="text">
+         <string>1e-10</string>
+        </property>
+        <property name="toolTip">
+         <string>Overall NLP convergence tolerance (tol). Enter in scientific notation, e.g. 1e-10.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_Ipopt_acceptable_tol">
+        <property name="text">
+         <string>Acceptable tolerance:</string>
+        </property>
+        <property name="toolTip">
+         <string>Relaxed convergence tolerance used with acceptable_iter (acceptable_tol). Enter in scientific notation, e.g. 1e-06.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="lineEdit_Ipopt_acceptable_tol">
+        <property name="text">
+         <string>1e-06</string>
+        </property>
+        <property name="toolTip">
+         <string>Relaxed convergence tolerance used with acceptable_iter (acceptable_tol). Enter in scientific notation, e.g. 1e-06.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_Ipopt_acceptable_iter">
+        <property name="text">
+         <string>Acceptable iterations:</string>
+        </property>
+        <property name="toolTip">
+         <string>Number of consecutive acceptable-tolerance iterations before declaring convergence (acceptable_iter).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_acceptable_iter">
+        <property name="toolTip">
+         <string>Number of consecutive acceptable-tolerance iterations before declaring convergence (acceptable_iter).</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_Ipopt_mu_strategy">
+        <property name="text">
+         <string>Mu strategy:</string>
+        </property>
+        <property name="toolTip">
+         <string>Barrier parameter update strategy: adaptive (recommended) or monotone (mu_strategy).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_mu_strategy">
+        <property name="toolTip">
+         <string>Barrier parameter update strategy: adaptive (recommended) or monotone (mu_strategy).</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>adaptive</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>monotone</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_Ipopt_hessian_approximation">
+        <property name="text">
+         <string>Hessian approximation:</string>
+        </property>
+        <property name="toolTip">
+         <string>Hessian approximation method: limited-memory L-BFGS (default) or exact second derivatives (hessian_approximation).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_hessian_approximation">
+        <property name="toolTip">
+         <string>Hessian approximation method: limited-memory L-BFGS (default) or exact second derivatives (hessian_approximation).</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>limited-memory</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>exact</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_Ipopt_lbfgs_history">
+        <property name="text">
+         <string>L-BFGS history size:</string>
+        </property>
+        <property name="toolTip">
+         <string>Number of past iterates kept in L-BFGS memory (limited_memory_max_history). Only used when hessian_approximation is limited-memory.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_lbfgs_history">
+        <property name="toolTip">
+         <string>Number of past iterates kept in L-BFGS memory (limited_memory_max_history). Only used when hessian_approximation is limited-memory.</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_resto_iter">
+        <property name="text">
+         <string>Max restoration iterations:</string>
+        </property>
+        <property name="toolTip">
+         <string>Maximum number of iterations in the restoration phase (max_resto_iter).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_max_resto_iter">
+        <property name="toolTip">
+         <string>Maximum number of iterations in the restoration phase (max_resto_iter).</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>2000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_Ipopt_print_level">
+        <property name="text">
+         <string>Print level:</string>
+        </property>
+        <property name="toolTip">
+         <string>IPOPT output verbosity: 0 = silent, 5 = default, 12 = maximum (print_level).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_print_level">
+        <property name="toolTip">
+         <string>IPOPT output verbosity: 0 = silent, 5 = default, 12 = maximum (print_level).</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>12</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_Ipopt_linear_solver">
+        <property name="text">
+         <string>Linear solver:</string>
+        </property>
+        <property name="toolTip">
+         <string>Linear solver used for IPOPT interior-point steps (linear_solver). Available solvers depend on the build.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_linear_solver">
+        <property name="toolTip">
+         <string>Linear solver used for IPOPT interior-point steps (linear_solver). Available solvers depend on the build.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="CollapsibleButton_Output" native="true">
      <property name="text" stdset="0">
       <string>Output</string>

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -515,6 +515,291 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_IpoptAdvancedSettings" native="true">
+     <property name="text" stdset="0">
+      <string>IPOPT Advanced Settings</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_IpoptSettings">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_iter">
+        <property name="text">
+         <string>Max iterations:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_max_iter">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>10000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_cpu_time">
+        <property name="text">
+         <string>Max CPU time (s):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_Ipopt_max_cpu_time">
+        <property name="minimum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>86400.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>60.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>3600.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_Ipopt_tol">
+        <property name="text">
+         <string>NLP tolerance:</string>
+        </property>
+        <property name="toolTip">
+         <string>Overall NLP convergence tolerance (tol). Enter in scientific notation, e.g. 1e-10.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="lineEdit_Ipopt_tol">
+        <property name="text">
+         <string>1e-10</string>
+        </property>
+        <property name="toolTip">
+         <string>Overall NLP convergence tolerance (tol). Enter in scientific notation, e.g. 1e-10.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_Ipopt_acceptable_tol">
+        <property name="text">
+         <string>Acceptable tolerance:</string>
+        </property>
+        <property name="toolTip">
+         <string>Relaxed convergence tolerance used with acceptable_iter (acceptable_tol). Enter in scientific notation, e.g. 1e-06.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="lineEdit_Ipopt_acceptable_tol">
+        <property name="text">
+         <string>1e-06</string>
+        </property>
+        <property name="toolTip">
+         <string>Relaxed convergence tolerance used with acceptable_iter (acceptable_tol). Enter in scientific notation, e.g. 1e-06.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_Ipopt_acceptable_iter">
+        <property name="text">
+         <string>Acceptable iterations:</string>
+        </property>
+        <property name="toolTip">
+         <string>Number of consecutive acceptable-tolerance iterations before declaring convergence (acceptable_iter).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_acceptable_iter">
+        <property name="toolTip">
+         <string>Number of consecutive acceptable-tolerance iterations before declaring convergence (acceptable_iter).</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_Ipopt_mu_strategy">
+        <property name="text">
+         <string>Mu strategy:</string>
+        </property>
+        <property name="toolTip">
+         <string>Barrier parameter update strategy: adaptive (recommended) or monotone (mu_strategy).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_mu_strategy">
+        <property name="toolTip">
+         <string>Barrier parameter update strategy: adaptive (recommended) or monotone (mu_strategy).</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>adaptive</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>monotone</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_Ipopt_hessian_approximation">
+        <property name="text">
+         <string>Hessian approximation:</string>
+        </property>
+        <property name="toolTip">
+         <string>Hessian approximation method: limited-memory L-BFGS (default) or exact second derivatives (hessian_approximation).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_hessian_approximation">
+        <property name="toolTip">
+         <string>Hessian approximation method: limited-memory L-BFGS (default) or exact second derivatives (hessian_approximation).</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>limited-memory</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>exact</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_Ipopt_lbfgs_history">
+        <property name="text">
+         <string>L-BFGS history size:</string>
+        </property>
+        <property name="toolTip">
+         <string>Number of past iterates kept in L-BFGS memory (limited_memory_max_history). Only used when hessian_approximation is limited-memory.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_lbfgs_history">
+        <property name="toolTip">
+         <string>Number of past iterates kept in L-BFGS memory (limited_memory_max_history). Only used when hessian_approximation is limited-memory.</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_Ipopt_max_resto_iter">
+        <property name="text">
+         <string>Max restoration iterations:</string>
+        </property>
+        <property name="toolTip">
+         <string>Maximum number of iterations in the restoration phase (max_resto_iter).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_max_resto_iter">
+        <property name="toolTip">
+         <string>Maximum number of iterations in the restoration phase (max_resto_iter).</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>2000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_Ipopt_print_level">
+        <property name="text">
+         <string>Print level:</string>
+        </property>
+        <property name="toolTip">
+         <string>IPOPT output verbosity: 0 = silent, 5 = default, 12 = maximum (print_level).</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="spinBox_Ipopt_print_level">
+        <property name="toolTip">
+         <string>IPOPT output verbosity: 0 = silent, 5 = default, 12 = maximum (print_level).</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>12</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_Ipopt_linear_solver">
+        <property name="text">
+         <string>Linear solver:</string>
+        </property>
+        <property name="toolTip">
+         <string>Linear solver used for IPOPT interior-point steps (linear_solver). Available solvers depend on the build.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QComboBox" name="comboBox_Ipopt_linear_solver">
+        <property name="toolTip">
+         <string>Linear solver used for IPOPT interior-point steps (linear_solver). Available solvers depend on the build.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="CollapsibleButton_Output" native="true">
      <property name="text" stdset="0">
       <string>Output</string>

--- a/ExternalBeamPlanning/Testing/CMakeLists.txt
+++ b/ExternalBeamPlanning/Testing/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(EXTENSION_BUILDS_IPOPT)
+  add_subdirectory(Cxx)
+endif()

--- a/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
+++ b/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Only build qSlicerIpoptOptimizer test if IPOPT is enabled
+if(EXTENSION_BUILDS_IPOPT)
+
+  if(WIN32)
+    set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
+  else()
+    find_path(IPOPT_INCLUDE_DIRS
+      NAMES IpIpoptApplication.hpp
+      PATHS
+        ${Ipopt_DIR}/include/coin-or
+        ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_INCLUDE_DIRS)
+    # Link against the full widgets library instead of compiling the .cxx directly.
+    # qSlicerIpoptOptimizer now inherits qSlicerAbstractPlanOptimizer which pulls in
+    # VTK/Slicer/MRML headers that a standalone compilation cannot resolve.
+    add_executable(qSlicerIpoptOptimizerTest qSlicerIpoptOptimizerTest.cxx)
+    set_target_properties(qSlicerIpoptOptimizerTest PROPERTIES AUTOMOC ON)
+
+    target_include_directories(qSlicerIpoptOptimizerTest PRIVATE
+      ${IPOPT_INCLUDE_DIRS}
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets
+      ${CMAKE_BINARY_DIR}/ExternalBeamPlanning/Widgets
+    )
+
+    # qSlicerExternalBeamPlanningModuleWidgets already links IPOPT transitively.
+    target_link_libraries(qSlicerIpoptOptimizerTest
+      qSlicerExternalBeamPlanningModuleWidgets
+      Qt5::Core
+    )
+
+    if(WIN32 AND DEFINED Ipopt_DLL_DIR)
+      file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
+      foreach(DLL_FILE ${IPOPT_DLLS})
+        add_custom_command(TARGET qSlicerIpoptOptimizerTest POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DLL_FILE}"
+            "$<TARGET_FILE_DIR:qSlicerIpoptOptimizerTest>"
+        )
+      endforeach()
+    endif()
+
+    add_test(
+      NAME qSlicerIpoptOptimizerBasicTest
+      COMMAND ${Slicer_LAUNCH_COMMAND} $<TARGET_FILE:qSlicerIpoptOptimizerTest>
+    )
+
+    set_tests_properties(qSlicerIpoptOptimizerBasicTest PROPERTIES
+      TIMEOUT 120
+      LABELS "IPOPT;ExternalBeamPlanning;Optimization"
+    )
+
+  else()
+    message(WARNING "IPOPT include dirs not found. Cannot build qSlicerIpoptOptimizer test.")
+  endif()
+
+else()
+  message(STATUS "IPOPT support disabled. Skipping qSlicerIpoptOptimizer test.")
+endif()

--- a/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
+++ b/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
@@ -1,20 +1,9 @@
 # Only build qSlicerIpoptOptimizer test if IPOPT is enabled
 if(EXTENSION_BUILDS_IPOPT)
-  # qSlicerIpoptOptimizer test executable
-  set(IPOPT_OPTIMIZER_TEST_SRCS
-    qSlicerIpoptOptimizerTest.cxx
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets/qSlicerIpoptOptimizer.cxx
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets/qSlicerIpoptOptimizer.h
-  )
 
-  # Find IPOPT installation (same pattern as main Testing/Cxx)
   if(WIN32)
-    # Windows uses prebuilt binaries
     set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
-    set(IPOPT_LIBRARIES "${Ipopt_LIBRARY_DIR}/ipopt.dll.lib")
-    set(IPOPT_DLL "${Ipopt_DLL}")
   else()
-    # Unix systems use built libraries
     find_path(IPOPT_INCLUDE_DIRS
       NAMES IpIpoptApplication.hpp
       PATHS
@@ -22,103 +11,28 @@ if(EXTENSION_BUILDS_IPOPT)
         ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
       NO_DEFAULT_PATH
     )
-
-    find_library(IPOPT_LIBRARIES
-      NAMES ipopt libipopt
-      PATHS
-        ${Ipopt_DIR}/lib
-        ${CMAKE_BINARY_DIR}/Ipopt-install/lib
-      NO_DEFAULT_PATH
-    )
   endif()
 
-  if(IPOPT_INCLUDE_DIRS AND IPOPT_LIBRARIES)
-    # Create the test executable
-    add_executable(qSlicerIpoptOptimizerTest ${IPOPT_OPTIMIZER_TEST_SRCS})
+  if(IPOPT_INCLUDE_DIRS)
+    # Link against the full widgets library instead of compiling the .cxx directly.
+    # qSlicerIpoptOptimizer now inherits qSlicerAbstractPlanOptimizer which pulls in
+    # VTK/Slicer/MRML headers that a standalone compilation cannot resolve.
+    add_executable(qSlicerIpoptOptimizerTest qSlicerIpoptOptimizerTest.cxx)
     set_target_properties(qSlicerIpoptOptimizerTest PROPERTIES AUTOMOC ON)
 
-    # Set include directories
     target_include_directories(qSlicerIpoptOptimizerTest PRIVATE
       ${IPOPT_INCLUDE_DIRS}
       ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets
       ${CMAKE_BINARY_DIR}/ExternalBeamPlanning/Widgets
     )
 
-    # Neutralize dllimport so qSlicerIpoptOptimizer compiles standalone
-    target_compile_definitions(qSlicerIpoptOptimizerTest PRIVATE
-      qSlicerExternalBeamPlanningModuleWidgets_STATIC
-    )
-
-    # Link libraries
+    # qSlicerExternalBeamPlanningModuleWidgets already links IPOPT transitively.
     target_link_libraries(qSlicerIpoptOptimizerTest
-      ${IPOPT_LIBRARIES}
+      qSlicerExternalBeamPlanningModuleWidgets
       Qt5::Core
     )
 
-    # Add additional system libraries that Ipopt might need on Unix
-    if(UNIX)
-      # Link Fortran runtime and METIS with explicit linker flags
-      target_link_options(qSlicerIpoptOptimizerTest PRIVATE "-Wl,--no-as-needed")
-      target_link_libraries(qSlicerIpoptOptimizerTest gfortran quadmath gcc_s metis)
-
-      # Find and link all required dependencies
-      set(IPOPT_DEPS)
-
-      # System math libraries
-      find_library(DL_LIBRARY dl)
-      if(DL_LIBRARY)
-        list(APPEND IPOPT_DEPS ${DL_LIBRARY})
-      endif()
-
-      find_library(M_LIBRARY m)
-      if(M_LIBRARY)
-        list(APPEND IPOPT_DEPS ${M_LIBRARY})
-      endif()
-
-      # BLAS/LAPACK libraries
-      find_library(LAPACK_LIBRARY lapack)
-      if(LAPACK_LIBRARY)
-        list(APPEND IPOPT_DEPS ${LAPACK_LIBRARY})
-      endif()
-
-      find_library(BLAS_LIBRARY blas)
-      if(BLAS_LIBRARY)
-        list(APPEND IPOPT_DEPS ${BLAS_LIBRARY})
-      endif()
-
-      # MUMPS library (coinmumps is the COIN-OR wrapped version)
-      find_library(MUMPS_LIBRARY
-        NAMES coinmumps libcoinmumps
-        PATHS
-          ${CMAKE_BINARY_DIR}/Mumps-install/lib
-          ${Mumps_DIR}/lib
-        NO_DEFAULT_PATH
-      )
-      if(MUMPS_LIBRARY)
-        list(APPEND IPOPT_DEPS ${MUMPS_LIBRARY})
-      endif()
-
-      # Link all dependencies
-      if(IPOPT_DEPS)
-        target_link_libraries(qSlicerIpoptOptimizerTest ${IPOPT_DEPS})
-      endif()
-    endif()
-
-    # Add the test to CTest
-    add_test(
-      NAME qSlicerIpoptOptimizerBasicTest
-      COMMAND qSlicerIpoptOptimizerTest
-    )
-
-    # Set test properties
-    set_tests_properties(qSlicerIpoptOptimizerBasicTest PROPERTIES
-      TIMEOUT 120
-      LABELS "IPOPT;ExternalBeamPlanning;Optimization"
-      ENVIRONMENT "PATH=${Qt5_DIR}/../../../bin\;$ENV{PATH}"
-    )
-
-    if(WIN32 AND IPOPT_DLL)
-      # Copy Ipopt DLLs to the test output directory
+    if(WIN32 AND DEFINED Ipopt_DLL_DIR)
       file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
       foreach(DLL_FILE ${IPOPT_DLLS})
         add_custom_command(TARGET qSlicerIpoptOptimizerTest POST_BUILD
@@ -128,9 +42,21 @@ if(EXTENSION_BUILDS_IPOPT)
         )
       endforeach()
     endif()
+
+    add_test(
+      NAME qSlicerIpoptOptimizerBasicTest
+      COMMAND ${Slicer_LAUNCH_COMMAND} $<TARGET_FILE:qSlicerIpoptOptimizerTest>
+    )
+
+    set_tests_properties(qSlicerIpoptOptimizerBasicTest PROPERTIES
+      TIMEOUT 120
+      LABELS "IPOPT;ExternalBeamPlanning;Optimization"
+    )
+
   else()
-    message(WARNING "IPOPT libraries not found. Cannot build qSlicerIpoptOptimizer test.")
+    message(WARNING "IPOPT include dirs not found. Cannot build qSlicerIpoptOptimizer test.")
   endif()
+
 else()
   message(STATUS "IPOPT support disabled. Skipping qSlicerIpoptOptimizer test.")
 endif()

--- a/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
+++ b/ExternalBeamPlanning/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,136 @@
+# Only build qSlicerIpoptOptimizer test if IPOPT is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  # qSlicerIpoptOptimizer test executable
+  set(IPOPT_OPTIMIZER_TEST_SRCS
+    qSlicerIpoptOptimizerTest.cxx
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets/qSlicerIpoptOptimizer.cxx
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets/qSlicerIpoptOptimizer.h
+  )
+
+  # Find IPOPT installation (same pattern as main Testing/Cxx)
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
+    set(IPOPT_LIBRARIES "${Ipopt_LIBRARY_DIR}/ipopt.dll.lib")
+    set(IPOPT_DLL "${Ipopt_DLL}")
+  else()
+    # Unix systems use built libraries
+    find_path(IPOPT_INCLUDE_DIRS
+      NAMES IpIpoptApplication.hpp
+      PATHS
+        ${Ipopt_DIR}/include/coin-or
+        ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH
+    )
+
+    find_library(IPOPT_LIBRARIES
+      NAMES ipopt libipopt
+      PATHS
+        ${Ipopt_DIR}/lib
+        ${CMAKE_BINARY_DIR}/Ipopt-install/lib
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_INCLUDE_DIRS AND IPOPT_LIBRARIES)
+    # Create the test executable
+    add_executable(qSlicerIpoptOptimizerTest ${IPOPT_OPTIMIZER_TEST_SRCS})
+    set_target_properties(qSlicerIpoptOptimizerTest PROPERTIES AUTOMOC ON)
+
+    # Set include directories
+    target_include_directories(qSlicerIpoptOptimizerTest PRIVATE
+      ${IPOPT_INCLUDE_DIRS}
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../Widgets
+      ${CMAKE_BINARY_DIR}/ExternalBeamPlanning/Widgets
+    )
+
+    # Neutralize dllimport so qSlicerIpoptOptimizer compiles standalone
+    target_compile_definitions(qSlicerIpoptOptimizerTest PRIVATE
+      qSlicerExternalBeamPlanningModuleWidgets_STATIC
+    )
+
+    # Link libraries
+    target_link_libraries(qSlicerIpoptOptimizerTest
+      ${IPOPT_LIBRARIES}
+      Qt5::Core
+    )
+
+    # Add additional system libraries that Ipopt might need on Unix
+    if(UNIX)
+      # Link Fortran runtime and METIS with explicit linker flags
+      target_link_options(qSlicerIpoptOptimizerTest PRIVATE "-Wl,--no-as-needed")
+      target_link_libraries(qSlicerIpoptOptimizerTest gfortran quadmath gcc_s metis)
+
+      # Find and link all required dependencies
+      set(IPOPT_DEPS)
+
+      # System math libraries
+      find_library(DL_LIBRARY dl)
+      if(DL_LIBRARY)
+        list(APPEND IPOPT_DEPS ${DL_LIBRARY})
+      endif()
+
+      find_library(M_LIBRARY m)
+      if(M_LIBRARY)
+        list(APPEND IPOPT_DEPS ${M_LIBRARY})
+      endif()
+
+      # BLAS/LAPACK libraries
+      find_library(LAPACK_LIBRARY lapack)
+      if(LAPACK_LIBRARY)
+        list(APPEND IPOPT_DEPS ${LAPACK_LIBRARY})
+      endif()
+
+      find_library(BLAS_LIBRARY blas)
+      if(BLAS_LIBRARY)
+        list(APPEND IPOPT_DEPS ${BLAS_LIBRARY})
+      endif()
+
+      # MUMPS library (coinmumps is the COIN-OR wrapped version)
+      find_library(MUMPS_LIBRARY
+        NAMES coinmumps libcoinmumps
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+        NO_DEFAULT_PATH
+      )
+      if(MUMPS_LIBRARY)
+        list(APPEND IPOPT_DEPS ${MUMPS_LIBRARY})
+      endif()
+
+      # Link all dependencies
+      if(IPOPT_DEPS)
+        target_link_libraries(qSlicerIpoptOptimizerTest ${IPOPT_DEPS})
+      endif()
+    endif()
+
+    # Add the test to CTest
+    add_test(
+      NAME qSlicerIpoptOptimizerBasicTest
+      COMMAND qSlicerIpoptOptimizerTest
+    )
+
+    # Set test properties
+    set_tests_properties(qSlicerIpoptOptimizerBasicTest PROPERTIES
+      TIMEOUT 120
+      LABELS "IPOPT;ExternalBeamPlanning;Optimization"
+      ENVIRONMENT "PATH=${Qt5_DIR}/../../../bin\;$ENV{PATH}"
+    )
+
+    if(WIN32 AND IPOPT_DLL)
+      # Copy Ipopt DLLs to the test output directory
+      file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
+      foreach(DLL_FILE ${IPOPT_DLLS})
+        add_custom_command(TARGET qSlicerIpoptOptimizerTest POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DLL_FILE}"
+            "$<TARGET_FILE_DIR:qSlicerIpoptOptimizerTest>"
+        )
+      endforeach()
+    endif()
+  else()
+    message(WARNING "IPOPT libraries not found. Cannot build qSlicerIpoptOptimizer test.")
+  endif()
+else()
+  message(STATUS "IPOPT support disabled. Skipping qSlicerIpoptOptimizer test.")
+endif()

--- a/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
+++ b/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
@@ -1,0 +1,116 @@
+#include "../../Widgets/qSlicerIpoptOptimizer.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <iostream>
+#include <cmath>
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    std::cout << "Testing qSlicerIpoptOptimizer..." << std::endl;
+
+    // Create optimizer
+    qSlicerIpoptOptimizer optimizer;
+
+    // Test 1: Simple quadratic function - minimize (x-2)^2 + (y-1)^2
+    std::cout << "\n=== Test 1: Simple Quadratic Optimization ===" << std::endl;
+
+    auto objective = [](const qSlicerIpoptOptimizer::Array& x) -> double {
+        return (x[0] - 2.0) * (x[0] - 2.0) + (x[1] - 1.0) * (x[1] - 1.0);
+    };
+
+    auto gradient = [](const qSlicerIpoptOptimizer::Array& x) -> qSlicerIpoptOptimizer::Array {
+        qSlicerIpoptOptimizer::Array grad(2);
+        grad[0] = 2.0 * (x[0] - 2.0);  // d/dx
+        grad[1] = 2.0 * (x[1] - 1.0);  // d/dy
+        return grad;
+    };
+
+    optimizer.setObjectiveFunction(objective);
+    optimizer.setGradientFunction(gradient);
+
+    // Set stricter tolerance for testing
+    optimizer.setAbsoluteObjectiveTolerance(1e-8);
+    optimizer.setMaxIterations(100);
+
+    // Starting point
+    qSlicerIpoptOptimizer::Array x0 = {0.0, 0.0};
+
+    // Solve
+    auto result = optimizer.solveProblem(x0);
+
+    // Check results
+    if (result.success) {
+        std::cout << "✓ Optimization succeeded!" << std::endl;
+        std::cout << "  Solution: [" << result.solution[0] << ", " << result.solution[1] << "]" << std::endl;
+        std::cout << "  Expected: [2.0, 1.0]" << std::endl;
+        std::cout << "  Final objective: " << result.final_objective_value << std::endl;
+        std::cout << "  Iterations: " << result.iteration_count << std::endl;
+
+        // Verify solution accuracy
+        double error_x = std::abs(result.solution[0] - 2.0);
+        double error_y = std::abs(result.solution[1] - 1.0);
+        double max_error = std::max(error_x, error_y);
+
+        if (max_error < 1e-6) {
+            std::cout << "✓ Solution accuracy test passed (error: " << max_error << ")" << std::endl;
+        } else {
+            std::cout << "✗ Solution accuracy test failed (error: " << max_error << ")" << std::endl;
+            return 1;
+        }
+    } else {
+        std::cout << "✗ Optimization failed with status: " << result.status << std::endl;
+        return 1;
+    }
+
+    // Test 2: Rosenbrock function - minimize (1-x)^2 + 100*(y-x^2)^2
+    std::cout << "\n=== Test 2: Rosenbrock Function ===" << std::endl;
+
+    auto rosenbrock_obj = [](const qSlicerIpoptOptimizer::Array& x) -> double {
+        return (1.0 - x[0]) * (1.0 - x[0]) + 100.0 * (x[1] - x[0]*x[0]) * (x[1] - x[0]*x[0]);
+    };
+
+    auto rosenbrock_grad = [](const qSlicerIpoptOptimizer::Array& x) -> qSlicerIpoptOptimizer::Array {
+        qSlicerIpoptOptimizer::Array grad(2);
+        grad[0] = -2.0 * (1.0 - x[0]) - 400.0 * x[0] * (x[1] - x[0]*x[0]);
+        grad[1] = 200.0 * (x[1] - x[0]*x[0]);
+        return grad;
+    };
+
+    optimizer.setObjectiveFunction(rosenbrock_obj);
+    optimizer.setGradientFunction(rosenbrock_grad);
+    optimizer.setMaxIterations(1000);
+
+    // Starting point for Rosenbrock
+    qSlicerIpoptOptimizer::Array x0_rb = {-1.2, 1.0};
+
+    auto result_rb = optimizer.solveProblem(x0_rb);
+
+    if (result_rb.success) {
+        std::cout << "✓ Rosenbrock optimization succeeded!" << std::endl;
+        std::cout << "  Solution: [" << result_rb.solution[0] << ", " << result_rb.solution[1] << "]" << std::endl;
+        std::cout << "  Expected: [1.0, 1.0]" << std::endl;
+        std::cout << "  Final objective: " << result_rb.final_objective_value << std::endl;
+        std::cout << "  Iterations: " << result_rb.iteration_count << std::endl;
+
+        // Verify solution (Rosenbrock is harder, so allow larger tolerance)
+        double error_x = std::abs(result_rb.solution[0] - 1.0);
+        double error_y = std::abs(result_rb.solution[1] - 1.0);
+        double max_error = std::max(error_x, error_y);
+
+        if (max_error < 1e-3) {
+            std::cout << "✓ Rosenbrock accuracy test passed (error: " << max_error << ")" << std::endl;
+        } else {
+            std::cout << "✗ Rosenbrock accuracy test failed (error: " << max_error << ")" << std::endl;
+            return 1;
+        }
+    } else {
+        std::cout << "✗ Rosenbrock optimization failed with status: " << result_rb.status << std::endl;
+        return 1;
+    }
+
+    std::cout << "\n✓ All tests passed successfully!" << std::endl;
+    return 0;
+}

--- a/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
+++ b/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
@@ -110,6 +110,7 @@ int main(int argc, char* argv[])
         std::cout << "✗ Rosenbrock optimization failed with status: " << result_rb.status << std::endl;
         return 1;
     }
+    // For a more advanced interactive test with proton patients, please check out https://github.com/SebastiaanBreedveld/TROTS/tree/master/SlicerRT_import
 
     std::cout << "\n✓ All tests passed successfully!" << std::endl;
     return 0;

--- a/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
+++ b/ExternalBeamPlanning/Testing/Cxx/qSlicerIpoptOptimizerTest.cxx
@@ -1,0 +1,117 @@
+#include "../../Widgets/qSlicerIpoptOptimizer.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <iostream>
+#include <cmath>
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    std::cout << "Testing qSlicerIpoptOptimizer..." << std::endl;
+
+    // Create optimizer
+    qSlicerIpoptOptimizer optimizer;
+
+    // Test 1: Simple quadratic function - minimize (x-2)^2 + (y-1)^2
+    std::cout << "\n=== Test 1: Simple Quadratic Optimization ===" << std::endl;
+
+    auto objective = [](const qSlicerIpoptOptimizer::Array& x) -> double {
+        return (x[0] - 2.0) * (x[0] - 2.0) + (x[1] - 1.0) * (x[1] - 1.0);
+    };
+
+    auto gradient = [](const qSlicerIpoptOptimizer::Array& x) -> qSlicerIpoptOptimizer::Array {
+        qSlicerIpoptOptimizer::Array grad(2);
+        grad[0] = 2.0 * (x[0] - 2.0);  // d/dx
+        grad[1] = 2.0 * (x[1] - 1.0);  // d/dy
+        return grad;
+    };
+
+    optimizer.setObjectiveFunction(objective);
+    optimizer.setGradientFunction(gradient);
+
+    // Set stricter tolerance for testing
+    optimizer.setAbsoluteObjectiveTolerance(1e-8);
+    optimizer.setMaxIterations(100);
+
+    // Starting point
+    qSlicerIpoptOptimizer::Array x0 = {0.0, 0.0};
+
+    // Solve
+    auto result = optimizer.solveProblem(x0);
+
+    // Check results
+    if (result.success) {
+        std::cout << "✓ Optimization succeeded!" << std::endl;
+        std::cout << "  Solution: [" << result.solution[0] << ", " << result.solution[1] << "]" << std::endl;
+        std::cout << "  Expected: [2.0, 1.0]" << std::endl;
+        std::cout << "  Final objective: " << result.final_objective_value << std::endl;
+        std::cout << "  Iterations: " << result.iteration_count << std::endl;
+
+        // Verify solution accuracy
+        double error_x = std::abs(result.solution[0] - 2.0);
+        double error_y = std::abs(result.solution[1] - 1.0);
+        double max_error = std::max(error_x, error_y);
+
+        if (max_error < 1e-6) {
+            std::cout << "✓ Solution accuracy test passed (error: " << max_error << ")" << std::endl;
+        } else {
+            std::cout << "✗ Solution accuracy test failed (error: " << max_error << ")" << std::endl;
+            return 1;
+        }
+    } else {
+        std::cout << "✗ Optimization failed with status: " << result.status << std::endl;
+        return 1;
+    }
+
+    // Test 2: Rosenbrock function - minimize (1-x)^2 + 100*(y-x^2)^2
+    std::cout << "\n=== Test 2: Rosenbrock Function ===" << std::endl;
+
+    auto rosenbrock_obj = [](const qSlicerIpoptOptimizer::Array& x) -> double {
+        return (1.0 - x[0]) * (1.0 - x[0]) + 100.0 * (x[1] - x[0]*x[0]) * (x[1] - x[0]*x[0]);
+    };
+
+    auto rosenbrock_grad = [](const qSlicerIpoptOptimizer::Array& x) -> qSlicerIpoptOptimizer::Array {
+        qSlicerIpoptOptimizer::Array grad(2);
+        grad[0] = -2.0 * (1.0 - x[0]) - 400.0 * x[0] * (x[1] - x[0]*x[0]);
+        grad[1] = 200.0 * (x[1] - x[0]*x[0]);
+        return grad;
+    };
+
+    optimizer.setObjectiveFunction(rosenbrock_obj);
+    optimizer.setGradientFunction(rosenbrock_grad);
+    optimizer.setMaxIterations(1000);
+
+    // Starting point for Rosenbrock
+    qSlicerIpoptOptimizer::Array x0_rb = {-1.2, 1.0};
+
+    auto result_rb = optimizer.solveProblem(x0_rb);
+
+    if (result_rb.success) {
+        std::cout << "✓ Rosenbrock optimization succeeded!" << std::endl;
+        std::cout << "  Solution: [" << result_rb.solution[0] << ", " << result_rb.solution[1] << "]" << std::endl;
+        std::cout << "  Expected: [1.0, 1.0]" << std::endl;
+        std::cout << "  Final objective: " << result_rb.final_objective_value << std::endl;
+        std::cout << "  Iterations: " << result_rb.iteration_count << std::endl;
+
+        // Verify solution (Rosenbrock is harder, so allow larger tolerance)
+        double error_x = std::abs(result_rb.solution[0] - 1.0);
+        double error_y = std::abs(result_rb.solution[1] - 1.0);
+        double max_error = std::max(error_x, error_y);
+
+        if (max_error < 1e-3) {
+            std::cout << "✓ Rosenbrock accuracy test passed (error: " << max_error << ")" << std::endl;
+        } else {
+            std::cout << "✗ Rosenbrock accuracy test failed (error: " << max_error << ")" << std::endl;
+            return 1;
+        }
+    } else {
+        std::cout << "✗ Rosenbrock optimization failed with status: " << result_rb.status << std::endl;
+        return 1;
+    }
+    // For a more advanced interactive test with proton patients, please check out https://github.com/SebastiaanBreedveld/TROTS/tree/master/SlicerRT_import
+
+    std::cout << "\n✓ All tests passed successfully!" << std::endl;
+    return 0;
+}

--- a/ExternalBeamPlanning/Widgets/CMakeLists.txt
+++ b/ExternalBeamPlanning/Widgets/CMakeLists.txt
@@ -14,6 +14,28 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${qSlicerBeamsModuleWidgets_INCLUDE_DIRS}
   )
 
+# Add IPOPT include directories if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  # Find IPOPT installation
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
+  else()
+    # Unix systems use built libraries
+    find_path(IPOPT_INCLUDE_DIRS
+      NAMES IpIpoptApplication.hpp
+      PATHS
+        ${Ipopt_DIR}/include/coin-or
+        ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_INCLUDE_DIRS)
+    list(APPEND ${KIT}_INCLUDE_DIRECTORIES ${IPOPT_INCLUDE_DIRS})
+  endif()
+endif()
+
 set(${KIT}_SRCS
   # Dose engines
   qSlicerAbstractDoseEngine.cxx
@@ -51,6 +73,14 @@ set(${KIT}_SRCS
   qMRMLObjectivesTableWidget.h
   )
 
+# Add IPOPT optimizer sources if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  list(APPEND ${KIT}_SRCS
+    qSlicerIpoptOptimizer.cxx
+    qSlicerIpoptOptimizer.h
+    )
+endif()
+
 set(${KIT}_UI_SRCS
   )
 
@@ -81,6 +111,13 @@ set(${KIT}_MOC_SRCS
   qMRMLObjectivesTableWidget.h
 )
 
+# Add IPOPT optimizer to MOC sources if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  list(APPEND ${KIT}_MOC_SRCS
+    qSlicerIpoptOptimizer.h
+    )
+endif()
+
 set(${KIT}_UI_SRCS
   UI/qMRMLObjectivesTableWidget.ui
   )
@@ -101,6 +138,78 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicerExternalBeamPlanningModuleMRML
   qSlicerBeamsModuleWidgets
   )
+
+# Add IPOPT libraries if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_LIBRARIES "${Ipopt_LIBRARY_DIR}/ipopt.dll.lib")
+  else()
+    # Unix systems use built libraries
+    find_library(IPOPT_LIBRARIES
+      NAMES ipopt libipopt
+      PATHS
+        ${Ipopt_DIR}/lib
+        ${CMAKE_BINARY_DIR}/Ipopt-install/lib
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_LIBRARIES)
+    list(APPEND ${KIT}_TARGET_LIBRARIES ${IPOPT_LIBRARIES})
+
+    # Add additional system libraries that IPOPT might need on Unix
+    if(UNIX)
+      list(APPEND ${KIT}_TARGET_LIBRARIES gfortran quadmath gcc_s)
+
+      # Find and link required dependencies
+      find_library(DL_LIBRARY dl)
+      if(DL_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${DL_LIBRARY})
+      endif()
+
+      find_library(M_LIBRARY m)
+      if(M_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${M_LIBRARY})
+      endif()
+
+      # MUMPS library (coinmumps is the COIN-OR wrapped version)
+      find_library(MUMPS_LIBRARY
+        NAMES coinmumps libcoinmumps
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+        NO_DEFAULT_PATH
+      )
+      if(MUMPS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${MUMPS_LIBRARY})
+      endif()
+
+      # Also need METIS (required by MUMPS)
+      find_library(METIS_LIBRARY
+        NAMES metis libmetis
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+        NO_DEFAULT_PATH
+      )
+      if(METIS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${METIS_LIBRARY})
+      endif()
+
+      # BLAS and LAPACK (required by MUMPS)
+      find_library(LAPACK_LIBRARY lapack)
+      if(LAPACK_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${LAPACK_LIBRARY})
+      endif()
+
+      find_library(BLAS_LIBRARY blas)
+      if(BLAS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${BLAS_LIBRARY})
+      endif()
+    endif()
+  endif()
+endif()
 
 set(${KIT}_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ExternalBeamPlanning/Widgets/CMakeLists.txt
+++ b/ExternalBeamPlanning/Widgets/CMakeLists.txt
@@ -68,6 +68,30 @@ set(${KIT}_SRCS
   qSlicerObjectiveLogic.h
   qSlicerSquaredDeviationObjective.cxx
   qSlicerSquaredDeviationObjective.h
+  qSlicerSquaredOverdosingObjective.cxx
+  qSlicerSquaredOverdosingObjective.h
+  qSlicerSquaredUnderdosingObjective.cxx
+  qSlicerSquaredUnderdosingObjective.h
+  qSlicerMeanDoseObjective.cxx
+  qSlicerMeanDoseObjective.h
+  qSlicerEUDObjective.cxx
+  qSlicerEUDObjective.h
+  qSlicerMaxDVHObjective.cxx
+  qSlicerMaxDVHObjective.h
+  qSlicerMinDVHObjective.cxx
+  qSlicerMinDVHObjective.h
+  qSlicerDVHUtils.h
+  # Constraints
+  qSlicerAbstractConstraint.cxx
+  qSlicerAbstractConstraint.h
+  qSlicerMinMaxDoseConstraint.cxx
+  qSlicerMinMaxDoseConstraint.h
+  qSlicerMinMaxDVHConstraint.cxx
+  qSlicerMinMaxDVHConstraint.h
+  qSlicerMinMaxEUDConstraint.cxx
+  qSlicerMinMaxEUDConstraint.h
+  qSlicerMinMaxMeanDoseConstraint.cxx
+  qSlicerMinMaxMeanDoseConstraint.h
   # Widgets
   qMRMLObjectivesTableWidget.cxx
   qMRMLObjectivesTableWidget.h
@@ -90,6 +114,7 @@ set_source_files_properties(
   qSlicerAbstractDoseEngine.h
   qSlicerAbstractPlanOptimizer.h
   qSlicerAbstractObjective.h
+  qSlicerAbstractConstraint.h
   WRAP_EXCLUDE
   )
 
@@ -108,6 +133,17 @@ set(${KIT}_MOC_SRCS
   qSlicerObjectivePluginHandler.h
   qSlicerObjectiveLogic.h
   qSlicerSquaredDeviationObjective.h
+  qSlicerSquaredOverdosingObjective.h
+  qSlicerSquaredUnderdosingObjective.h
+  qSlicerMeanDoseObjective.h
+  qSlicerEUDObjective.h
+  qSlicerMaxDVHObjective.h
+  qSlicerMinDVHObjective.h
+  qSlicerAbstractConstraint.h
+  qSlicerMinMaxDoseConstraint.h
+  qSlicerMinMaxDVHConstraint.h
+  qSlicerMinMaxEUDConstraint.h
+  qSlicerMinMaxMeanDoseConstraint.h
   qMRMLObjectivesTableWidget.h
 )
 
@@ -234,6 +270,18 @@ SlicerMacroBuildModuleWidgets(
   RESOURCES ${${KIT}_RESOURCES}
   WRAP_PYTHONQT
   )
+
+# Deploy IPOPT DLLs next to the module widgets library so Slicer can load it
+if(EXTENSION_BUILDS_IPOPT AND WIN32 AND DEFINED Ipopt_DLL_DIR)
+  file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
+  foreach(DLL_FILE ${IPOPT_DLLS})
+    add_custom_command(TARGET ${KIT} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${DLL_FILE}"
+        "$<TARGET_FILE_DIR:${KIT}>"
+    )
+  endforeach()
+endif()
 
 #-----------------------------------------------------------------------------
 if(Slicer_USE_PYTHONQT)

--- a/ExternalBeamPlanning/Widgets/CMakeLists.txt
+++ b/ExternalBeamPlanning/Widgets/CMakeLists.txt
@@ -196,8 +196,6 @@ if(EXTENSION_BUILDS_IPOPT)
 
     # Add additional system libraries that IPOPT might need on Unix
     if(UNIX)
-      list(APPEND ${KIT}_TARGET_LIBRARIES gfortran quadmath gcc_s)
-
       # Find and link required dependencies
       find_library(DL_LIBRARY dl)
       if(DL_LIBRARY)
@@ -227,7 +225,6 @@ if(EXTENSION_BUILDS_IPOPT)
         PATHS
           ${CMAKE_BINARY_DIR}/Mumps-install/lib
           ${Mumps_DIR}/lib
-        NO_DEFAULT_PATH
       )
       if(METIS_LIBRARY)
         list(APPEND ${KIT}_TARGET_LIBRARIES ${METIS_LIBRARY})
@@ -243,6 +240,9 @@ if(EXTENSION_BUILDS_IPOPT)
       if(BLAS_LIBRARY)
         list(APPEND ${KIT}_TARGET_LIBRARIES ${BLAS_LIBRARY})
       endif()
+
+      # gfortran runtime must come after all Fortran static libs (IPOPT, MUMPS)
+      list(APPEND ${KIT}_TARGET_LIBRARIES gfortran quadmath gcc_s)
     endif()
   endif()
 endif()

--- a/ExternalBeamPlanning/Widgets/CMakeLists.txt
+++ b/ExternalBeamPlanning/Widgets/CMakeLists.txt
@@ -14,6 +14,28 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${qSlicerBeamsModuleWidgets_INCLUDE_DIRS}
   )
 
+# Add IPOPT include directories if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  # Find IPOPT installation
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_INCLUDE_DIRS "${Ipopt_INCLUDE_DIR}")
+  else()
+    # Unix systems use built libraries
+    find_path(IPOPT_INCLUDE_DIRS
+      NAMES IpIpoptApplication.hpp
+      PATHS
+        ${Ipopt_DIR}/include/coin-or
+        ${CMAKE_BINARY_DIR}/Ipopt-install/include/coin-or
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_INCLUDE_DIRS)
+    list(APPEND ${KIT}_INCLUDE_DIRECTORIES ${IPOPT_INCLUDE_DIRS})
+  endif()
+endif()
+
 set(${KIT}_SRCS
   # Dose engines
   qSlicerAbstractDoseEngine.cxx
@@ -46,10 +68,42 @@ set(${KIT}_SRCS
   qSlicerObjectiveLogic.h
   qSlicerSquaredDeviationObjective.cxx
   qSlicerSquaredDeviationObjective.h
+  qSlicerSquaredOverdosingObjective.cxx
+  qSlicerSquaredOverdosingObjective.h
+  qSlicerSquaredUnderdosingObjective.cxx
+  qSlicerSquaredUnderdosingObjective.h
+  qSlicerMeanDoseObjective.cxx
+  qSlicerMeanDoseObjective.h
+  qSlicerEUDObjective.cxx
+  qSlicerEUDObjective.h
+  qSlicerMaxDVHObjective.cxx
+  qSlicerMaxDVHObjective.h
+  qSlicerMinDVHObjective.cxx
+  qSlicerMinDVHObjective.h
+  qSlicerDVHUtils.h
+  # Constraints
+  qSlicerAbstractConstraint.cxx
+  qSlicerAbstractConstraint.h
+  qSlicerMinMaxDoseConstraint.cxx
+  qSlicerMinMaxDoseConstraint.h
+  qSlicerMinMaxDVHConstraint.cxx
+  qSlicerMinMaxDVHConstraint.h
+  qSlicerMinMaxEUDConstraint.cxx
+  qSlicerMinMaxEUDConstraint.h
+  qSlicerMinMaxMeanDoseConstraint.cxx
+  qSlicerMinMaxMeanDoseConstraint.h
   # Widgets
   qMRMLObjectivesTableWidget.cxx
   qMRMLObjectivesTableWidget.h
   )
+
+# Add IPOPT optimizer sources if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  list(APPEND ${KIT}_SRCS
+    qSlicerIpoptOptimizer.cxx
+    qSlicerIpoptOptimizer.h
+    )
+endif()
 
 set(${KIT}_UI_SRCS
   )
@@ -60,6 +114,7 @@ set_source_files_properties(
   qSlicerAbstractDoseEngine.h
   qSlicerAbstractPlanOptimizer.h
   qSlicerAbstractObjective.h
+  qSlicerAbstractConstraint.h
   WRAP_EXCLUDE
   )
 
@@ -78,8 +133,26 @@ set(${KIT}_MOC_SRCS
   qSlicerObjectivePluginHandler.h
   qSlicerObjectiveLogic.h
   qSlicerSquaredDeviationObjective.h
+  qSlicerSquaredOverdosingObjective.h
+  qSlicerSquaredUnderdosingObjective.h
+  qSlicerMeanDoseObjective.h
+  qSlicerEUDObjective.h
+  qSlicerMaxDVHObjective.h
+  qSlicerMinDVHObjective.h
+  qSlicerAbstractConstraint.h
+  qSlicerMinMaxDoseConstraint.h
+  qSlicerMinMaxDVHConstraint.h
+  qSlicerMinMaxEUDConstraint.h
+  qSlicerMinMaxMeanDoseConstraint.h
   qMRMLObjectivesTableWidget.h
 )
+
+# Add IPOPT optimizer to MOC sources if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  list(APPEND ${KIT}_MOC_SRCS
+    qSlicerIpoptOptimizer.h
+    )
+endif()
 
 set(${KIT}_UI_SRCS
   UI/qMRMLObjectivesTableWidget.ui
@@ -101,6 +174,78 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicerExternalBeamPlanningModuleMRML
   qSlicerBeamsModuleWidgets
   )
+
+# Add IPOPT libraries if IPOPT support is enabled
+if(EXTENSION_BUILDS_IPOPT)
+  if(WIN32)
+    # Windows uses prebuilt binaries
+    set(IPOPT_LIBRARIES "${Ipopt_LIBRARY_DIR}/ipopt.dll.lib")
+  else()
+    # Unix systems use built libraries
+    find_library(IPOPT_LIBRARIES
+      NAMES ipopt libipopt
+      PATHS
+        ${Ipopt_DIR}/lib
+        ${CMAKE_BINARY_DIR}/Ipopt-install/lib
+      NO_DEFAULT_PATH
+    )
+  endif()
+
+  if(IPOPT_LIBRARIES)
+    list(APPEND ${KIT}_TARGET_LIBRARIES ${IPOPT_LIBRARIES})
+
+    # Add additional system libraries that IPOPT might need on Unix
+    if(UNIX)
+      # Find and link required dependencies
+      find_library(DL_LIBRARY dl)
+      if(DL_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${DL_LIBRARY})
+      endif()
+
+      find_library(M_LIBRARY m)
+      if(M_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${M_LIBRARY})
+      endif()
+
+      # MUMPS library (coinmumps is the COIN-OR wrapped version)
+      find_library(MUMPS_LIBRARY
+        NAMES coinmumps libcoinmumps
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+        NO_DEFAULT_PATH
+      )
+      if(MUMPS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${MUMPS_LIBRARY})
+      endif()
+
+      # Also need METIS (required by MUMPS)
+      find_library(METIS_LIBRARY
+        NAMES metis libmetis
+        PATHS
+          ${CMAKE_BINARY_DIR}/Mumps-install/lib
+          ${Mumps_DIR}/lib
+      )
+      if(METIS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${METIS_LIBRARY})
+      endif()
+
+      # BLAS and LAPACK (required by MUMPS)
+      find_library(LAPACK_LIBRARY lapack)
+      if(LAPACK_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${LAPACK_LIBRARY})
+      endif()
+
+      find_library(BLAS_LIBRARY blas)
+      if(BLAS_LIBRARY)
+        list(APPEND ${KIT}_TARGET_LIBRARIES ${BLAS_LIBRARY})
+      endif()
+
+      # gfortran runtime must come after all Fortran static libs (IPOPT, MUMPS)
+      list(APPEND ${KIT}_TARGET_LIBRARIES gfortran quadmath gcc_s)
+    endif()
+  endif()
+endif()
 
 set(${KIT}_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -125,6 +270,18 @@ SlicerMacroBuildModuleWidgets(
   RESOURCES ${${KIT}_RESOURCES}
   WRAP_PYTHONQT
   )
+
+# Deploy IPOPT DLLs next to the module widgets library so Slicer can load it
+if(EXTENSION_BUILDS_IPOPT AND WIN32 AND DEFINED Ipopt_DLL_DIR)
+  file(GLOB IPOPT_DLLS "${Ipopt_DLL_DIR}/*.dll")
+  foreach(DLL_FILE ${IPOPT_DLLS})
+    add_custom_command(TARGET ${KIT} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${DLL_FILE}"
+        "$<TARGET_FILE_DIR:${KIT}>"
+    )
+  endforeach()
+endif()
 
 #-----------------------------------------------------------------------------
 if(Slicer_USE_PYTHONQT)

--- a/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
+++ b/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
@@ -38,7 +38,9 @@
 #include <QDebug>
 #include <QKeyEvent>
 #include <QStringList>
+#include <QCheckBox>
 #include <QComboBox>
+#include <QHBoxLayout>
 #include <QLineEdit>
 #include <QSpinBox>
 
@@ -97,10 +99,12 @@ void qMRMLObjectivesTableWidgetPrivate::init()
   this->setMessage(QString());
 
   // Set table header properties
-  this->ColumnLabels << "Number" << "ObjectiveName" << "Segments" << "OverlapPriority" << "Penalty" << "Parameters";
-  this->ObjectivesTable->setHorizontalHeaderLabels(
-    QStringList() << "#" << "Objective" << "Segments" << "OP" << "p" << "Parameters");
+  this->ColumnLabels << "Number" << "IsConstraint" << "ObjectiveName" << "Segments" << "OverlapPriority" << "Penalty" << "Parameters";
   this->ObjectivesTable->setColumnCount(this->ColumnLabels.size());
+  this->ObjectivesTable->setHorizontalHeaderLabels(
+    QStringList() << "#" << "C" << "Objective" << "Segments" << "OP" << "p" << "Parameters");
+  this->ObjectivesTable->horizontalHeaderItem(this->columnIndex("IsConstraint"))
+    ->setToolTip("Constraint (check to show constraints instead of objectives)");
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
   this->ObjectivesTable->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
@@ -437,15 +441,39 @@ void qMRMLObjectivesTableWidget::onObjectiveAdded()
     return;
   }
 
-  // Objectives (Combo Box)
+  // IsConstraint checkbox — disabled if this optimizer has no constraints
+  QCheckBox* constraintCheckBox = new QCheckBox();
+  bool hasConstraints = std::any_of(availableObjectives.begin(), availableObjectives.end(),
+    [](const qSlicerAbstractPlanOptimizer::ObjectiveStruct& o) { return o.isConstraint; });
+  constraintCheckBox->setToolTip("Check to show constraints instead of objectives");
+  d->ObjectivesTable->setCellWidget(row, d->columnIndex("IsConstraint"), constraintCheckBox);
+  d->ObjectivesTable->setColumnHidden(d->columnIndex("IsConstraint"), !hasConstraints);
+
+  // Objectives (Combo Box) — initially populated with objectives only
   QComboBox* objectivesDropdown = new QComboBox();
-  for (auto objective : availableObjectives)
+  auto repopulateObjectiveDropdown = [availableObjectives](QComboBox* combo, bool isConstraint)
   {
-    QVariant var;
-    var.setValue(objective);
-    objectivesDropdown->addItem(objective.name, var);
-  }
+    combo->blockSignals(true);
+    combo->clear();
+    for (const auto& obj : availableObjectives)
+    {
+      if (obj.isConstraint == isConstraint)
+      {
+        QVariant var;
+        var.setValue(obj);
+        combo->addItem(obj.name, var);
+      }
+    }
+    combo->blockSignals(false);
+  };
+  repopulateObjectiveDropdown(objectivesDropdown, false);
   d->ObjectivesTable->setCellWidget(row, d->columnIndex("ObjectiveName"), objectivesDropdown);
+
+  connect(constraintCheckBox, &QCheckBox::toggled, this, [this, row, objectivesDropdown, repopulateObjectiveDropdown](bool checked)
+  {
+    repopulateObjectiveDropdown(objectivesDropdown, checked);
+    this->onObjectiveChanged(row);
+  });
   connect(objectivesDropdown, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, row]
   {
     this->onObjectiveChanged(row);
@@ -745,6 +773,11 @@ void qMRMLObjectivesTableWidget::onObjectiveChanged(int row)
   }
   objectiveNode->SetName(objectiveStruct.name.toStdString().c_str());
   objectiveNode->SetSegmentationAndSegmentID(segmentationNode, segmentID.toStdString().c_str());
+
+  QCheckBox* constraintCheckBox = qobject_cast<QCheckBox*>(
+    d->ObjectivesTable->cellWidget(row, d->columnIndex("IsConstraint")));
+  bool isConstraint = constraintCheckBox && constraintCheckBox->isChecked();
+  objectiveNode->SetAttribute("isConstraint", isConstraint ? "true" : "false");
 
   // Create overlap priority SpinBox
   int overlapPriorityValue = this->findOverlapPriorityValueOfSegment(row);

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractConstraint.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractConstraint.cxx
@@ -1,0 +1,27 @@
+#include "qSlicerAbstractConstraint.h"
+
+qSlicerAbstractConstraint::qSlicerAbstractConstraint(QObject* parent)
+  : QObject(parent)
+{}
+
+qSlicerAbstractConstraint::~qSlicerAbstractConstraint() = default;
+
+QString qSlicerAbstractConstraint::name() const
+{
+  return m_Name;
+}
+
+void qSlicerAbstractConstraint::setName(QString name)
+{
+  m_Name = name;
+}
+
+QMap<QString, QVariant> qSlicerAbstractConstraint::getConstraintParameters() const
+{
+  return constraintParameters;
+}
+
+void qSlicerAbstractConstraint::setConstraintParameters(QMap<QString, QVariant> parameters)
+{
+  constraintParameters = parameters;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractConstraint.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractConstraint.h
@@ -1,0 +1,63 @@
+#ifndef __qSlicerAbstractConstraint_h
+#define __qSlicerAbstractConstraint_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+
+#include <QObject>
+#include <QMap>
+#include <QVariant>
+#include <QString>
+
+#include <itkeigen/Eigen/Dense>
+
+/// \ingroup SlicerRt_QtModules_ExternalBeamPlanning
+/// \brief Abstract base class for dose constraint functions used in plan optimization.
+///
+/// Mirrors the matRad_DoseConstraint interface. Each concrete constraint provides:
+///   - The number of scalar constraint equations it contributes
+///   - The constraint function values g(dose)
+///   - The Jacobian dg/d(dose)  (rows = constraints, cols = voxels)
+///   - Upper and lower bounds for g
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerAbstractConstraint : public QObject
+{
+  Q_OBJECT
+  Q_PROPERTY(QString name READ name WRITE setName)
+
+public:
+  using DoseType = Eigen::VectorXd;
+
+  typedef QObject Superclass;
+  explicit qSlicerAbstractConstraint(QObject* parent = nullptr);
+  ~qSlicerAbstractConstraint() override;
+
+  virtual QString name() const;
+  virtual void setName(QString name);
+
+  QMap<QString, QVariant> getConstraintParameters() const;
+  void setConstraintParameters(QMap<QString, QVariant> parameters);
+
+  /// Number of scalar constraint equations this instance contributes.
+  virtual int numConstraints(int numVoxels) const = 0;
+
+  /// Constraint function values: vector of length numConstraints(n).
+  Q_INVOKABLE virtual DoseType computeDoseConstraintFunction(const DoseType& dose) = 0;
+
+  /// Jacobian: matrix of shape (numConstraints, numVoxels).
+  Q_INVOKABLE virtual Eigen::MatrixXd computeDoseConstraintJacobian(const DoseType& dose) = 0;
+
+  /// Upper bounds for each constraint equation.
+  Q_INVOKABLE virtual DoseType upperBounds(int numVoxels) = 0;
+
+  /// Lower bounds for each constraint equation.
+  Q_INVOKABLE virtual DoseType lowerBounds(int numVoxels) = 0;
+
+protected:
+  QString m_Name;
+  QMap<QString, QVariant> constraintParameters;
+  virtual void initializeParameters() = 0;
+
+private:
+  Q_DISABLE_COPY(qSlicerAbstractConstraint);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractPlanOptimizer.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractPlanOptimizer.h
@@ -71,6 +71,7 @@ public:
   {
     QString name;
     QMap<QString, QVariant> parameters;
+    bool isConstraint = false;
   };
 
 signals:

--- a/ExternalBeamPlanning/Widgets/qSlicerDVHUtils.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerDVHUtils.h
@@ -1,0 +1,23 @@
+#ifndef __qSlicerDVHUtils_h
+#define __qSlicerDVHUtils_h
+
+#include <itkeigen/Eigen/Core>
+#include <algorithm>
+#include <vector>
+
+/// Returns the dose value d such that the fraction of voxels with dose >= d
+/// equals refVol.  Equivalent to matRad_calcInversDVH.
+inline double qSlicerCalcInverseDVH(double refVol, const Eigen::VectorXd& dose)
+{
+  int n = static_cast<int>(dose.size());
+  if (n == 0) return 0.0;
+
+  std::vector<double> sorted(dose.data(), dose.data() + n);
+  std::sort(sorted.begin(), sorted.end(), std::greater<double>());
+
+  int idx = static_cast<int>(std::ceil(refVol * n)) - 1;
+  idx = std::max(0, std::min(idx, n - 1));
+  return sorted[idx];
+}
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerEUDObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerEUDObjective.cxx
@@ -1,0 +1,57 @@
+#include "qSlicerEUDObjective.h"
+
+#include <QDebug>
+#include <cmath>
+
+qSlicerEUDObjective::qSlicerEUDObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "EUD";
+  this->initializeParameters();
+}
+
+qSlicerEUDObjective::~qSlicerEUDObjective() = default;
+
+void qSlicerEUDObjective::initializeParameters()
+{
+  this->objectivesParameters["eudRef"] = 0.0;
+  this->objectivesParameters["exponent"] = 3.5;
+}
+
+float qSlicerEUDObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double eudRef = this->objectivesParameters["eudRef"].toDouble();
+  double k = this->objectivesParameters["exponent"].toDouble();
+
+  double powerSum = dose.array().pow(k).sum();
+  double eud = std::pow(powerSum / dose.size(), 1.0 / k);
+  double diff = eud - eudRef;
+  return static_cast<float>(diff * diff);
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerEUDObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double eudRef = this->objectivesParameters["eudRef"].toDouble();
+  double k = this->objectivesParameters["exponent"].toDouble();
+  int n = static_cast<int>(dose.size());
+
+  // Replace zeros for numerical stability
+  DoseType d = dose;
+  for (int i = 0; i < n; ++i)
+    if (d[i] == 0.0) d[i] = 1e-3;
+
+  double powerSum = d.array().pow(k).sum();
+  double eud = std::pow(powerSum / n, 1.0 / k);
+
+  // grad_i = 2 * (n)^(-1/k) * powerSum^((1-k)/k) * d_i^(k-1) * (EUD - eudRef)
+  double scale = 2.0 * std::pow(1.0 / n, 1.0 / k) * std::pow(powerSum, (1.0 - k) / k) * (eud - eudRef);
+  DoseType grad = scale * d.array().pow(k - 1.0).matrix();
+
+  if (!grad.allFinite())
+  {
+    qWarning() << "EUD gradient computation failed (non-finite values). Reduce exponent.";
+    return DoseType::Zero(n);
+  }
+  return grad;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerEUDObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerEUDObjective.h
@@ -1,0 +1,29 @@
+#ifndef __qSlicerEUDObjective_h
+#define __qSlicerEUDObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+/// Penalized Equivalent Uniform Dose (EUD) objective.
+/// f = (EUD - eudRef)^2  where  EUD = (mean(dose^k))^(1/k)
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerEUDObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerEUDObjective(QObject* parent = nullptr);
+  ~qSlicerEUDObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerEUDObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
@@ -1,24 +1,63 @@
 #include "qSlicerIpoptOptimizer.h"
 
+// ExternalBeamPlanning includes
+#include "qSlicerAbstractObjective.h"
+#include "qSlicerAbstractConstraint.h"
+#include "qSlicerSquaredDeviationObjective.h"
+#include "qSlicerSquaredOverdosingObjective.h"
+#include "qSlicerSquaredUnderdosingObjective.h"
+#include "qSlicerMeanDoseObjective.h"
+#include "qSlicerEUDObjective.h"
+#include "qSlicerMaxDVHObjective.h"
+#include "qSlicerMinDVHObjective.h"
+#include "qSlicerMinMaxDoseConstraint.h"
+#include "qSlicerMinMaxDVHConstraint.h"
+#include "qSlicerMinMaxEUDConstraint.h"
+#include "qSlicerMinMaxMeanDoseConstraint.h"
+
+// Beams includes
+#include "vtkMRMLRTBeamNode.h"
+
+// MRML includes
+#include "vtkMRMLRTPlanNode.h"
+#include "vtkMRMLRTObjectiveNode.h"
+#include "vtkMRMLSegmentationNode.h"
+#include <vtkMRMLScalarVolumeNode.h>
+
+// Segmentations includes
+#include "vtkSlicerSegmentationsModuleLogic.h"
+
+// MRML includes (continued)
+#include <vtkMRMLLabelMapVolumeNode.h>
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkImageReslice.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkStringArray.h>
+
+// Eigen includes
+#include <itkeigen/Eigen/Dense>
+#include <itkeigen/Eigen/Sparse>
+
 // Qt includes
 #include <QDebug>
-#include <QThread>
-#include <QMutex>
-#include <QMutexLocker>
 
 // STL includes
 #include <iostream>
 #include <regex>
 #include <cassert>
+#include <numeric>
+#include <memory>
 
 // Static constants
 const QString qSlicerIpoptOptimizer::NAME = "Interior Point Optimizer";
 const QString qSlicerIpoptOptimizer::SHORT_NAME = "ipopt";
 const bool qSlicerIpoptOptimizer::GPU_COMPATIBLE = false;
-const bool qSlicerIpoptOptimizer::ALLOW_KEYBOARD_CANCEL = true;
-const double qSlicerIpoptOptimizer::DEFAULT_TOLERANCE = 1e-10;
+const bool qSlicerIpoptOptimizer::ALLOW_KEYBOARD_CANCEL = false;
 const double qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL = 1e-6;
-const int qSlicerIpoptOptimizer::DEFAULT_MAX_ITER = 1000;
+const int qSlicerIpoptOptimizer::DEFAULT_MAX_ITER = 10000;
 const double qSlicerIpoptOptimizer::DEFAULT_MAX_TIME = 3600.0;
 
 //-----------------------------------------------------------------------------
@@ -37,24 +76,30 @@ public:
   qSlicerIpoptOptimizer::Options options;
   qSlicerIpoptOptimizer::Result lastResult;
 
-  // Function pointers
+  // Function pointers — objectives
   qSlicerIpoptOptimizer::ObjectiveFunction objectiveFunction;
   qSlicerIpoptOptimizer::GradientFunction gradientFunction;
-  qSlicerIpoptOptimizer::CallbackFunction intermediateCallback;
 
-  // Cancellation support
-  std::atomic<bool> cancellationRequested{false};
-  bool keyboardCancelEnabled = true;
+  // Function pointers — constraints
+  // constraintFunction: w → g(w), size numConstraints
+  // constraintJacobianFunction: w → row-major Jacobian, size numConstraints*|w|
+  // constraintBoundsFunction: () → {lb, ub}, each size numConstraints
+  std::function<qSlicerIpoptOptimizer::Array(const qSlicerIpoptOptimizer::Array&)> constraintFunction;
+  std::function<qSlicerIpoptOptimizer::Array(const qSlicerIpoptOptimizer::Array&)> constraintJacobianFunction;
+  std::function<std::pair<qSlicerIpoptOptimizer::Array,
+                          qSlicerIpoptOptimizer::Array>()>                         constraintBoundsFunction;
+  int numConstraints = 0;
 
-  // Thread safety
-  mutable QMutex mutex;
-
-  // Validate and create IPOPT problem
   SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> validateIpoptProblem(
     const qSlicerIpoptOptimizer::Array& x0);
 
-  // Version handling for options
-  void normalizeTimingStatisticsOption();
+  struct StructureTerm {
+    Eigen::SparseMatrix<double> D;
+    QString objectiveType;
+    double bound;
+    double weight;
+  };
+  std::vector<StructureTerm> structureTerms;
 };
 
 //-----------------------------------------------------------------------------
@@ -78,20 +123,26 @@ public:
                            Index& nnz_h_lag, IndexStyleEnum& index_style) override
   {
     n = this->n;
-    m = 0;  // No constraints for now
-    nnz_jac_g = 0;  // No constraint jacobian
-    nnz_h_lag = 0;  // Will use limited-memory BFGS
-    index_style = TNLP::C_STYLE;  // 0-based indexing
+    m = d->numConstraints;
+    nnz_jac_g = m * n;  // dense Jacobian
+    nnz_h_lag = 0;      // limited-memory BFGS — no explicit Hessian
+    index_style = TNLP::C_STYLE;
     return true;
   }
 
   virtual bool get_bounds_info(Index n, Number* x_l, Number* x_u,
                               Index m, Number* g_l, Number* g_u) override
   {
-    // Set variable bounds (unbounded for now)
     for (Index i = 0; i < n; i++) {
-      x_l[i] = -1e19;
+      x_l[i] = 0.0;   // fluence weights must be non-negative
       x_u[i] = 1e19;
+    }
+    if (m > 0 && d->constraintBoundsFunction) {
+      auto [lb, ub] = d->constraintBoundsFunction();
+      for (Index i = 0; i < m; i++) {
+        g_l[i] = (i < static_cast<Index>(lb.size())) ? lb[i] : -1e19;
+        g_u[i] = (i < static_cast<Index>(ub.size())) ? ub[i] :  1e19;
+      }
     }
     return true;
   }
@@ -143,36 +194,36 @@ public:
 
   virtual bool eval_g(Index n, const Number* x, bool new_x, Index m, Number* g) override
   {
-    // No constraints
+    if (m == 0) return true;
+    if (!d->constraintFunction) return false;
+    Array xvec(x, x + n);
+    Array gvec = d->constraintFunction(xvec);
+    for (Index i = 0; i < m; i++)
+      g[i] = (i < static_cast<Index>(gvec.size())) ? gvec[i] : 0.0;
     return true;
   }
 
   virtual bool eval_jac_g(Index n, const Number* x, bool new_x, Index m,
-                         Index nele_jac, Index* iRow, Index* jCol, Number* values) override
+                          Index nele_jac, Index* iRow, Index* jCol, Number* values) override
   {
-    // No constraints
+    if (m == 0) return true;
+    if (values == nullptr) {
+      // Return sparsity structure — dense: row i, col j → entry i*n+j
+      Index k = 0;
+      for (Index i = 0; i < m; i++)
+        for (Index j = 0; j < n; j++) {
+          iRow[k] = i;
+          jCol[k] = j;
+          ++k;
+        }
+    } else {
+      if (!d->constraintJacobianFunction) return false;
+      Array xvec(x, x + n);
+      Array jac = d->constraintJacobianFunction(xvec);
+      for (Index k2 = 0; k2 < nele_jac; k2++)
+        values[k2] = (k2 < static_cast<Index>(jac.size())) ? jac[k2] : 0.0;
+    }
     return true;
-  }
-
-  virtual bool intermediate_callback(AlgorithmMode mode, Index iter, Number obj_value,
-                                    Number inf_pr, Number inf_du, Number mu,
-                                    Number d_norm, Number regularization_size,
-                                    Number alpha_du, Number alpha_pr, Index ls_trials,
-                                    const IpoptData* ip_data,
-                                    IpoptCalculatedQuantities* ip_cq) override
-  {
-    // Check for cancellation
-    if (d->cancellationRequested.load()) {
-      return false; // Abort optimization
-    }
-
-    // Call user callback if provided
-    if (d->intermediateCallback) {
-      Array currentX; // Would need to extract current x from ip_data if needed
-      return d->intermediateCallback(static_cast<int>(iter), obj_value, currentX);
-    }
-
-    return true; // Continue optimization
   }
 
   virtual void finalize_solution(SolverReturn status, Index n, const Number* x,
@@ -181,12 +232,10 @@ public:
                                 Number obj_value, const IpoptData* ip_data,
                                 IpoptCalculatedQuantities* ip_cq) override
   {
-    // Store results in the private class
-    QMutexLocker locker(&d->mutex);
     d->lastResult.solution = Array(x, x + n);
     d->lastResult.final_objective_value = obj_value;
     d->lastResult.status = static_cast<ApplicationReturnStatus>(status);
-    d->lastResult.success = (status == SUCCESS);
+    d->lastResult.success = (status == SUCCESS || status == STOP_AT_ACCEPTABLE_POINT);
   }
 };
 
@@ -226,18 +275,7 @@ SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> qSlicerIpoptOptimizerPrivate::vali
     return nullptr;
   }
 
-  // Handle version-specific options
-  normalizeTimingStatisticsOption();
-
   return SmartPtr<qSlicerIpoptOptimizer::IpoptProblem>(new qSlicerIpoptOptimizer::IpoptProblem(this, x0));
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerIpoptOptimizerPrivate::normalizeTimingStatisticsOption()
-{
-  // This mimics the Python version's handling of timing statistics option names
-  // For now, we assume the newer "print_timing_statistics" is supported
-  // In a real implementation, you might want to check the IPOPT version
 }
 
 //-----------------------------------------------------------------------------
@@ -248,6 +286,8 @@ qSlicerIpoptOptimizer::qSlicerIpoptOptimizer(QObject* parent)
   : Superclass(parent)
   , d_ptr(new qSlicerIpoptOptimizerPrivate(*this))
 {
+  this->m_Name = NAME;
+  this->setAvailableObjectives();
 }
 
 //-----------------------------------------------------------------------------
@@ -257,7 +297,7 @@ qSlicerIpoptOptimizer::~qSlicerIpoptOptimizer() = default;
 void qSlicerIpoptOptimizer::setMaxIterations(int maxIter)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->options.max_iter = maxIter;
 }
 
@@ -265,7 +305,7 @@ void qSlicerIpoptOptimizer::setMaxIterations(int maxIter)
 void qSlicerIpoptOptimizer::setMaxTime(double maxTime)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->options.max_cpu_time = maxTime;
 }
 
@@ -273,7 +313,7 @@ void qSlicerIpoptOptimizer::setMaxTime(double maxTime)
 void qSlicerIpoptOptimizer::setAbsoluteObjectiveTolerance(double tol)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->options.acceptable_tol = tol;
 }
 
@@ -281,7 +321,7 @@ void qSlicerIpoptOptimizer::setAbsoluteObjectiveTolerance(double tol)
 void qSlicerIpoptOptimizer::setObjectiveFunction(ObjectiveFunction func)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->objectiveFunction = func;
 }
 
@@ -289,31 +329,60 @@ void qSlicerIpoptOptimizer::setObjectiveFunction(ObjectiveFunction func)
 void qSlicerIpoptOptimizer::setGradientFunction(GradientFunction func)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->gradientFunction = func;
 }
 
+
 //-----------------------------------------------------------------------------
-void qSlicerIpoptOptimizer::setIntermediateCallback(CallbackFunction callback)
+void qSlicerIpoptOptimizer::addStructureTerm(
+  const QList<double>& data, const QList<int>& rowInd, const QList<int>& colInd,
+  int nVoxels, int nBixels, const QString& objectiveType, double bound, double weight)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
-  d->intermediateCallback = callback;
+
+  using Triplet = Eigen::Triplet<double>;
+  std::vector<Triplet> triplets;
+  triplets.reserve(data.size());
+  for (int k = 0; k < data.size(); ++k)
+    triplets.emplace_back(rowInd[k], colInd[k], data[k]);
+
+  qSlicerIpoptOptimizerPrivate::StructureTerm term;
+  term.D.resize(nVoxels, nBixels);
+  term.D.setFromTriplets(triplets.begin(), triplets.end());
+  term.objectiveType = objectiveType;
+  term.bound = bound;
+  term.weight = weight;
+
+  d->structureTerms.push_back(std::move(term));
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerIpoptOptimizer::setKeyboardCancelEnabled(bool enabled)
+void qSlicerIpoptOptimizer::clearStructureTerms()
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
-  d->keyboardCancelEnabled = enabled;
+  d->structureTerms.clear();
+  d->objectiveFunction = nullptr;
+  d->gradientFunction  = nullptr;
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerIpoptOptimizer::requestCancellation()
+bool qSlicerIpoptOptimizer::solve(const QList<double>& x0)
 {
-  Q_D(qSlicerIpoptOptimizer);
-  d->cancellationRequested.store(true);
+  Array x0vec(x0.begin(), x0.end());
+  Result result = solveProblem(x0vec);
+  return result.success;
+}
+
+//-----------------------------------------------------------------------------
+QList<double> qSlicerIpoptOptimizer::getSolution() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+  QList<double> sol;
+  sol.reserve(static_cast<int>(d->lastResult.solution.size()));
+  for (double v : d->lastResult.solution)
+    sol.append(v);
+  return sol;
 }
 
 //-----------------------------------------------------------------------------
@@ -321,13 +390,69 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
 {
   Q_D(qSlicerIpoptOptimizer);
 
-  // Reset cancellation flag
-  d->cancellationRequested.store(false);
+  // Auto-wire objective/gradient from structure terms when no explicit function is set
+  if (!d->structureTerms.empty())
+  {
+    auto sharedTerms = std::make_shared<std::vector<qSlicerIpoptOptimizerPrivate::StructureTerm>>(
+      d->structureTerms);
 
-  // Update options with current values
-  d->options.max_iter = d->options.max_iter;
-  d->options.max_cpu_time = d->options.max_cpu_time;
-  d->options.acceptable_tol = d->options.acceptable_tol;
+    d->objectiveFunction = [sharedTerms](const Array& w) -> double
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      double total = 0.0;
+      for (const auto& t : *sharedTerms)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        double f = 0.0;
+        if (t.objectiveType == "SquaredOverdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            if (diff > 0.0) f += diff * diff;
+          }
+        } else if (t.objectiveType == "SquaredUnderdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = t.bound - dose[i];
+            if (diff > 0.0) f += diff * diff;
+          }
+        } else if (t.objectiveType == "SquaredDeviation") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            f += diff * diff;
+          }
+        }
+        total += t.weight * f / dose.size();
+      }
+      return total;
+    };
+
+    d->gradientFunction = [sharedTerms](const Array& w) -> Array
+    {
+      int n = static_cast<int>(w.size());
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), n);
+      Eigen::VectorXd grad = Eigen::VectorXd::Zero(n);
+      for (const auto& t : *sharedTerms)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        Eigen::VectorXd gDose = Eigen::VectorXd::Zero(dose.size());
+        if (t.objectiveType == "SquaredOverdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            if (diff > 0.0) gDose[i] = 2.0 * diff;
+          }
+        } else if (t.objectiveType == "SquaredUnderdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = t.bound - dose[i];
+            if (diff > 0.0) gDose[i] = -2.0 * diff;
+          }
+        } else if (t.objectiveType == "SquaredDeviation") {
+          for (int i = 0; i < dose.size(); ++i)
+            gDose[i] = 2.0 * (dose[i] - t.bound);
+        }
+        grad += t.weight * (t.D.transpose() * gDose) / dose.size();
+      }
+      return Array(grad.data(), grad.data() + n);
+    };
+  }
 
   // Create and validate IPOPT problem
   SmartPtr<IpoptProblem> nlp = d->validateIpoptProblem(x0);
@@ -353,6 +478,7 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
   app->Options()->SetNumericValue("acceptable_compl_inf_tol", d->options.acceptable_compl_inf_tol);
   app->Options()->SetNumericValue("acceptable_obj_change_tol", d->options.acceptable_obj_change_tol);
   app->Options()->SetIntegerValue("max_iter", d->options.max_iter);
+  app->Options()->SetIntegerValue("max_resto_iter", d->options.max_resto_iter);
   app->Options()->SetNumericValue("max_cpu_time", d->options.max_cpu_time);
   app->Options()->SetStringValue("mu_strategy", d->options.mu_strategy.toStdString());
   app->Options()->SetStringValue("hessian_approximation", d->options.hessian_approximation.toStdString());
@@ -380,7 +506,7 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
   // Get results
   Result result = d->lastResult;
   result.status = status;
-  result.success = (status == Solve_Succeeded);
+  result.success = (status == Solve_Succeeded || status == Solved_To_Acceptable_Level);
 
   if (result.success) {
     result.iteration_count = app->Statistics()->IterationCount();
@@ -397,7 +523,7 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
 qSlicerIpoptOptimizer::Options qSlicerIpoptOptimizer::getOptions() const
 {
   Q_D(const qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   return d->options;
 }
 
@@ -405,7 +531,7 @@ qSlicerIpoptOptimizer::Options qSlicerIpoptOptimizer::getOptions() const
 void qSlicerIpoptOptimizer::setOptions(const Options& options)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   d->options = options;
 }
 
@@ -413,7 +539,7 @@ void qSlicerIpoptOptimizer::setOptions(const Options& options)
 void qSlicerIpoptOptimizer::setOption(const QString& key, const QVariant& value)
 {
   Q_D(qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
 
   // Handle individual option setting
   if (key == "print_level") {
@@ -434,6 +560,457 @@ void qSlicerIpoptOptimizer::setOption(const QString& key, const QVariant& value)
 qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::getLastResult() const
 {
   Q_D(const qSlicerIpoptOptimizer);
-  QMutexLocker locker(&d->mutex);
+
   return d->lastResult;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setAvailableObjectives()
+{
+  availableObjectives.clear();
+
+  auto addObjective = [this](qSlicerAbstractObjective* obj) {
+    ObjectiveStruct s;
+    s.name = obj->name();
+    s.parameters = obj->getObjectiveParameters();
+    s.isConstraint = false;
+    availableObjectives.push_back(s);
+    delete obj;
+  };
+  auto addConstraint = [this](qSlicerAbstractConstraint* c) {
+    ObjectiveStruct s;
+    s.name = c->name();
+    s.parameters = c->getConstraintParameters();
+    s.isConstraint = true;
+    availableObjectives.push_back(s);
+    delete c;
+  };
+
+  // Objectives
+  addObjective(new qSlicerSquaredDeviationObjective());
+  addObjective(new qSlicerSquaredOverdosingObjective());
+  addObjective(new qSlicerSquaredUnderdosingObjective());
+  addObjective(new qSlicerMeanDoseObjective());
+  addObjective(new qSlicerEUDObjective());
+  addObjective(new qSlicerMaxDVHObjective());
+  addObjective(new qSlicerMinDVHObjective());
+
+  // Constraints
+  addConstraint(new qSlicerMinMaxDoseConstraint());
+  addConstraint(new qSlicerMinMaxDVHConstraint());
+  addConstraint(new qSlicerMinMaxEUDConstraint());
+  addConstraint(new qSlicerMinMaxMeanDoseConstraint());
+}
+
+//-----------------------------------------------------------------------------
+// Helper: create a constraint object by name and apply parameters from node attributes.
+static std::unique_ptr<qSlicerAbstractConstraint> createConstraintByName(
+  const QString& name, vtkMRMLRTObjectiveNode* node)
+{
+  std::unique_ptr<qSlicerAbstractConstraint> c;
+  if      (name == "Min/Max Dose") c = std::make_unique<qSlicerMinMaxDoseConstraint>();
+  else if (name == "DVH")         c = std::make_unique<qSlicerMinMaxDVHConstraint>();
+  else if (name == "EUD")         c = std::make_unique<qSlicerMinMaxEUDConstraint>();
+  else if (name == "Mean Dose")   c = std::make_unique<qSlicerMinMaxMeanDoseConstraint>();
+  else return nullptr;
+
+  QMap<QString, QVariant> params = c->getConstraintParameters();
+  for (const QString& key : params.keys())
+  {
+    const char* val = node->GetAttribute(key.toStdString().c_str());
+    if (val) params[key] = QString(val).toDouble();
+  }
+  c->setConstraintParameters(params);
+  return c;
+}
+
+//-----------------------------------------------------------------------------
+// Helper: create an objective object by name and apply parameters from a node attribute map.
+static std::unique_ptr<qSlicerAbstractObjective> createObjectiveByName(
+  const QString& name, vtkMRMLRTObjectiveNode* node)
+{
+  std::unique_ptr<qSlicerAbstractObjective> obj;
+  if      (name == "Squared Deviation")   obj = std::make_unique<qSlicerSquaredDeviationObjective>();
+  else if (name == "Squared Overdosing")  obj = std::make_unique<qSlicerSquaredOverdosingObjective>();
+  else if (name == "Squared Underdosing") obj = std::make_unique<qSlicerSquaredUnderdosingObjective>();
+  else if (name == "Mean Dose")           obj = std::make_unique<qSlicerMeanDoseObjective>();
+  else if (name == "EUD")                 obj = std::make_unique<qSlicerEUDObjective>();
+  else if (name == "Max DVH")             obj = std::make_unique<qSlicerMaxDVHObjective>();
+  else if (name == "Min DVH")             obj = std::make_unique<qSlicerMinDVHObjective>();
+  else return nullptr;
+
+  // Copy parameter values from node attributes
+  QMap<QString, QVariant> params = obj->getObjectiveParameters();
+  for (const QString& key : params.keys())
+  {
+    const char* val = node->GetAttribute(key.toStdString().c_str());
+    if (val) params[key] = QString(val).toDouble();
+  }
+  obj->setObjectiveParameters(params);
+  return obj;
+}
+
+//-----------------------------------------------------------------------------
+// Helper: extract flat voxel indices (row indices in D) for a segment.
+// Mirrors slicer.util.arrayFromSegmentBinaryLabelmap: exports the segment to a
+// temporary labelmap node resampled to the reference volume geometry.
+static std::vector<int> getSegmentVoxelIndices(
+  vtkMRMLRTObjectiveNode* objNode,
+  vtkMRMLVolumeNode* referenceVolumeNode,
+  int numVoxels)
+{
+  std::vector<int> indices;
+
+  vtkMRMLSegmentationNode* segNode = objNode->GetSegmentationNode();
+  const char* segID = objNode->GetSegmentID();
+  if (!segNode || !segID || !referenceVolumeNode) return indices;
+
+  vtkMRMLScene* scene = segNode->GetScene();
+  if (!scene) return indices;
+
+  vtkNew<vtkMRMLLabelMapVolumeNode> tempLabelmap;
+  scene->AddNode(tempLabelmap);
+
+  vtkNew<vtkStringArray> segIds;
+  segIds->InsertNextValue(segID);
+
+  bool ok = vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(
+    segNode, segIds, tempLabelmap, referenceVolumeNode);
+
+  if (!ok || !tempLabelmap->GetImageData())
+  {
+    scene->RemoveNode(tempLabelmap);
+    qWarning() << "ExportSegmentsToLabelmapNode failed for" << objNode->GetName();
+    return indices;
+  }
+
+  vtkImageData* img = tempLabelmap->GetImageData();
+  int dims[3];
+  img->GetDimensions(dims);
+  int total = dims[0] * dims[1] * dims[2];
+
+  if (total != numVoxels)
+  {
+    scene->RemoveNode(tempLabelmap);
+    qWarning() << "Labelmap/dose grid size mismatch for" << objNode->GetName()
+               << ":" << total << "vs" << numVoxels;
+    return indices;
+  }
+
+  void* rawPtr = img->GetScalarPointer();
+  int scalarType = img->GetScalarType();
+  indices.reserve(total / 4);
+  for (int i = 0; i < total; ++i)
+  {
+    double val = 0.0;
+    if      (scalarType == VTK_UNSIGNED_CHAR)  val = static_cast<unsigned char*>(rawPtr)[i];
+    else if (scalarType == VTK_SHORT)          val = static_cast<short*>(rawPtr)[i];
+    else if (scalarType == VTK_UNSIGNED_SHORT) val = static_cast<unsigned short*>(rawPtr)[i];
+    else if (scalarType == VTK_INT)            val = static_cast<int*>(rawPtr)[i];
+    if (val > 0.0) indices.push_back(i);
+  }
+
+  scene->RemoveNode(tempLabelmap);
+  return indices;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
+  vtkMRMLRTPlanNode* planNode,
+  std::vector<vtkSmartPointer<vtkMRMLRTObjectiveNode>> objectives,
+  vtkMRMLScalarVolumeNode* resultOptimizationVolumeNode)
+{
+  if (!planNode || !resultOptimizationVolumeNode)
+    return "Invalid plan or result volume node";
+  if (objectives.empty())
+    return "No objectives defined";
+
+  vtkMRMLScalarVolumeNode* refVol = planNode->GetReferenceVolumeNode();
+  if (!refVol)
+    return "No reference volume on plan";
+
+  // ── Step 1: collect beams and build combined D (numVoxels × totalBixels) ──
+
+  std::vector<vtkMRMLRTBeamNode*> beams;
+  planNode->GetBeams(beams);
+  if (beams.empty())
+    return "No beams in plan";
+
+  // Use dose grid from first beam; fall back to reference volume if not set.
+  int doseGridDim[3] = {0, 0, 0};
+  double doseGridSpacing[3] = {0.0, 0.0, 0.0};
+  beams[0]->GetDoseGridDim(doseGridDim);
+  beams[0]->GetDoseGridSpacing(doseGridSpacing);
+  bool useRefVolGrid = (doseGridDim[0] <= 0);
+  if (useRefVolGrid)
+  {
+    refVol->GetImageData()->GetDimensions(doseGridDim);
+    refVol->GetSpacing(doseGridSpacing);
+  }
+  int numVoxels = doseGridDim[0] * doseGridDim[1] * doseGridDim[2];
+
+  // Build a temporary volume node representing the dose grid geometry so that
+  // ExportSegmentsToLabelmapNode resamples segments to dose-grid resolution,
+  // not CT resolution.  Origin and direction are taken from the reference volume;
+  // spacing and dims come from the beam's dose grid (or the ref vol when useRefVolGrid).
+  vtkMRMLScene* scene = planNode->GetScene();
+  vtkNew<vtkMRMLScalarVolumeNode> doseGridVolNode;
+  vtkNew<vtkMatrix4x4> doseIJKToRAS; // saved for use when writing the result dose volume
+  scene->AddNode(doseGridVolNode);
+  {
+    vtkNew<vtkImageData> img;
+    img->SetDimensions(doseGridDim);
+    img->AllocateScalars(VTK_FLOAT, 1);
+    doseGridVolNode->SetAndObserveImageData(img);
+    doseGridVolNode->SetSpacing(doseGridSpacing);
+    doseGridVolNode->SetOrigin(refVol->GetOrigin());
+
+    // Direction: same as refVol but scaled to dose grid spacing
+    vtkNew<vtkMatrix4x4> refIJKToRAS;
+    refVol->GetIJKToRASMatrix(refIJKToRAS);
+    double refSpacing[3];
+    refVol->GetSpacing(refSpacing);
+    doseIJKToRAS->DeepCopy(refIJKToRAS);
+    for (int col = 0; col < 3; ++col)
+    {
+      double scale = doseGridSpacing[col] / refSpacing[col];
+      for (int row = 0; row < 3; ++row)
+        doseIJKToRAS->SetElement(row, col, refIJKToRAS->GetElement(row, col) * scale);
+    }
+    doseGridVolNode->SetIJKToRASMatrix(doseIJKToRAS);
+  }
+
+  using SparseD = vtkMRMLRTBeamNode::DoseInfluenceMatrixType; // Eigen ColMajor sparse
+  using Triplet = Eigen::Triplet<double>;
+
+  std::vector<Triplet> triplets;
+  int colOffset = 0;
+  for (vtkMRMLRTBeamNode* beam : beams)
+  {
+    const SparseD& Di = beam->GetDoseInfluenceMatrix();
+    if (Di.rows() == 0 || Di.cols() == 0)
+      return QString("Dose influence matrix empty for beam '%1'. "
+                     "Run dose calculation first.").arg(beam->GetName());
+    for (int k = 0; k < Di.outerSize(); ++k)
+      for (SparseD::InnerIterator it(Di, k); it; ++it)
+        triplets.emplace_back(static_cast<int>(it.row()),
+                              colOffset + static_cast<int>(it.col()),
+                              it.value());
+    colOffset += static_cast<int>(Di.cols());
+  }
+  int totalBixels = colOffset;
+
+  SparseD D(numVoxels, totalBixels);
+  D.setFromTriplets(triplets.begin(), triplets.end());
+
+  // ── Step 2: map each node → objective or constraint object, voxel indices, penalty ──
+
+  struct StructObj {
+    std::unique_ptr<qSlicerAbstractObjective> obj;
+    std::vector<int> voxelIndices;
+    double penalty;
+  };
+  struct StructConstraint {
+    std::unique_ptr<qSlicerAbstractConstraint> constraint;
+    std::vector<int> voxelIndices;
+  };
+
+  std::vector<StructObj> structObjs;
+  std::vector<StructConstraint> structConstraints;
+
+  for (auto& objNodePtr : objectives)
+  {
+    vtkMRMLRTObjectiveNode* node = objNodePtr.GetPointer();
+    if (!node) continue;
+
+    QString typeName(node->GetName());
+
+    std::vector<int> voxelIdx = getSegmentVoxelIndices(node, doseGridVolNode, numVoxels);
+    if (voxelIdx.empty())
+    {
+      qWarning() << "Could not extract voxel mask for" << node->GetName()
+                 << "— applying to all voxels";
+      voxelIdx.resize(numVoxels);
+      std::iota(voxelIdx.begin(), voxelIdx.end(), 0);
+    }
+
+    // Try objective first
+    auto obj = createObjectiveByName(typeName, node);
+    if (obj)
+    {
+      double penalty = 1.0;
+      const char* penAttr = node->GetAttribute("penalty");
+      if (penAttr) penalty = atof(penAttr);
+      structObjs.push_back({std::move(obj), std::move(voxelIdx), penalty});
+      continue;
+    }
+
+    // Try constraint
+    auto con = createConstraintByName(typeName, node);
+    if (con)
+    {
+      structConstraints.push_back({std::move(con), std::move(voxelIdx)});
+      continue;
+    }
+
+    qWarning() << "Unknown objective type:" << node->GetName() << "— skipping";
+  }
+
+  scene->RemoveNode(doseGridVolNode);
+
+  if (structObjs.empty() && structConstraints.empty())
+    return "No valid objectives or constraints could be configured";
+
+  // ── Step 3: wire IPOPT objective and gradient as lambdas ──
+  // f(w) = Σ_i penalty_i * f_i( D[struct_i, :] * w )
+  // ∇f/∂w = Σ_i penalty_i * D[struct_i, :]ᵀ * ∇f_i( D[struct_i, :] * w )
+
+  auto sharedSO = std::make_shared<std::vector<StructObj>>(std::move(structObjs));
+  auto sharedD  = std::make_shared<SparseD>(std::move(D));
+
+  setObjectiveFunction([sharedSO, sharedD](const Array& w) -> double
+  {
+    Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+    Eigen::VectorXd dose = (*sharedD) * wv;
+    double total = 0.0;
+    for (auto& so : *sharedSO)
+    {
+      Eigen::VectorXd dStruct(so.voxelIndices.size());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        dStruct[j] = dose[so.voxelIndices[j]];
+      total += so.penalty * static_cast<double>(so.obj->computeDoseObjectiveFunction(dStruct));
+    }
+    return total;
+  });
+
+  setGradientFunction([sharedSO, sharedD](const Array& w) -> Array
+  {
+    int n = static_cast<int>(w.size());
+    Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), n);
+    Eigen::VectorXd dose = (*sharedD) * wv;
+    Eigen::VectorXd gradW = Eigen::VectorXd::Zero(n);
+
+    for (auto& so : *sharedSO)
+    {
+      Eigen::VectorXd dStruct(so.voxelIndices.size());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        dStruct[j] = dose[so.voxelIndices[j]];
+
+      Eigen::VectorXd gDoseStruct =
+        so.penalty * so.obj->computeDoseObjectiveGradient(dStruct);
+
+      // Scatter structure gradient back to full voxel space, then chain-rule through D.
+      Eigen::VectorXd gDoseFull = Eigen::VectorXd::Zero(sharedD->rows());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        gDoseFull[so.voxelIndices[j]] += gDoseStruct[j];
+
+      gradW += sharedD->transpose() * gDoseFull;
+    }
+    return Array(gradW.data(), gradW.data() + n);
+  });
+
+  // ── Step 3b: wire constraints ──
+  {
+    Q_D(qSlicerIpoptOptimizer);
+
+    // Compute total constraint count
+    int totalCon = 0;
+    for (auto& sc : structConstraints)
+      totalCon += sc.constraint->numConstraints(static_cast<int>(sc.voxelIndices.size()));
+    d->numConstraints = totalCon;
+
+    if (totalCon > 0)
+    {
+      auto sharedSC = std::make_shared<std::vector<StructConstraint>>(std::move(structConstraints));
+
+      d->constraintBoundsFunction = [sharedSC, totalCon]()
+        -> std::pair<qSlicerIpoptOptimizer::Array, qSlicerIpoptOptimizer::Array>
+      {
+        qSlicerIpoptOptimizer::Array lb, ub;
+        lb.reserve(totalCon);
+        ub.reserve(totalCon);
+        for (auto& sc : *sharedSC)
+        {
+          int nv = static_cast<int>(sc.voxelIndices.size());
+          Eigen::VectorXd lbv = sc.constraint->lowerBounds(nv);
+          Eigen::VectorXd ubv = sc.constraint->upperBounds(nv);
+          for (int i = 0; i < lbv.size(); ++i) { lb.push_back(lbv[i]); ub.push_back(ubv[i]); }
+        }
+        return {lb, ub};
+      };
+
+      d->constraintFunction = [sharedSC, sharedD, totalCon](const qSlicerIpoptOptimizer::Array& w)
+        -> qSlicerIpoptOptimizer::Array
+      {
+        Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+        Eigen::VectorXd dose = (*sharedD) * wv;
+        qSlicerIpoptOptimizer::Array g;
+        g.reserve(totalCon);
+        for (auto& sc : *sharedSC)
+        {
+          Eigen::VectorXd dStruct(sc.voxelIndices.size());
+          for (size_t j = 0; j < sc.voxelIndices.size(); ++j)
+            dStruct[j] = dose[sc.voxelIndices[j]];
+          Eigen::VectorXd gv = sc.constraint->computeDoseConstraintFunction(dStruct);
+          for (int i = 0; i < gv.size(); ++i) g.push_back(gv[i]);
+        }
+        return g;
+      };
+
+      d->constraintJacobianFunction = [sharedSC, sharedD, totalCon](const qSlicerIpoptOptimizer::Array& w)
+        -> qSlicerIpoptOptimizer::Array
+      {
+        int nBixels = static_cast<int>(sharedD->cols());
+        Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+        Eigen::VectorXd dose = (*sharedD) * wv;
+        qSlicerIpoptOptimizer::Array jac(totalCon * nBixels, 0.0);
+        int rowOffset = 0;
+        for (auto& sc : *sharedSC)
+        {
+          int nv = static_cast<int>(sc.voxelIndices.size());
+          Eigen::VectorXd dStruct(nv);
+          for (int j = 0; j < nv; ++j) dStruct[j] = dose[sc.voxelIndices[j]];
+          Eigen::MatrixXd Jdose = sc.constraint->computeDoseConstraintJacobian(dStruct);
+          int numCon = static_cast<int>(Jdose.rows());
+          for (int ci = 0; ci < numCon; ++ci)
+          {
+            Eigen::VectorXd jFull = Eigen::VectorXd::Zero(sharedD->rows());
+            for (int j = 0; j < nv; ++j) jFull[sc.voxelIndices[j]] = Jdose(ci, j);
+            Eigen::VectorXd jW = sharedD->transpose() * jFull;
+            for (int j = 0; j < nBixels; ++j)
+              jac[(rowOffset + ci) * nBixels + j] = jW[j];
+          }
+          rowOffset += numCon;
+        }
+        return jac;
+      };
+    }
+  }
+
+  // ── Step 4: solve ──
+  emit progressInfoUpdated("Starting IPOPT optimization...");
+  Array w0(totalBixels, 1.0 / totalBixels); // uniform initial fluence
+  Result result = solveProblem(w0);
+  if (!result.success)
+    return QString("IPOPT solver did not converge (status %1)").arg(result.status);
+
+  // ── Step 5: compute and store result dose volume ──
+  Eigen::VectorXd wOpt = Eigen::Map<Eigen::VectorXd>(
+    result.solution.data(), result.solution.size());
+  Eigen::VectorXd doseOpt = (*sharedD) * wOpt;
+
+  vtkNew<vtkImageData> doseImg;
+  doseImg->SetDimensions(doseGridDim);
+  doseImg->AllocateScalars(VTK_FLOAT, 1);
+  float* ptr = static_cast<float*>(doseImg->GetScalarPointer());
+  for (int i = 0; i < numVoxels; ++i)
+    ptr[i] = static_cast<float>(doseOpt[i]);
+
+  resultOptimizationVolumeNode->SetAndObserveImageData(doseImg);
+  resultOptimizationVolumeNode->SetIJKToRASMatrix(doseIJKToRAS);
+  resultOptimizationVolumeNode->SetName(
+    (std::string(planNode->GetName()) + "_IpoptOptimizedDose").c_str());
+
+  emit progressInfoUpdated("IPOPT optimization complete.");
+  return QString(); // empty = success
 }

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
@@ -1,0 +1,439 @@
+#include "qSlicerIpoptOptimizer.h"
+
+// Qt includes
+#include <QDebug>
+#include <QThread>
+#include <QMutex>
+#include <QMutexLocker>
+
+// STL includes
+#include <iostream>
+#include <regex>
+#include <cassert>
+
+// Static constants
+const QString qSlicerIpoptOptimizer::NAME = "Interior Point Optimizer";
+const QString qSlicerIpoptOptimizer::SHORT_NAME = "ipopt";
+const bool qSlicerIpoptOptimizer::GPU_COMPATIBLE = false;
+const bool qSlicerIpoptOptimizer::ALLOW_KEYBOARD_CANCEL = true;
+const double qSlicerIpoptOptimizer::DEFAULT_TOLERANCE = 1e-10;
+const double qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL = 1e-6;
+const int qSlicerIpoptOptimizer::DEFAULT_MAX_ITER = 1000;
+const double qSlicerIpoptOptimizer::DEFAULT_MAX_TIME = 3600.0;
+
+//-----------------------------------------------------------------------------
+/// \ingroup SlicerRt_QtModules_ExternalBeamPlanning
+class qSlicerIpoptOptimizerPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerIpoptOptimizer);
+protected:
+  qSlicerIpoptOptimizer* const q_ptr;
+
+public:
+  qSlicerIpoptOptimizerPrivate(qSlicerIpoptOptimizer& object);
+  ~qSlicerIpoptOptimizerPrivate();
+
+  // Options and settings
+  qSlicerIpoptOptimizer::Options options;
+  qSlicerIpoptOptimizer::Result lastResult;
+
+  // Function pointers
+  qSlicerIpoptOptimizer::ObjectiveFunction objectiveFunction;
+  qSlicerIpoptOptimizer::GradientFunction gradientFunction;
+  qSlicerIpoptOptimizer::CallbackFunction intermediateCallback;
+
+  // Cancellation support
+  std::atomic<bool> cancellationRequested{false};
+  bool keyboardCancelEnabled = true;
+
+  // Thread safety
+  mutable QMutex mutex;
+
+  // Validate and create IPOPT problem
+  SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> validateIpoptProblem(
+    const qSlicerIpoptOptimizer::Array& x0);
+
+  // Version handling for options
+  void normalizeTimingStatisticsOption();
+};
+
+//-----------------------------------------------------------------------------
+/// Internal TNLP implementation for IPOPT
+class qSlicerIpoptOptimizer::IpoptProblem : public TNLP
+{
+private:
+  qSlicerIpoptOptimizerPrivate* d;
+  Array x0;
+  int n;
+
+public:
+  IpoptProblem(qSlicerIpoptOptimizerPrivate* dPtr, const Array& initialPoint)
+    : d(dPtr), x0(initialPoint), n(static_cast<int>(initialPoint.size()))
+  {}
+
+  virtual ~IpoptProblem() = default;
+
+  // TNLP interface implementation
+  virtual bool get_nlp_info(Index& n, Index& m, Index& nnz_jac_g,
+                           Index& nnz_h_lag, IndexStyleEnum& index_style) override
+  {
+    n = this->n;
+    m = 0;  // No constraints for now
+    nnz_jac_g = 0;  // No constraint jacobian
+    nnz_h_lag = 0;  // Will use limited-memory BFGS
+    index_style = TNLP::C_STYLE;  // 0-based indexing
+    return true;
+  }
+
+  virtual bool get_bounds_info(Index n, Number* x_l, Number* x_u,
+                              Index m, Number* g_l, Number* g_u) override
+  {
+    // Set variable bounds (unbounded for now)
+    for (Index i = 0; i < n; i++) {
+      x_l[i] = -1e19;
+      x_u[i] = 1e19;
+    }
+    return true;
+  }
+
+  virtual bool get_starting_point(Index n, bool init_x, Number* x,
+                                 bool init_z, Number* z_L, Number* z_U,
+                                 Index m, bool init_lambda, Number* lambda) override
+  {
+    assert(init_x == true);
+    assert(init_z == false);
+    assert(init_lambda == false);
+
+    // Set initial point
+    for (Index i = 0; i < n; i++) {
+      x[i] = (i < static_cast<Index>(x0.size())) ? x0[i] : 0.0;
+    }
+    return true;
+  }
+
+  virtual bool eval_f(Index n, const Number* x, bool new_x, Number& obj_value) override
+  {
+    if (!d->objectiveFunction) {
+      return false;
+    }
+
+    Array xvec(x, x + n);
+    obj_value = d->objectiveFunction(xvec);
+    return true;
+  }
+
+  virtual bool eval_grad_f(Index n, const Number* x, bool new_x, Number* grad_f) override
+  {
+    if (!d->gradientFunction) {
+      return false;
+    }
+
+    Array xvec(x, x + n);
+    Array gradient = d->gradientFunction(xvec);
+
+    if (gradient.size() != static_cast<size_t>(n)) {
+      return false;
+    }
+
+    for (Index i = 0; i < n; i++) {
+      grad_f[i] = gradient[i];
+    }
+    return true;
+  }
+
+  virtual bool eval_g(Index n, const Number* x, bool new_x, Index m, Number* g) override
+  {
+    // No constraints
+    return true;
+  }
+
+  virtual bool eval_jac_g(Index n, const Number* x, bool new_x, Index m,
+                         Index nele_jac, Index* iRow, Index* jCol, Number* values) override
+  {
+    // No constraints
+    return true;
+  }
+
+  virtual bool intermediate_callback(AlgorithmMode mode, Index iter, Number obj_value,
+                                    Number inf_pr, Number inf_du, Number mu,
+                                    Number d_norm, Number regularization_size,
+                                    Number alpha_du, Number alpha_pr, Index ls_trials,
+                                    const IpoptData* ip_data,
+                                    IpoptCalculatedQuantities* ip_cq) override
+  {
+    // Check for cancellation
+    if (d->cancellationRequested.load()) {
+      return false; // Abort optimization
+    }
+
+    // Call user callback if provided
+    if (d->intermediateCallback) {
+      Array currentX; // Would need to extract current x from ip_data if needed
+      return d->intermediateCallback(static_cast<int>(iter), obj_value, currentX);
+    }
+
+    return true; // Continue optimization
+  }
+
+  virtual void finalize_solution(SolverReturn status, Index n, const Number* x,
+                                const Number* z_L, const Number* z_U,
+                                Index m, const Number* g, const Number* lambda,
+                                Number obj_value, const IpoptData* ip_data,
+                                IpoptCalculatedQuantities* ip_cq) override
+  {
+    // Store results in the private class
+    QMutexLocker locker(&d->mutex);
+    d->lastResult.solution = Array(x, x + n);
+    d->lastResult.final_objective_value = obj_value;
+    d->lastResult.status = static_cast<ApplicationReturnStatus>(status);
+    d->lastResult.success = (status == SUCCESS);
+  }
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerIpoptOptimizerPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizerPrivate::qSlicerIpoptOptimizerPrivate(qSlicerIpoptOptimizer& object)
+  : q_ptr(&object)
+{
+  // Initialize default options
+  options.acceptable_tol = qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL;
+  options.max_iter = qSlicerIpoptOptimizer::DEFAULT_MAX_ITER;
+  options.max_cpu_time = qSlicerIpoptOptimizer::DEFAULT_MAX_TIME;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizerPrivate::~qSlicerIpoptOptimizerPrivate() = default;
+
+//-----------------------------------------------------------------------------
+SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> qSlicerIpoptOptimizerPrivate::validateIpoptProblem(
+  const qSlicerIpoptOptimizer::Array& x0)
+{
+  // Validate required functions
+  if (!objectiveFunction) {
+    qCritical() << "Objective function not set";
+    return nullptr;
+  }
+
+  if (!gradientFunction) {
+    qCritical() << "Gradient function not set";
+    return nullptr;
+  }
+
+  if (x0.empty()) {
+    qCritical() << "Initial point is empty";
+    return nullptr;
+  }
+
+  // Handle version-specific options
+  normalizeTimingStatisticsOption();
+
+  return SmartPtr<qSlicerIpoptOptimizer::IpoptProblem>(new qSlicerIpoptOptimizer::IpoptProblem(this, x0));
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizerPrivate::normalizeTimingStatisticsOption()
+{
+  // This mimics the Python version's handling of timing statistics option names
+  // For now, we assume the newer "print_timing_statistics" is supported
+  // In a real implementation, you might want to check the IPOPT version
+}
+
+//-----------------------------------------------------------------------------
+// qSlicerIpoptOptimizer methods
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::qSlicerIpoptOptimizer(QObject* parent)
+  : Superclass(parent)
+  , d_ptr(new qSlicerIpoptOptimizerPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::~qSlicerIpoptOptimizer() = default;
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setMaxIterations(int maxIter)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->options.max_iter = maxIter;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setMaxTime(double maxTime)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->options.max_cpu_time = maxTime;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setAbsoluteObjectiveTolerance(double tol)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->options.acceptable_tol = tol;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setObjectiveFunction(ObjectiveFunction func)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->objectiveFunction = func;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setGradientFunction(GradientFunction func)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->gradientFunction = func;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setIntermediateCallback(CallbackFunction callback)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->intermediateCallback = callback;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setKeyboardCancelEnabled(bool enabled)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->keyboardCancelEnabled = enabled;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::requestCancellation()
+{
+  Q_D(qSlicerIpoptOptimizer);
+  d->cancellationRequested.store(true);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x0)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  // Reset cancellation flag
+  d->cancellationRequested.store(false);
+
+  // Update options with current values
+  d->options.max_iter = d->options.max_iter;
+  d->options.max_cpu_time = d->options.max_cpu_time;
+  d->options.acceptable_tol = d->options.acceptable_tol;
+
+  // Create and validate IPOPT problem
+  SmartPtr<IpoptProblem> nlp = d->validateIpoptProblem(x0);
+  if (IsNull(nlp)) {
+    Result result;
+    result.success = false;
+    result.status = Invalid_Problem_Definition;
+    return result;
+  }
+
+  // Create IPOPT application
+  SmartPtr<IpoptApplication> app = IpoptApplicationFactory();
+
+  // Set options
+  app->Options()->SetNumericValue("tol", d->options.tol);
+  app->Options()->SetNumericValue("dual_inf_tol", d->options.dual_inf_tol);
+  app->Options()->SetNumericValue("constr_viol_tol", d->options.constr_viol_tol);
+  app->Options()->SetNumericValue("compl_inf_tol", d->options.compl_inf_tol);
+  app->Options()->SetIntegerValue("acceptable_iter", d->options.acceptable_iter);
+  app->Options()->SetNumericValue("acceptable_tol", d->options.acceptable_tol);
+  app->Options()->SetNumericValue("acceptable_constr_viol_tol", d->options.acceptable_constr_viol_tol);
+  app->Options()->SetNumericValue("acceptable_dual_inf_tol", d->options.acceptable_dual_inf_tol);
+  app->Options()->SetNumericValue("acceptable_compl_inf_tol", d->options.acceptable_compl_inf_tol);
+  app->Options()->SetNumericValue("acceptable_obj_change_tol", d->options.acceptable_obj_change_tol);
+  app->Options()->SetIntegerValue("max_iter", d->options.max_iter);
+  app->Options()->SetNumericValue("max_cpu_time", d->options.max_cpu_time);
+  app->Options()->SetStringValue("mu_strategy", d->options.mu_strategy.toStdString());
+  app->Options()->SetStringValue("hessian_approximation", d->options.hessian_approximation.toStdString());
+  app->Options()->SetIntegerValue("limited_memory_max_history", d->options.limited_memory_max_history);
+  app->Options()->SetStringValue("limited_memory_initialization", d->options.limited_memory_initialization.toStdString());
+  app->Options()->SetStringValue("linear_solver", d->options.linear_solver.toStdString());
+  app->Options()->SetIntegerValue("print_level", d->options.print_level);
+  app->Options()->SetStringValue("print_user_options", d->options.print_user_options.toStdString());
+  app->Options()->SetStringValue("print_options_documentation", d->options.print_options_documentation.toStdString());
+  app->Options()->SetStringValue("print_timing_statistics", d->options.print_timing_statistics.toStdString());
+
+  // Initialize the application
+  ApplicationReturnStatus status = app->Initialize();
+  if (status != Solve_Succeeded) {
+    qCritical() << "IPOPT initialization failed with status:" << status;
+    Result result;
+    result.success = false;
+    result.status = status;
+    return result;
+  }
+
+  // Solve the problem
+  status = app->OptimizeTNLP(nlp);
+
+  // Get results
+  Result result = d->lastResult;
+  result.status = status;
+  result.success = (status == Solve_Succeeded);
+
+  if (result.success) {
+    result.iteration_count = app->Statistics()->IterationCount();
+  }
+
+  // Emit completion signal
+  emit optimizationCompleted(result.success,
+    result.success ? "Optimization completed successfully" : "Optimization failed");
+
+  return result;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Options qSlicerIpoptOptimizer::getOptions() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  return d->options;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setOptions(const Options& options)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  d->options = options;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setOption(const QString& key, const QVariant& value)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+
+  // Handle individual option setting
+  if (key == "print_level") {
+    d->options.print_level = value.toInt();
+  } else if (key == "tol") {
+    d->options.tol = value.toDouble();
+  } else if (key == "max_iter") {
+    d->options.max_iter = value.toInt();
+  } else if (key == "max_cpu_time") {
+    d->options.max_cpu_time = value.toDouble();
+  } else if (key == "acceptable_tol") {
+    d->options.acceptable_tol = value.toDouble();
+  }
+  // Add more option handling as needed
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::getLastResult() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+  QMutexLocker locker(&d->mutex);
+  return d->lastResult;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
@@ -56,9 +56,9 @@ const QString qSlicerIpoptOptimizer::NAME = "Interior Point Optimizer";
 const QString qSlicerIpoptOptimizer::SHORT_NAME = "ipopt";
 const bool qSlicerIpoptOptimizer::GPU_COMPATIBLE = false;
 const bool qSlicerIpoptOptimizer::ALLOW_KEYBOARD_CANCEL = false;
-const double qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL = 1e-6;
+const double qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL = 1e10;  // in matRad this disables NLP-error acceptable sub-criterion
 const int qSlicerIpoptOptimizer::DEFAULT_MAX_ITER = 10000;
-const double qSlicerIpoptOptimizer::DEFAULT_MAX_TIME = 3600.0;
+const double qSlicerIpoptOptimizer::DEFAULT_MAX_TIME = 7200.0;
 
 //-----------------------------------------------------------------------------
 /// \ingroup SlicerRt_QtModules_ExternalBeamPlanning
@@ -100,6 +100,19 @@ public:
     double weight;
   };
   std::vector<StructureTerm> structureTerms;
+
+  struct ConstraintTerm {
+    Eigen::SparseMatrix<double> D;
+    QString constraintType;  // "MaxDose" or "MinDose"
+    double bound;
+    double smoothingT;
+  };
+  std::vector<ConstraintTerm> constraintTerms;
+
+  // Sparse Jacobian pattern set from Python via setConstraintJacobianSparsity().
+  // Empty → fall back to dense m×n pattern.
+  std::vector<std::pair<int,int>> jacSparsityPattern;
+  int numJacNonzeros = 0;
 };
 
 //-----------------------------------------------------------------------------
@@ -110,6 +123,13 @@ private:
   qSlicerIpoptOptimizerPrivate* d;
   Array x0;
   int n;
+
+  // Best-iterate tracking: save the iterate with the lowest constraint violation
+  // seen during optimization. Returned instead of the final iterate when the
+  // solver exits without converging (e.g. max iterations exceeded).
+  Array   bestX;
+  double  bestInfPr = std::numeric_limits<double>::max();
+  Array   lastEvalX;  // x seen in the most recent eval_f call
 
 public:
   IpoptProblem(qSlicerIpoptOptimizerPrivate* dPtr, const Array& initialPoint)
@@ -124,7 +144,7 @@ public:
   {
     n = this->n;
     m = d->numConstraints;
-    nnz_jac_g = m * n;  // dense Jacobian
+    nnz_jac_g = (d->numJacNonzeros > 0) ? d->numJacNonzeros : m * n;
     nnz_h_lag = 0;      // limited-memory BFGS — no explicit Hessian
     index_style = TNLP::C_STYLE;
     return true;
@@ -168,8 +188,21 @@ public:
       return false;
     }
 
-    Array xvec(x, x + n);
-    obj_value = d->objectiveFunction(xvec);
+    lastEvalX.assign(x, x + n);
+    obj_value = d->objectiveFunction(lastEvalX);
+    return true;
+  }
+
+  virtual bool intermediate_callback(AlgorithmMode mode, Index iter,
+    Number obj_value, Number inf_pr, Number inf_du, Number mu, Number d_norm,
+    Number regularization_size, Number alpha_du, Number alpha_pr,
+    Index ls_trials, const IpoptData* ip_data,
+    IpoptCalculatedQuantities* ip_cq) override
+  {
+    if (inf_pr < bestInfPr && !lastEvalX.empty()) {
+      bestInfPr = inf_pr;
+      bestX     = lastEvalX;
+    }
     return true;
   }
 
@@ -208,14 +241,16 @@ public:
   {
     if (m == 0) return true;
     if (values == nullptr) {
-      // Return sparsity structure — dense: row i, col j → entry i*n+j
-      Index k = 0;
-      for (Index i = 0; i < m; i++)
-        for (Index j = 0; j < n; j++) {
-          iRow[k] = i;
-          jCol[k] = j;
-          ++k;
+      if (!d->jacSparsityPattern.empty()) {
+        for (Index k = 0; k < nele_jac; ++k) {
+          iRow[k] = static_cast<Index>(d->jacSparsityPattern[k].first);
+          jCol[k] = static_cast<Index>(d->jacSparsityPattern[k].second);
         }
+      } else {
+        Index k = 0;
+        for (Index i = 0; i < m; i++)
+          for (Index j = 0; j < n; j++) { iRow[k] = i; jCol[k] = j; ++k; }
+      }
     } else {
       if (!d->constraintJacobianFunction) return false;
       Array xvec(x, x + n);
@@ -232,7 +267,11 @@ public:
                                 Number obj_value, const IpoptData* ip_data,
                                 IpoptCalculatedQuantities* ip_cq) override
   {
-    d->lastResult.solution = Array(x, x + n);
+    // Use the best iterate (lowest constraint violation) rather than the final
+    // iterate, which may be worse when the solver exits at max iterations.
+    bool converged = (status == SUCCESS || status == STOP_AT_ACCEPTABLE_POINT);
+    bool useBest   = !converged && !bestX.empty();
+    d->lastResult.solution = useBest ? bestX : Array(x, x + n);
     d->lastResult.final_objective_value = obj_value;
     d->lastResult.status = static_cast<ApplicationReturnStatus>(status);
     d->lastResult.success = (status == SUCCESS || status == STOP_AT_ACCEPTABLE_POINT);
@@ -333,6 +372,19 @@ void qSlicerIpoptOptimizer::setGradientFunction(GradientFunction func)
   d->gradientFunction = func;
 }
 
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setConstraintJacobianSparsity(const QList<int>& iRow,
+                                                           const QList<int>& jCol)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  d->jacSparsityPattern.clear();
+  const int n = qMin(iRow.size(), jCol.size());
+  d->jacSparsityPattern.reserve(n);
+  for (int k = 0; k < n; ++k)
+    d->jacSparsityPattern.emplace_back(iRow[k], jCol[k]);
+  d->numJacNonzeros = static_cast<int>(d->jacSparsityPattern.size());
+}
+
 
 //-----------------------------------------------------------------------------
 void qSlicerIpoptOptimizer::addStructureTerm(
@@ -358,12 +410,42 @@ void qSlicerIpoptOptimizer::addStructureTerm(
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::addStructureConstraint(
+  const QList<double>& data, const QList<int>& rowInd, const QList<int>& colInd,
+  int nVoxels, int nBixels, const QString& constraintType, double bound, double smoothingT)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  using Triplet = Eigen::Triplet<double>;
+  std::vector<Triplet> triplets;
+  triplets.reserve(data.size());
+  for (int k = 0; k < data.size(); ++k)
+    triplets.emplace_back(rowInd[k], colInd[k], data[k]);
+
+  qSlicerIpoptOptimizerPrivate::ConstraintTerm term;
+  term.D.resize(nVoxels, nBixels);
+  term.D.setFromTriplets(triplets.begin(), triplets.end());
+  term.constraintType = constraintType;
+  term.bound          = bound;
+  term.smoothingT     = smoothingT;
+
+  d->constraintTerms.push_back(std::move(term));
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerIpoptOptimizer::clearStructureTerms()
 {
   Q_D(qSlicerIpoptOptimizer);
   d->structureTerms.clear();
-  d->objectiveFunction = nullptr;
-  d->gradientFunction  = nullptr;
+  d->constraintTerms.clear();
+  d->objectiveFunction          = nullptr;
+  d->gradientFunction           = nullptr;
+  d->constraintFunction         = nullptr;
+  d->constraintJacobianFunction = nullptr;
+  d->constraintBoundsFunction   = nullptr;
+  d->numConstraints             = 0;
+  d->jacSparsityPattern.clear();
+  d->numJacNonzeros             = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -419,6 +501,13 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
             double diff = dose[i] - t.bound;
             f += diff * diff;
           }
+        } else if (t.objectiveType == "MeanDose") {
+          double meanDose = dose.sum() / dose.size();
+          f = std::abs(meanDose - t.bound) * dose.size(); // linear |mean-bound| (matRad default)
+        } else if (t.objectiveType == "MeanDoseQuadratic") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          f = diff * diff * dose.size(); // quadratic (mean-bound)^2
         }
         total += t.weight * f / dose.size();
       }
@@ -447,6 +536,15 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
         } else if (t.objectiveType == "SquaredDeviation") {
           for (int i = 0; i < dose.size(); ++i)
             gDose[i] = 2.0 * (dose[i] - t.bound);
+        } else if (t.objectiveType == "MeanDose") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          if (diff != 0.0)
+            gDose = Eigen::VectorXd::Constant(dose.size(), diff > 0.0 ? 1.0 : -1.0);
+        } else if (t.objectiveType == "MeanDoseQuadratic") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          gDose = Eigen::VectorXd::Constant(dose.size(), 2.0 * diff);
         }
         grad += t.weight * (t.D.transpose() * gDose) / dose.size();
       }
@@ -454,8 +552,139 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
     };
   }
 
+  // Auto-wire constraints from constraintTerms when present
+  if (!d->constraintTerms.empty())
+  {
+    auto sharedCon = std::make_shared<std::vector<qSlicerIpoptOptimizerPrivate::ConstraintTerm>>(
+      d->constraintTerms);
+
+    int numCon = static_cast<int>(d->constraintTerms.size());
+    d->numConstraints = numCon;
+
+    d->constraintBoundsFunction = [sharedCon, numCon]()
+      -> std::pair<qSlicerIpoptOptimizer::Array, qSlicerIpoptOptimizer::Array>
+    {
+      qSlicerIpoptOptimizer::Array lb(numCon, -1e19);
+      qSlicerIpoptOptimizer::Array ub(numCon,  1e19);
+      for (int i = 0; i < numCon; ++i)
+      {
+        const auto& t = (*sharedCon)[i];
+        if (t.constraintType == "MaxDose") { lb[i] = 0.0; ub[i] = t.bound; }
+        else                               { lb[i] = t.bound; }  // MinDose
+      }
+      return {lb, ub};
+    };
+
+    // g_i(w) = logsumexp( D_i·w, T)          for MaxDose  → constrained ≤ bound
+    // g_i(w) = −logsumexp(−D_i·w, T)         for MinDose  → constrained ≥ bound
+    d->constraintFunction = [sharedCon](const qSlicerIpoptOptimizer::Array& w)
+      -> qSlicerIpoptOptimizer::Array
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      qSlicerIpoptOptimizer::Array g;
+      g.reserve(sharedCon->size());
+      for (const auto& t : *sharedCon)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        if (t.constraintType == "MinDose") dose = -dose;
+        // numerically stable logsumexp
+        double dmax = dose.maxCoeff();
+        double sum  = 0.0;
+        for (int j = 0; j < dose.size(); ++j)
+          sum += std::exp((dose[j] - dmax) / t.smoothingT);
+        double val = dmax + t.smoothingT * std::log(sum);
+        g.push_back(t.constraintType == "MinDose" ? -val : val);
+      }
+      return g;
+    };
+
+    // If no sparsity pattern was set from Python, auto-compute it from D non-zeros.
+    if (d->jacSparsityPattern.empty())
+    {
+      for (int ci = 0; ci < numCon; ++ci)
+      {
+        const auto& t = (*sharedCon)[ci];
+        for (int j = 0; j < t.D.outerSize(); ++j)
+          if (t.D.outerIndexPtr()[j] < t.D.outerIndexPtr()[j + 1])
+            d->jacSparsityPattern.emplace_back(ci, j);
+      }
+      d->numJacNonzeros = static_cast<int>(d->jacSparsityPattern.size());
+    }
+
+    // Sparse Jacobian: for each (ci, j) in pattern, value = D_ci.col(j) · softmax(±dose_ci)
+    auto sharedPat = std::make_shared<std::vector<std::pair<int,int>>>(d->jacSparsityPattern);
+    d->constraintJacobianFunction = [sharedCon, sharedPat](const qSlicerIpoptOptimizer::Array& w)
+      -> qSlicerIpoptOptimizer::Array
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      qSlicerIpoptOptimizer::Array vals(sharedPat->size());
+      int curCi = -1;
+      Eigen::VectorXd softw;
+      for (int k = 0; k < static_cast<int>(sharedPat->size()); ++k)
+      {
+        int ci = (*sharedPat)[k].first;
+        int j  = (*sharedPat)[k].second;
+        if (ci != curCi)
+        {
+          const auto& t = (*sharedCon)[ci];
+          Eigen::VectorXd dose = t.D * wv;
+          if (t.constraintType == "MinDose") dose = -dose;
+          double dmax = dose.maxCoeff();
+          Eigen::VectorXd expv(dose.size());
+          for (int v = 0; v < dose.size(); ++v)
+            expv[v] = std::exp((dose[v] - dmax) / t.smoothingT);
+          softw = expv / expv.sum();
+          curCi = ci;
+        }
+        vals[k] = (*sharedCon)[ci].D.col(j).dot(softw);
+      }
+      return vals;
+    };
+  }
+
+  // Match matRad's x0 initialization exactly:
+  //   doseTarget = max dose parameter across all target structures
+  //   V          = union of all target voxels (SquaredUnderdosing + MinDose)
+  //   scale      = doseTarget / mean(D_allTargets * ones)
+  //   x0         = scale * ones
+  // Reference: matRad_fluenceOptimization.m lines 99-122, 312-314
+  Array startX0 = x0;
+  {
+    int n = static_cast<int>(x0.size());
+    Eigen::VectorXd wOnes = Eigen::VectorXd::Ones(n);
+    double doseTarget = 0.0;
+    std::vector<double> allTargetDoses;
+
+    for (const auto& t : d->structureTerms)
+    {
+      if (t.objectiveType == "SquaredUnderdosing")
+      {
+        doseTarget = std::max(doseTarget, t.bound);
+        Eigen::VectorXd dose = t.D * wOnes;
+        allTargetDoses.insert(allTargetDoses.end(), dose.data(), dose.data() + dose.size());
+      }
+    }
+    for (const auto& t : d->constraintTerms)
+    {
+      if (t.constraintType == "MinDose")
+      {
+        doseTarget = std::max(doseTarget, t.bound);
+        Eigen::VectorXd dose = t.D * wOnes;
+        allTargetDoses.insert(allTargetDoses.end(), dose.data(), dose.data() + dose.size());
+      }
+    }
+
+    if (doseTarget > 0.0 && !allTargetDoses.empty())
+    {
+      double meanTargetDose = std::accumulate(allTargetDoses.begin(), allTargetDoses.end(), 0.0)
+                              / static_cast<double>(allTargetDoses.size());
+      if (meanTargetDose > 0.0)
+        startX0.assign(n, doseTarget / meanTargetDose);
+    }
+  }
+
   // Create and validate IPOPT problem
-  SmartPtr<IpoptProblem> nlp = d->validateIpoptProblem(x0);
+  SmartPtr<IpoptProblem> nlp = d->validateIpoptProblem(startX0);
   if (IsNull(nlp)) {
     Result result;
     result.success = false;
@@ -541,19 +770,28 @@ void qSlicerIpoptOptimizer::setOption(const QString& key, const QVariant& value)
   Q_D(qSlicerIpoptOptimizer);
 
 
-  // Handle individual option setting
-  if (key == "print_level") {
-    d->options.print_level = value.toInt();
-  } else if (key == "tol") {
-    d->options.tol = value.toDouble();
-  } else if (key == "max_iter") {
-    d->options.max_iter = value.toInt();
-  } else if (key == "max_cpu_time") {
-    d->options.max_cpu_time = value.toDouble();
-  } else if (key == "acceptable_tol") {
-    d->options.acceptable_tol = value.toDouble();
-  }
-  // Add more option handling as needed
+  if      (key == "print_level")                d->options.print_level = value.toInt();
+  else if (key == "tol")                         d->options.tol = value.toDouble();
+  else if (key == "dual_inf_tol")               d->options.dual_inf_tol = value.toDouble();
+  else if (key == "constr_viol_tol")            d->options.constr_viol_tol = value.toDouble();
+  else if (key == "compl_inf_tol")              d->options.compl_inf_tol = value.toDouble();
+  else if (key == "acceptable_iter")            d->options.acceptable_iter = value.toInt();
+  else if (key == "acceptable_tol")             d->options.acceptable_tol = value.toDouble();
+  else if (key == "acceptable_constr_viol_tol") d->options.acceptable_constr_viol_tol = value.toDouble();
+  else if (key == "acceptable_dual_inf_tol")    d->options.acceptable_dual_inf_tol = value.toDouble();
+  else if (key == "acceptable_compl_inf_tol")   d->options.acceptable_compl_inf_tol = value.toDouble();
+  else if (key == "acceptable_obj_change_tol")  d->options.acceptable_obj_change_tol = value.toDouble();
+  else if (key == "max_iter")                    d->options.max_iter = value.toInt();
+  else if (key == "max_resto_iter")              d->options.max_resto_iter = value.toInt();
+  else if (key == "max_cpu_time")               d->options.max_cpu_time = value.toDouble();
+  else if (key == "mu_strategy")                d->options.mu_strategy = value.toString();
+  else if (key == "hessian_approximation")      d->options.hessian_approximation = value.toString();
+  else if (key == "limited_memory_max_history") d->options.limited_memory_max_history = value.toInt();
+  else if (key == "limited_memory_initialization") d->options.limited_memory_initialization = value.toString();
+  else if (key == "linear_solver")              d->options.linear_solver = value.toString();
+  else if (key == "print_user_options")         d->options.print_user_options = value.toString();
+  else if (key == "print_options_documentation") d->options.print_options_documentation = value.toString();
+  else if (key == "print_timing_statistics")    d->options.print_timing_statistics = value.toString();
 }
 
 //-----------------------------------------------------------------------------
@@ -989,7 +1227,10 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
 
   // ── Step 4: solve ──
   emit progressInfoUpdated("Starting IPOPT optimization...");
-  Array w0(totalBixels, 1.0 / totalBixels); // uniform initial fluence
+
+  // Scale initial weights so the mean dose in the most demanding MinDose
+  Array w0(totalBixels, 1.0 / totalBixels);
+
   Result result = solveProblem(w0);
   if (!result.success)
     return QString("IPOPT solver did not converge (status %1)").arg(result.status);

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
@@ -1,0 +1,1257 @@
+#include "qSlicerIpoptOptimizer.h"
+
+// ExternalBeamPlanning includes
+#include "qSlicerAbstractObjective.h"
+#include "qSlicerAbstractConstraint.h"
+#include "qSlicerSquaredDeviationObjective.h"
+#include "qSlicerSquaredOverdosingObjective.h"
+#include "qSlicerSquaredUnderdosingObjective.h"
+#include "qSlicerMeanDoseObjective.h"
+#include "qSlicerEUDObjective.h"
+#include "qSlicerMaxDVHObjective.h"
+#include "qSlicerMinDVHObjective.h"
+#include "qSlicerMinMaxDoseConstraint.h"
+#include "qSlicerMinMaxDVHConstraint.h"
+#include "qSlicerMinMaxEUDConstraint.h"
+#include "qSlicerMinMaxMeanDoseConstraint.h"
+
+// Beams includes
+#include "vtkMRMLRTBeamNode.h"
+
+// MRML includes
+#include "vtkMRMLRTPlanNode.h"
+#include "vtkMRMLRTObjectiveNode.h"
+#include "vtkMRMLSegmentationNode.h"
+#include <vtkMRMLScalarVolumeNode.h>
+
+// Segmentations includes
+#include "vtkSlicerSegmentationsModuleLogic.h"
+
+// MRML includes (continued)
+#include <vtkMRMLLabelMapVolumeNode.h>
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkImageReslice.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkStringArray.h>
+
+// Eigen includes
+#include <itkeigen/Eigen/Dense>
+#include <itkeigen/Eigen/Sparse>
+
+// Qt includes
+#include <QDebug>
+
+// STL includes
+#include <iostream>
+#include <regex>
+#include <cassert>
+#include <numeric>
+#include <memory>
+
+// Static constants
+const QString qSlicerIpoptOptimizer::NAME = "Interior Point Optimizer";
+const QString qSlicerIpoptOptimizer::SHORT_NAME = "ipopt";
+const bool qSlicerIpoptOptimizer::GPU_COMPATIBLE = false;
+const bool qSlicerIpoptOptimizer::ALLOW_KEYBOARD_CANCEL = false;
+const double qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL = 1e10;  // in matRad this disables NLP-error acceptable sub-criterion
+const int qSlicerIpoptOptimizer::DEFAULT_MAX_ITER = 10000;
+const double qSlicerIpoptOptimizer::DEFAULT_MAX_TIME = 7200.0;
+
+//-----------------------------------------------------------------------------
+/// \ingroup SlicerRt_QtModules_ExternalBeamPlanning
+class qSlicerIpoptOptimizerPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerIpoptOptimizer);
+protected:
+  qSlicerIpoptOptimizer* const q_ptr;
+
+public:
+  qSlicerIpoptOptimizerPrivate(qSlicerIpoptOptimizer& object);
+  ~qSlicerIpoptOptimizerPrivate();
+
+  // Options and settings
+  qSlicerIpoptOptimizer::Options options;
+  qSlicerIpoptOptimizer::Result lastResult;
+
+  // Function pointers — objectives
+  qSlicerIpoptOptimizer::ObjectiveFunction objectiveFunction;
+  qSlicerIpoptOptimizer::GradientFunction gradientFunction;
+
+  // Function pointers — constraints
+  // constraintFunction: w → g(w), size numConstraints
+  // constraintJacobianFunction: w → row-major Jacobian, size numConstraints*|w|
+  // constraintBoundsFunction: () → {lb, ub}, each size numConstraints
+  std::function<qSlicerIpoptOptimizer::Array(const qSlicerIpoptOptimizer::Array&)> constraintFunction;
+  std::function<qSlicerIpoptOptimizer::Array(const qSlicerIpoptOptimizer::Array&)> constraintJacobianFunction;
+  std::function<std::pair<qSlicerIpoptOptimizer::Array,
+                          qSlicerIpoptOptimizer::Array>()>                         constraintBoundsFunction;
+  int numConstraints = 0;
+
+  SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> validateIpoptProblem(
+    const qSlicerIpoptOptimizer::Array& x0);
+
+  struct StructureTerm {
+    Eigen::SparseMatrix<double> D;
+    QString objectiveType;
+    double bound;
+    double weight;
+  };
+  std::vector<StructureTerm> structureTerms;
+
+  struct ConstraintTerm {
+    Eigen::SparseMatrix<double> D;
+    QString constraintType;  // "MaxDose" or "MinDose"
+    double bound;
+    double smoothingT;
+  };
+  std::vector<ConstraintTerm> constraintTerms;
+
+  // Sparse Jacobian pattern set from Python via setConstraintJacobianSparsity().
+  // Empty → fall back to dense m×n pattern.
+  std::vector<std::pair<int,int>> jacSparsityPattern;
+  int numJacNonzeros = 0;
+};
+
+//-----------------------------------------------------------------------------
+/// Internal TNLP implementation for IPOPT
+class qSlicerIpoptOptimizer::IpoptProblem : public TNLP
+{
+private:
+  qSlicerIpoptOptimizerPrivate* d;
+  Array x0;
+  int n;
+
+  // Best-iterate tracking: save the iterate with the lowest constraint violation
+  // seen during optimization. Returned instead of the final iterate when the
+  // solver exits without converging (e.g. max iterations exceeded).
+  Array   bestX;
+  double  bestInfPr = std::numeric_limits<double>::max();
+  Array   lastEvalX;  // x seen in the most recent eval_f call
+
+public:
+  IpoptProblem(qSlicerIpoptOptimizerPrivate* dPtr, const Array& initialPoint)
+    : d(dPtr), x0(initialPoint), n(static_cast<int>(initialPoint.size()))
+  {}
+
+  virtual ~IpoptProblem() = default;
+
+  // TNLP interface implementation
+  virtual bool get_nlp_info(Index& n, Index& m, Index& nnz_jac_g,
+                           Index& nnz_h_lag, IndexStyleEnum& index_style) override
+  {
+    n = this->n;
+    m = d->numConstraints;
+    nnz_jac_g = (d->numJacNonzeros > 0) ? d->numJacNonzeros : m * n;
+    nnz_h_lag = 0;      // limited-memory BFGS — no explicit Hessian
+    index_style = TNLP::C_STYLE;
+    return true;
+  }
+
+  virtual bool get_bounds_info(Index n, Number* x_l, Number* x_u,
+                              Index m, Number* g_l, Number* g_u) override
+  {
+    for (Index i = 0; i < n; i++) {
+      x_l[i] = 0.0;   // fluence weights must be non-negative
+      x_u[i] = 1e19;
+    }
+    if (m > 0 && d->constraintBoundsFunction) {
+      auto [lb, ub] = d->constraintBoundsFunction();
+      for (Index i = 0; i < m; i++) {
+        g_l[i] = (i < static_cast<Index>(lb.size())) ? lb[i] : -1e19;
+        g_u[i] = (i < static_cast<Index>(ub.size())) ? ub[i] :  1e19;
+      }
+    }
+    return true;
+  }
+
+  virtual bool get_starting_point(Index n, bool init_x, Number* x,
+                                 bool init_z, Number* z_L, Number* z_U,
+                                 Index m, bool init_lambda, Number* lambda) override
+  {
+    assert(init_x == true);
+    assert(init_z == false);
+    assert(init_lambda == false);
+
+    // Set initial point
+    for (Index i = 0; i < n; i++) {
+      x[i] = (i < static_cast<Index>(x0.size())) ? x0[i] : 0.0;
+    }
+    return true;
+  }
+
+  virtual bool eval_f(Index n, const Number* x, bool new_x, Number& obj_value) override
+  {
+    if (!d->objectiveFunction) {
+      return false;
+    }
+
+    lastEvalX.assign(x, x + n);
+    obj_value = d->objectiveFunction(lastEvalX);
+    return true;
+  }
+
+  virtual bool intermediate_callback(AlgorithmMode mode, Index iter,
+    Number obj_value, Number inf_pr, Number inf_du, Number mu, Number d_norm,
+    Number regularization_size, Number alpha_du, Number alpha_pr,
+    Index ls_trials, const IpoptData* ip_data,
+    IpoptCalculatedQuantities* ip_cq) override
+  {
+    if (inf_pr < bestInfPr && !lastEvalX.empty()) {
+      bestInfPr = inf_pr;
+      bestX     = lastEvalX;
+    }
+    return true;
+  }
+
+  virtual bool eval_grad_f(Index n, const Number* x, bool new_x, Number* grad_f) override
+  {
+    if (!d->gradientFunction) {
+      return false;
+    }
+
+    Array xvec(x, x + n);
+    Array gradient = d->gradientFunction(xvec);
+
+    if (gradient.size() != static_cast<size_t>(n)) {
+      return false;
+    }
+
+    for (Index i = 0; i < n; i++) {
+      grad_f[i] = gradient[i];
+    }
+    return true;
+  }
+
+  virtual bool eval_g(Index n, const Number* x, bool new_x, Index m, Number* g) override
+  {
+    if (m == 0) return true;
+    if (!d->constraintFunction) return false;
+    Array xvec(x, x + n);
+    Array gvec = d->constraintFunction(xvec);
+    for (Index i = 0; i < m; i++)
+      g[i] = (i < static_cast<Index>(gvec.size())) ? gvec[i] : 0.0;
+    return true;
+  }
+
+  virtual bool eval_jac_g(Index n, const Number* x, bool new_x, Index m,
+                          Index nele_jac, Index* iRow, Index* jCol, Number* values) override
+  {
+    if (m == 0) return true;
+    if (values == nullptr) {
+      if (!d->jacSparsityPattern.empty()) {
+        for (Index k = 0; k < nele_jac; ++k) {
+          iRow[k] = static_cast<Index>(d->jacSparsityPattern[k].first);
+          jCol[k] = static_cast<Index>(d->jacSparsityPattern[k].second);
+        }
+      } else {
+        Index k = 0;
+        for (Index i = 0; i < m; i++)
+          for (Index j = 0; j < n; j++) { iRow[k] = i; jCol[k] = j; ++k; }
+      }
+    } else {
+      if (!d->constraintJacobianFunction) return false;
+      Array xvec(x, x + n);
+      Array jac = d->constraintJacobianFunction(xvec);
+      for (Index k2 = 0; k2 < nele_jac; k2++)
+        values[k2] = (k2 < static_cast<Index>(jac.size())) ? jac[k2] : 0.0;
+    }
+    return true;
+  }
+
+  virtual void finalize_solution(SolverReturn status, Index n, const Number* x,
+                                const Number* z_L, const Number* z_U,
+                                Index m, const Number* g, const Number* lambda,
+                                Number obj_value, const IpoptData* ip_data,
+                                IpoptCalculatedQuantities* ip_cq) override
+  {
+    // Use the best iterate (lowest constraint violation) rather than the final
+    // iterate, which may be worse when the solver exits at max iterations.
+    bool converged = (status == SUCCESS || status == STOP_AT_ACCEPTABLE_POINT);
+    bool useBest   = !converged && !bestX.empty();
+    d->lastResult.solution = useBest ? bestX : Array(x, x + n);
+    d->lastResult.final_objective_value = obj_value;
+    d->lastResult.status = static_cast<ApplicationReturnStatus>(status);
+    d->lastResult.success = (status == SUCCESS || status == STOP_AT_ACCEPTABLE_POINT);
+  }
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerIpoptOptimizerPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizerPrivate::qSlicerIpoptOptimizerPrivate(qSlicerIpoptOptimizer& object)
+  : q_ptr(&object)
+{
+  // Initialize default options
+  options.acceptable_tol = qSlicerIpoptOptimizer::DEFAULT_ABS_OBJ_TOL;
+  options.max_iter = qSlicerIpoptOptimizer::DEFAULT_MAX_ITER;
+  options.max_cpu_time = qSlicerIpoptOptimizer::DEFAULT_MAX_TIME;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizerPrivate::~qSlicerIpoptOptimizerPrivate() = default;
+
+//-----------------------------------------------------------------------------
+SmartPtr<qSlicerIpoptOptimizer::IpoptProblem> qSlicerIpoptOptimizerPrivate::validateIpoptProblem(
+  const qSlicerIpoptOptimizer::Array& x0)
+{
+  // Validate required functions
+  if (!objectiveFunction) {
+    qCritical() << "Objective function not set";
+    return nullptr;
+  }
+
+  if (!gradientFunction) {
+    qCritical() << "Gradient function not set";
+    return nullptr;
+  }
+
+  if (x0.empty()) {
+    qCritical() << "Initial point is empty";
+    return nullptr;
+  }
+
+  return SmartPtr<qSlicerIpoptOptimizer::IpoptProblem>(new qSlicerIpoptOptimizer::IpoptProblem(this, x0));
+}
+
+//-----------------------------------------------------------------------------
+// qSlicerIpoptOptimizer methods
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::qSlicerIpoptOptimizer(QObject* parent)
+  : Superclass(parent)
+  , d_ptr(new qSlicerIpoptOptimizerPrivate(*this))
+{
+  this->m_Name = NAME;
+  this->setAvailableObjectives();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::~qSlicerIpoptOptimizer() = default;
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setMaxIterations(int maxIter)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->options.max_iter = maxIter;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setMaxTime(double maxTime)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->options.max_cpu_time = maxTime;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setAbsoluteObjectiveTolerance(double tol)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->options.acceptable_tol = tol;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setObjectiveFunction(ObjectiveFunction func)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->objectiveFunction = func;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setGradientFunction(GradientFunction func)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->gradientFunction = func;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setConstraintJacobianSparsity(const QList<int>& iRow,
+                                                           const QList<int>& jCol)
+{
+  Q_D(qSlicerIpoptOptimizer);
+  d->jacSparsityPattern.clear();
+  const int n = qMin(iRow.size(), jCol.size());
+  d->jacSparsityPattern.reserve(n);
+  for (int k = 0; k < n; ++k)
+    d->jacSparsityPattern.emplace_back(iRow[k], jCol[k]);
+  d->numJacNonzeros = static_cast<int>(d->jacSparsityPattern.size());
+}
+
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::addStructureTerm(
+  const QList<double>& data, const QList<int>& rowInd, const QList<int>& colInd,
+  int nVoxels, int nBixels, const QString& objectiveType, double bound, double weight)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  using Triplet = Eigen::Triplet<double>;
+  std::vector<Triplet> triplets;
+  triplets.reserve(data.size());
+  for (int k = 0; k < data.size(); ++k)
+    triplets.emplace_back(rowInd[k], colInd[k], data[k]);
+
+  qSlicerIpoptOptimizerPrivate::StructureTerm term;
+  term.D.resize(nVoxels, nBixels);
+  term.D.setFromTriplets(triplets.begin(), triplets.end());
+  term.objectiveType = objectiveType;
+  term.bound = bound;
+  term.weight = weight;
+
+  d->structureTerms.push_back(std::move(term));
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::addStructureConstraint(
+  const QList<double>& data, const QList<int>& rowInd, const QList<int>& colInd,
+  int nVoxels, int nBixels, const QString& constraintType, double bound, double smoothingT)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  using Triplet = Eigen::Triplet<double>;
+  std::vector<Triplet> triplets;
+  triplets.reserve(data.size());
+  for (int k = 0; k < data.size(); ++k)
+    triplets.emplace_back(rowInd[k], colInd[k], data[k]);
+
+  qSlicerIpoptOptimizerPrivate::ConstraintTerm term;
+  term.D.resize(nVoxels, nBixels);
+  term.D.setFromTriplets(triplets.begin(), triplets.end());
+  term.constraintType = constraintType;
+  term.bound          = bound;
+  term.smoothingT     = smoothingT;
+
+  d->constraintTerms.push_back(std::move(term));
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::clearStructureTerms()
+{
+  Q_D(qSlicerIpoptOptimizer);
+  d->structureTerms.clear();
+  d->constraintTerms.clear();
+  d->objectiveFunction          = nullptr;
+  d->gradientFunction           = nullptr;
+  d->constraintFunction         = nullptr;
+  d->constraintJacobianFunction = nullptr;
+  d->constraintBoundsFunction   = nullptr;
+  d->numConstraints             = 0;
+  d->jacSparsityPattern.clear();
+  d->numJacNonzeros             = 0;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerIpoptOptimizer::solve(const QList<double>& x0)
+{
+  Array x0vec(x0.begin(), x0.end());
+  Result result = solveProblem(x0vec);
+  return result.success;
+}
+
+//-----------------------------------------------------------------------------
+QList<double> qSlicerIpoptOptimizer::getSolution() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+  QList<double> sol;
+  sol.reserve(static_cast<int>(d->lastResult.solution.size()));
+  for (double v : d->lastResult.solution)
+    sol.append(v);
+  return sol;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x0)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  // Auto-wire objective/gradient from structure terms when no explicit function is set
+  if (!d->structureTerms.empty())
+  {
+    auto sharedTerms = std::make_shared<std::vector<qSlicerIpoptOptimizerPrivate::StructureTerm>>(
+      d->structureTerms);
+
+    d->objectiveFunction = [sharedTerms](const Array& w) -> double
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      double total = 0.0;
+      for (const auto& t : *sharedTerms)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        double f = 0.0;
+        if (t.objectiveType == "SquaredOverdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            if (diff > 0.0) f += diff * diff;
+          }
+        } else if (t.objectiveType == "SquaredUnderdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = t.bound - dose[i];
+            if (diff > 0.0) f += diff * diff;
+          }
+        } else if (t.objectiveType == "SquaredDeviation") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            f += diff * diff;
+          }
+        } else if (t.objectiveType == "MeanDose") {
+          double meanDose = dose.sum() / dose.size();
+          f = std::abs(meanDose - t.bound) * dose.size(); // linear |mean-bound| (matRad default)
+        } else if (t.objectiveType == "MeanDoseQuadratic") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          f = diff * diff * dose.size(); // quadratic (mean-bound)^2
+        }
+        total += t.weight * f / dose.size();
+      }
+      return total;
+    };
+
+    d->gradientFunction = [sharedTerms](const Array& w) -> Array
+    {
+      int n = static_cast<int>(w.size());
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), n);
+      Eigen::VectorXd grad = Eigen::VectorXd::Zero(n);
+      for (const auto& t : *sharedTerms)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        Eigen::VectorXd gDose = Eigen::VectorXd::Zero(dose.size());
+        if (t.objectiveType == "SquaredOverdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = dose[i] - t.bound;
+            if (diff > 0.0) gDose[i] = 2.0 * diff;
+          }
+        } else if (t.objectiveType == "SquaredUnderdosing") {
+          for (int i = 0; i < dose.size(); ++i) {
+            double diff = t.bound - dose[i];
+            if (diff > 0.0) gDose[i] = -2.0 * diff;
+          }
+        } else if (t.objectiveType == "SquaredDeviation") {
+          for (int i = 0; i < dose.size(); ++i)
+            gDose[i] = 2.0 * (dose[i] - t.bound);
+        } else if (t.objectiveType == "MeanDose") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          if (diff != 0.0)
+            gDose = Eigen::VectorXd::Constant(dose.size(), diff > 0.0 ? 1.0 : -1.0);
+        } else if (t.objectiveType == "MeanDoseQuadratic") {
+          double meanDose = dose.sum() / dose.size();
+          double diff = meanDose - t.bound;
+          gDose = Eigen::VectorXd::Constant(dose.size(), 2.0 * diff);
+        }
+        grad += t.weight * (t.D.transpose() * gDose) / dose.size();
+      }
+      return Array(grad.data(), grad.data() + n);
+    };
+  }
+
+  // Auto-wire constraints from constraintTerms when present
+  if (!d->constraintTerms.empty())
+  {
+    auto sharedCon = std::make_shared<std::vector<qSlicerIpoptOptimizerPrivate::ConstraintTerm>>(
+      d->constraintTerms);
+
+    int numCon = static_cast<int>(d->constraintTerms.size());
+    d->numConstraints = numCon;
+
+    d->constraintBoundsFunction = [sharedCon, numCon]()
+      -> std::pair<qSlicerIpoptOptimizer::Array, qSlicerIpoptOptimizer::Array>
+    {
+      qSlicerIpoptOptimizer::Array lb(numCon, -1e19);
+      qSlicerIpoptOptimizer::Array ub(numCon,  1e19);
+      for (int i = 0; i < numCon; ++i)
+      {
+        const auto& t = (*sharedCon)[i];
+        if (t.constraintType == "MaxDose") { lb[i] = 0.0; ub[i] = t.bound; }
+        else                               { lb[i] = t.bound; }  // MinDose
+      }
+      return {lb, ub};
+    };
+
+    // g_i(w) = logsumexp( D_i·w, T)          for MaxDose  → constrained ≤ bound
+    // g_i(w) = −logsumexp(−D_i·w, T)         for MinDose  → constrained ≥ bound
+    d->constraintFunction = [sharedCon](const qSlicerIpoptOptimizer::Array& w)
+      -> qSlicerIpoptOptimizer::Array
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      qSlicerIpoptOptimizer::Array g;
+      g.reserve(sharedCon->size());
+      for (const auto& t : *sharedCon)
+      {
+        Eigen::VectorXd dose = t.D * wv;
+        if (t.constraintType == "MinDose") dose = -dose;
+        // numerically stable logsumexp
+        double dmax = dose.maxCoeff();
+        double sum  = 0.0;
+        for (int j = 0; j < dose.size(); ++j)
+          sum += std::exp((dose[j] - dmax) / t.smoothingT);
+        double val = dmax + t.smoothingT * std::log(sum);
+        g.push_back(t.constraintType == "MinDose" ? -val : val);
+      }
+      return g;
+    };
+
+    // If no sparsity pattern was set from Python, auto-compute it from D non-zeros.
+    if (d->jacSparsityPattern.empty())
+    {
+      for (int ci = 0; ci < numCon; ++ci)
+      {
+        const auto& t = (*sharedCon)[ci];
+        for (int j = 0; j < t.D.outerSize(); ++j)
+          if (t.D.outerIndexPtr()[j] < t.D.outerIndexPtr()[j + 1])
+            d->jacSparsityPattern.emplace_back(ci, j);
+      }
+      d->numJacNonzeros = static_cast<int>(d->jacSparsityPattern.size());
+    }
+
+    // Sparse Jacobian: for each (ci, j) in pattern, value = D_ci.col(j) · softmax(±dose_ci)
+    auto sharedPat = std::make_shared<std::vector<std::pair<int,int>>>(d->jacSparsityPattern);
+    d->constraintJacobianFunction = [sharedCon, sharedPat](const qSlicerIpoptOptimizer::Array& w)
+      -> qSlicerIpoptOptimizer::Array
+    {
+      Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+      qSlicerIpoptOptimizer::Array vals(sharedPat->size());
+      int curCi = -1;
+      Eigen::VectorXd softw;
+      for (int k = 0; k < static_cast<int>(sharedPat->size()); ++k)
+      {
+        int ci = (*sharedPat)[k].first;
+        int j  = (*sharedPat)[k].second;
+        if (ci != curCi)
+        {
+          const auto& t = (*sharedCon)[ci];
+          Eigen::VectorXd dose = t.D * wv;
+          if (t.constraintType == "MinDose") dose = -dose;
+          double dmax = dose.maxCoeff();
+          Eigen::VectorXd expv(dose.size());
+          for (int v = 0; v < dose.size(); ++v)
+            expv[v] = std::exp((dose[v] - dmax) / t.smoothingT);
+          softw = expv / expv.sum();
+          curCi = ci;
+        }
+        vals[k] = (*sharedCon)[ci].D.col(j).dot(softw);
+      }
+      return vals;
+    };
+  }
+
+  // Match matRad's x0 initialization exactly:
+  //   doseTarget = max dose parameter across all target structures
+  //   V          = union of all target voxels (SquaredUnderdosing + MinDose)
+  //   scale      = doseTarget / mean(D_allTargets * ones)
+  //   x0         = scale * ones
+  // Reference: matRad_fluenceOptimization.m lines 99-122, 312-314
+  Array startX0 = x0;
+  {
+    int n = static_cast<int>(x0.size());
+    Eigen::VectorXd wOnes = Eigen::VectorXd::Ones(n);
+    double doseTarget = 0.0;
+    std::vector<double> allTargetDoses;
+
+    for (const auto& t : d->structureTerms)
+    {
+      if (t.objectiveType == "SquaredUnderdosing")
+      {
+        doseTarget = std::max(doseTarget, t.bound);
+        Eigen::VectorXd dose = t.D * wOnes;
+        allTargetDoses.insert(allTargetDoses.end(), dose.data(), dose.data() + dose.size());
+      }
+    }
+    for (const auto& t : d->constraintTerms)
+    {
+      if (t.constraintType == "MinDose")
+      {
+        doseTarget = std::max(doseTarget, t.bound);
+        Eigen::VectorXd dose = t.D * wOnes;
+        allTargetDoses.insert(allTargetDoses.end(), dose.data(), dose.data() + dose.size());
+      }
+    }
+
+    if (doseTarget > 0.0 && !allTargetDoses.empty())
+    {
+      double meanTargetDose = std::accumulate(allTargetDoses.begin(), allTargetDoses.end(), 0.0)
+                              / static_cast<double>(allTargetDoses.size());
+      if (meanTargetDose > 0.0)
+        startX0.assign(n, doseTarget / meanTargetDose);
+    }
+  }
+
+  // Create and validate IPOPT problem
+  SmartPtr<IpoptProblem> nlp = d->validateIpoptProblem(startX0);
+  if (IsNull(nlp)) {
+    Result result;
+    result.success = false;
+    result.status = Invalid_Problem_Definition;
+    return result;
+  }
+
+  // Create IPOPT application
+  SmartPtr<IpoptApplication> app = IpoptApplicationFactory();
+
+  // Set options
+  app->Options()->SetNumericValue("tol", d->options.tol);
+  app->Options()->SetNumericValue("dual_inf_tol", d->options.dual_inf_tol);
+  app->Options()->SetNumericValue("constr_viol_tol", d->options.constr_viol_tol);
+  app->Options()->SetNumericValue("compl_inf_tol", d->options.compl_inf_tol);
+  app->Options()->SetIntegerValue("acceptable_iter", d->options.acceptable_iter);
+  app->Options()->SetNumericValue("acceptable_tol", d->options.acceptable_tol);
+  app->Options()->SetNumericValue("acceptable_constr_viol_tol", d->options.acceptable_constr_viol_tol);
+  app->Options()->SetNumericValue("acceptable_dual_inf_tol", d->options.acceptable_dual_inf_tol);
+  app->Options()->SetNumericValue("acceptable_compl_inf_tol", d->options.acceptable_compl_inf_tol);
+  app->Options()->SetNumericValue("acceptable_obj_change_tol", d->options.acceptable_obj_change_tol);
+  app->Options()->SetIntegerValue("max_iter", d->options.max_iter);
+  app->Options()->SetIntegerValue("max_resto_iter", d->options.max_resto_iter);
+  app->Options()->SetNumericValue("max_cpu_time", d->options.max_cpu_time);
+  app->Options()->SetStringValue("mu_strategy", d->options.mu_strategy.toStdString());
+  app->Options()->SetStringValue("hessian_approximation", d->options.hessian_approximation.toStdString());
+  app->Options()->SetIntegerValue("limited_memory_max_history", d->options.limited_memory_max_history);
+  app->Options()->SetStringValue("limited_memory_initialization", d->options.limited_memory_initialization.toStdString());
+  app->Options()->SetStringValue("linear_solver", d->options.linear_solver.toStdString());
+  app->Options()->SetIntegerValue("print_level", d->options.print_level);
+  app->Options()->SetStringValue("print_user_options", d->options.print_user_options.toStdString());
+  app->Options()->SetStringValue("print_options_documentation", d->options.print_options_documentation.toStdString());
+  app->Options()->SetStringValue("print_timing_statistics", d->options.print_timing_statistics.toStdString());
+
+  // Initialize the application
+  ApplicationReturnStatus status = app->Initialize();
+  if (status != Solve_Succeeded) {
+    qCritical() << "IPOPT initialization failed with status:" << status;
+    Result result;
+    result.success = false;
+    result.status = status;
+    return result;
+  }
+
+  // Solve the problem
+  status = app->OptimizeTNLP(nlp);
+
+  // Get results
+  Result result = d->lastResult;
+  result.status = status;
+  result.success = (status == Solve_Succeeded || status == Solved_To_Acceptable_Level);
+
+  if (result.success) {
+    result.iteration_count = app->Statistics()->IterationCount();
+  }
+
+  // Emit completion signal
+  emit optimizationCompleted(result.success,
+    result.success ? "Optimization completed successfully" : "Optimization failed");
+
+  return result;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Options qSlicerIpoptOptimizer::getOptions() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+
+  return d->options;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setOptions(const Options& options)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+  d->options = options;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setOption(const QString& key, const QVariant& value)
+{
+  Q_D(qSlicerIpoptOptimizer);
+
+
+  if      (key == "print_level")                d->options.print_level = value.toInt();
+  else if (key == "tol")                         d->options.tol = value.toDouble();
+  else if (key == "dual_inf_tol")               d->options.dual_inf_tol = value.toDouble();
+  else if (key == "constr_viol_tol")            d->options.constr_viol_tol = value.toDouble();
+  else if (key == "compl_inf_tol")              d->options.compl_inf_tol = value.toDouble();
+  else if (key == "acceptable_iter")            d->options.acceptable_iter = value.toInt();
+  else if (key == "acceptable_tol")             d->options.acceptable_tol = value.toDouble();
+  else if (key == "acceptable_constr_viol_tol") d->options.acceptable_constr_viol_tol = value.toDouble();
+  else if (key == "acceptable_dual_inf_tol")    d->options.acceptable_dual_inf_tol = value.toDouble();
+  else if (key == "acceptable_compl_inf_tol")   d->options.acceptable_compl_inf_tol = value.toDouble();
+  else if (key == "acceptable_obj_change_tol")  d->options.acceptable_obj_change_tol = value.toDouble();
+  else if (key == "max_iter")                    d->options.max_iter = value.toInt();
+  else if (key == "max_resto_iter")              d->options.max_resto_iter = value.toInt();
+  else if (key == "max_cpu_time")               d->options.max_cpu_time = value.toDouble();
+  else if (key == "mu_strategy")                d->options.mu_strategy = value.toString();
+  else if (key == "hessian_approximation")      d->options.hessian_approximation = value.toString();
+  else if (key == "limited_memory_max_history") d->options.limited_memory_max_history = value.toInt();
+  else if (key == "limited_memory_initialization") d->options.limited_memory_initialization = value.toString();
+  else if (key == "linear_solver")              d->options.linear_solver = value.toString();
+  else if (key == "print_user_options")         d->options.print_user_options = value.toString();
+  else if (key == "print_options_documentation") d->options.print_options_documentation = value.toString();
+  else if (key == "print_timing_statistics")    d->options.print_timing_statistics = value.toString();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::getLastResult() const
+{
+  Q_D(const qSlicerIpoptOptimizer);
+
+  return d->lastResult;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerIpoptOptimizer::setAvailableObjectives()
+{
+  availableObjectives.clear();
+
+  auto addObjective = [this](qSlicerAbstractObjective* obj) {
+    ObjectiveStruct s;
+    s.name = obj->name();
+    s.parameters = obj->getObjectiveParameters();
+    s.isConstraint = false;
+    availableObjectives.push_back(s);
+    delete obj;
+  };
+  auto addConstraint = [this](qSlicerAbstractConstraint* c) {
+    ObjectiveStruct s;
+    s.name = c->name();
+    s.parameters = c->getConstraintParameters();
+    s.isConstraint = true;
+    availableObjectives.push_back(s);
+    delete c;
+  };
+
+  // Objectives
+  addObjective(new qSlicerSquaredDeviationObjective());
+  addObjective(new qSlicerSquaredOverdosingObjective());
+  addObjective(new qSlicerSquaredUnderdosingObjective());
+  addObjective(new qSlicerMeanDoseObjective());
+  addObjective(new qSlicerEUDObjective());
+  addObjective(new qSlicerMaxDVHObjective());
+  addObjective(new qSlicerMinDVHObjective());
+
+  // Constraints
+  addConstraint(new qSlicerMinMaxDoseConstraint());
+  addConstraint(new qSlicerMinMaxDVHConstraint());
+  addConstraint(new qSlicerMinMaxEUDConstraint());
+  addConstraint(new qSlicerMinMaxMeanDoseConstraint());
+}
+
+//-----------------------------------------------------------------------------
+// Helper: create a constraint object by name and apply parameters from node attributes.
+static std::unique_ptr<qSlicerAbstractConstraint> createConstraintByName(
+  const QString& name, vtkMRMLRTObjectiveNode* node)
+{
+  std::unique_ptr<qSlicerAbstractConstraint> c;
+  if      (name == "Min/Max Dose") c = std::make_unique<qSlicerMinMaxDoseConstraint>();
+  else if (name == "DVH")         c = std::make_unique<qSlicerMinMaxDVHConstraint>();
+  else if (name == "EUD")         c = std::make_unique<qSlicerMinMaxEUDConstraint>();
+  else if (name == "Mean Dose")   c = std::make_unique<qSlicerMinMaxMeanDoseConstraint>();
+  else return nullptr;
+
+  QMap<QString, QVariant> params = c->getConstraintParameters();
+  for (const QString& key : params.keys())
+  {
+    const char* val = node->GetAttribute(key.toStdString().c_str());
+    if (val) params[key] = QString(val).toDouble();
+  }
+  c->setConstraintParameters(params);
+  return c;
+}
+
+//-----------------------------------------------------------------------------
+// Helper: create an objective object by name and apply parameters from a node attribute map.
+static std::unique_ptr<qSlicerAbstractObjective> createObjectiveByName(
+  const QString& name, vtkMRMLRTObjectiveNode* node)
+{
+  std::unique_ptr<qSlicerAbstractObjective> obj;
+  if      (name == "Squared Deviation")   obj = std::make_unique<qSlicerSquaredDeviationObjective>();
+  else if (name == "Squared Overdosing")  obj = std::make_unique<qSlicerSquaredOverdosingObjective>();
+  else if (name == "Squared Underdosing") obj = std::make_unique<qSlicerSquaredUnderdosingObjective>();
+  else if (name == "Mean Dose")           obj = std::make_unique<qSlicerMeanDoseObjective>();
+  else if (name == "EUD")                 obj = std::make_unique<qSlicerEUDObjective>();
+  else if (name == "Max DVH")             obj = std::make_unique<qSlicerMaxDVHObjective>();
+  else if (name == "Min DVH")             obj = std::make_unique<qSlicerMinDVHObjective>();
+  else return nullptr;
+
+  // Copy parameter values from node attributes
+  QMap<QString, QVariant> params = obj->getObjectiveParameters();
+  for (const QString& key : params.keys())
+  {
+    const char* val = node->GetAttribute(key.toStdString().c_str());
+    if (val) params[key] = QString(val).toDouble();
+  }
+  obj->setObjectiveParameters(params);
+  return obj;
+}
+
+//-----------------------------------------------------------------------------
+// Helper: extract flat voxel indices (row indices in D) for a segment.
+// Mirrors slicer.util.arrayFromSegmentBinaryLabelmap: exports the segment to a
+// temporary labelmap node resampled to the reference volume geometry.
+static std::vector<int> getSegmentVoxelIndices(
+  vtkMRMLRTObjectiveNode* objNode,
+  vtkMRMLVolumeNode* referenceVolumeNode,
+  int numVoxels)
+{
+  std::vector<int> indices;
+
+  vtkMRMLSegmentationNode* segNode = objNode->GetSegmentationNode();
+  const char* segID = objNode->GetSegmentID();
+  if (!segNode || !segID || !referenceVolumeNode) return indices;
+
+  vtkMRMLScene* scene = segNode->GetScene();
+  if (!scene) return indices;
+
+  vtkNew<vtkMRMLLabelMapVolumeNode> tempLabelmap;
+  scene->AddNode(tempLabelmap);
+
+  vtkNew<vtkStringArray> segIds;
+  segIds->InsertNextValue(segID);
+
+  bool ok = vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(
+    segNode, segIds, tempLabelmap, referenceVolumeNode);
+
+  if (!ok || !tempLabelmap->GetImageData())
+  {
+    scene->RemoveNode(tempLabelmap);
+    qWarning() << "ExportSegmentsToLabelmapNode failed for" << objNode->GetName();
+    return indices;
+  }
+
+  vtkImageData* img = tempLabelmap->GetImageData();
+  int dims[3];
+  img->GetDimensions(dims);
+  int total = dims[0] * dims[1] * dims[2];
+
+  if (total != numVoxels)
+  {
+    scene->RemoveNode(tempLabelmap);
+    qWarning() << "Labelmap/dose grid size mismatch for" << objNode->GetName()
+               << ":" << total << "vs" << numVoxels;
+    return indices;
+  }
+
+  void* rawPtr = img->GetScalarPointer();
+  int scalarType = img->GetScalarType();
+  indices.reserve(total / 4);
+  for (int i = 0; i < total; ++i)
+  {
+    double val = 0.0;
+    if      (scalarType == VTK_UNSIGNED_CHAR)  val = static_cast<unsigned char*>(rawPtr)[i];
+    else if (scalarType == VTK_SHORT)          val = static_cast<short*>(rawPtr)[i];
+    else if (scalarType == VTK_UNSIGNED_SHORT) val = static_cast<unsigned short*>(rawPtr)[i];
+    else if (scalarType == VTK_INT)            val = static_cast<int*>(rawPtr)[i];
+    if (val > 0.0) indices.push_back(i);
+  }
+
+  scene->RemoveNode(tempLabelmap);
+  return indices;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
+  vtkMRMLRTPlanNode* planNode,
+  std::vector<vtkSmartPointer<vtkMRMLRTObjectiveNode>> objectives,
+  vtkMRMLScalarVolumeNode* resultOptimizationVolumeNode)
+{
+  if (!planNode || !resultOptimizationVolumeNode)
+    return "Invalid plan or result volume node";
+  if (objectives.empty())
+    return "No objectives defined";
+
+  vtkMRMLScalarVolumeNode* refVol = planNode->GetReferenceVolumeNode();
+  if (!refVol)
+    return "No reference volume on plan";
+
+  // ── Step 1: collect beams and build combined D (numVoxels × totalBixels) ──
+
+  std::vector<vtkMRMLRTBeamNode*> beams;
+  planNode->GetBeams(beams);
+  if (beams.empty())
+    return "No beams in plan";
+
+  // Use dose grid from first beam; fall back to reference volume if not set.
+  int doseGridDim[3] = {0, 0, 0};
+  double doseGridSpacing[3] = {0.0, 0.0, 0.0};
+  beams[0]->GetDoseGridDim(doseGridDim);
+  beams[0]->GetDoseGridSpacing(doseGridSpacing);
+  bool useRefVolGrid = (doseGridDim[0] <= 0);
+  if (useRefVolGrid)
+  {
+    refVol->GetImageData()->GetDimensions(doseGridDim);
+    refVol->GetSpacing(doseGridSpacing);
+  }
+  int numVoxels = doseGridDim[0] * doseGridDim[1] * doseGridDim[2];
+
+  // Build a temporary volume node representing the dose grid geometry so that
+  // ExportSegmentsToLabelmapNode resamples segments to dose-grid resolution,
+  // not CT resolution.  Origin and direction are taken from the reference volume;
+  // spacing and dims come from the beam's dose grid (or the ref vol when useRefVolGrid).
+  vtkMRMLScene* scene = planNode->GetScene();
+  vtkNew<vtkMRMLScalarVolumeNode> doseGridVolNode;
+  vtkNew<vtkMatrix4x4> doseIJKToRAS; // saved for use when writing the result dose volume
+  scene->AddNode(doseGridVolNode);
+  {
+    vtkNew<vtkImageData> img;
+    img->SetDimensions(doseGridDim);
+    img->AllocateScalars(VTK_FLOAT, 1);
+    doseGridVolNode->SetAndObserveImageData(img);
+    doseGridVolNode->SetSpacing(doseGridSpacing);
+    doseGridVolNode->SetOrigin(refVol->GetOrigin());
+
+    // Direction: same as refVol but scaled to dose grid spacing
+    vtkNew<vtkMatrix4x4> refIJKToRAS;
+    refVol->GetIJKToRASMatrix(refIJKToRAS);
+    double refSpacing[3];
+    refVol->GetSpacing(refSpacing);
+    doseIJKToRAS->DeepCopy(refIJKToRAS);
+    for (int col = 0; col < 3; ++col)
+    {
+      double scale = doseGridSpacing[col] / refSpacing[col];
+      for (int row = 0; row < 3; ++row)
+        doseIJKToRAS->SetElement(row, col, refIJKToRAS->GetElement(row, col) * scale);
+    }
+    doseGridVolNode->SetIJKToRASMatrix(doseIJKToRAS);
+  }
+
+  using SparseD = vtkMRMLRTBeamNode::DoseInfluenceMatrixType; // Eigen ColMajor sparse
+  using Triplet = Eigen::Triplet<double>;
+
+  std::vector<Triplet> triplets;
+  int colOffset = 0;
+  for (vtkMRMLRTBeamNode* beam : beams)
+  {
+    const SparseD& Di = beam->GetDoseInfluenceMatrix();
+    if (Di.rows() == 0 || Di.cols() == 0)
+      return QString("Dose influence matrix empty for beam '%1'. "
+                     "Run dose calculation first.").arg(beam->GetName());
+    for (int k = 0; k < Di.outerSize(); ++k)
+      for (SparseD::InnerIterator it(Di, k); it; ++it)
+        triplets.emplace_back(static_cast<int>(it.row()),
+                              colOffset + static_cast<int>(it.col()),
+                              it.value());
+    colOffset += static_cast<int>(Di.cols());
+  }
+  int totalBixels = colOffset;
+
+  SparseD D(numVoxels, totalBixels);
+  D.setFromTriplets(triplets.begin(), triplets.end());
+
+  // ── Step 2: map each node → objective or constraint object, voxel indices, penalty ──
+
+  struct StructObj {
+    std::unique_ptr<qSlicerAbstractObjective> obj;
+    std::vector<int> voxelIndices;
+    double penalty;
+  };
+  struct StructConstraint {
+    std::unique_ptr<qSlicerAbstractConstraint> constraint;
+    std::vector<int> voxelIndices;
+  };
+
+  std::vector<StructObj> structObjs;
+  std::vector<StructConstraint> structConstraints;
+
+  for (auto& objNodePtr : objectives)
+  {
+    vtkMRMLRTObjectiveNode* node = objNodePtr.GetPointer();
+    if (!node) continue;
+
+    QString typeName(node->GetName());
+
+    std::vector<int> voxelIdx = getSegmentVoxelIndices(node, doseGridVolNode, numVoxels);
+    if (voxelIdx.empty())
+    {
+      qWarning() << "Could not extract voxel mask for" << node->GetName()
+                 << "— applying to all voxels";
+      voxelIdx.resize(numVoxels);
+      std::iota(voxelIdx.begin(), voxelIdx.end(), 0);
+    }
+
+    // Try objective first
+    auto obj = createObjectiveByName(typeName, node);
+    if (obj)
+    {
+      double penalty = 1.0;
+      const char* penAttr = node->GetAttribute("penalty");
+      if (penAttr) penalty = atof(penAttr);
+      structObjs.push_back({std::move(obj), std::move(voxelIdx), penalty});
+      continue;
+    }
+
+    // Try constraint
+    auto con = createConstraintByName(typeName, node);
+    if (con)
+    {
+      structConstraints.push_back({std::move(con), std::move(voxelIdx)});
+      continue;
+    }
+
+    qWarning() << "Unknown objective type:" << node->GetName() << "— skipping";
+  }
+
+  scene->RemoveNode(doseGridVolNode);
+
+  if (structObjs.empty() && structConstraints.empty())
+    return "No valid objectives or constraints could be configured";
+
+  // ── Step 3: wire IPOPT objective and gradient as lambdas ──
+  // f(w) = Σ_i penalty_i * f_i( D[struct_i, :] * w )
+  // ∇f/∂w = Σ_i penalty_i * D[struct_i, :]ᵀ * ∇f_i( D[struct_i, :] * w )
+
+  auto sharedSO = std::make_shared<std::vector<StructObj>>(std::move(structObjs));
+  auto sharedD  = std::make_shared<SparseD>(std::move(D));
+
+  setObjectiveFunction([sharedSO, sharedD](const Array& w) -> double
+  {
+    Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+    Eigen::VectorXd dose = (*sharedD) * wv;
+    double total = 0.0;
+    for (auto& so : *sharedSO)
+    {
+      Eigen::VectorXd dStruct(so.voxelIndices.size());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        dStruct[j] = dose[so.voxelIndices[j]];
+      total += so.penalty * static_cast<double>(so.obj->computeDoseObjectiveFunction(dStruct));
+    }
+    return total;
+  });
+
+  setGradientFunction([sharedSO, sharedD](const Array& w) -> Array
+  {
+    int n = static_cast<int>(w.size());
+    Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), n);
+    Eigen::VectorXd dose = (*sharedD) * wv;
+    Eigen::VectorXd gradW = Eigen::VectorXd::Zero(n);
+
+    for (auto& so : *sharedSO)
+    {
+      Eigen::VectorXd dStruct(so.voxelIndices.size());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        dStruct[j] = dose[so.voxelIndices[j]];
+
+      Eigen::VectorXd gDoseStruct =
+        so.penalty * so.obj->computeDoseObjectiveGradient(dStruct);
+
+      // Scatter structure gradient back to full voxel space, then chain-rule through D.
+      Eigen::VectorXd gDoseFull = Eigen::VectorXd::Zero(sharedD->rows());
+      for (size_t j = 0; j < so.voxelIndices.size(); ++j)
+        gDoseFull[so.voxelIndices[j]] += gDoseStruct[j];
+
+      gradW += sharedD->transpose() * gDoseFull;
+    }
+    return Array(gradW.data(), gradW.data() + n);
+  });
+
+  // ── Step 3b: wire constraints ──
+  {
+    Q_D(qSlicerIpoptOptimizer);
+
+    // Compute total constraint count
+    int totalCon = 0;
+    for (auto& sc : structConstraints)
+      totalCon += sc.constraint->numConstraints(static_cast<int>(sc.voxelIndices.size()));
+    d->numConstraints = totalCon;
+
+    if (totalCon > 0)
+    {
+      auto sharedSC = std::make_shared<std::vector<StructConstraint>>(std::move(structConstraints));
+
+      d->constraintBoundsFunction = [sharedSC, totalCon]()
+        -> std::pair<qSlicerIpoptOptimizer::Array, qSlicerIpoptOptimizer::Array>
+      {
+        qSlicerIpoptOptimizer::Array lb, ub;
+        lb.reserve(totalCon);
+        ub.reserve(totalCon);
+        for (auto& sc : *sharedSC)
+        {
+          int nv = static_cast<int>(sc.voxelIndices.size());
+          Eigen::VectorXd lbv = sc.constraint->lowerBounds(nv);
+          Eigen::VectorXd ubv = sc.constraint->upperBounds(nv);
+          for (int i = 0; i < lbv.size(); ++i) { lb.push_back(lbv[i]); ub.push_back(ubv[i]); }
+        }
+        return {lb, ub};
+      };
+
+      d->constraintFunction = [sharedSC, sharedD, totalCon](const qSlicerIpoptOptimizer::Array& w)
+        -> qSlicerIpoptOptimizer::Array
+      {
+        Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+        Eigen::VectorXd dose = (*sharedD) * wv;
+        qSlicerIpoptOptimizer::Array g;
+        g.reserve(totalCon);
+        for (auto& sc : *sharedSC)
+        {
+          Eigen::VectorXd dStruct(sc.voxelIndices.size());
+          for (size_t j = 0; j < sc.voxelIndices.size(); ++j)
+            dStruct[j] = dose[sc.voxelIndices[j]];
+          Eigen::VectorXd gv = sc.constraint->computeDoseConstraintFunction(dStruct);
+          for (int i = 0; i < gv.size(); ++i) g.push_back(gv[i]);
+        }
+        return g;
+      };
+
+      d->constraintJacobianFunction = [sharedSC, sharedD, totalCon](const qSlicerIpoptOptimizer::Array& w)
+        -> qSlicerIpoptOptimizer::Array
+      {
+        int nBixels = static_cast<int>(sharedD->cols());
+        Eigen::VectorXd wv = Eigen::Map<const Eigen::VectorXd>(w.data(), w.size());
+        Eigen::VectorXd dose = (*sharedD) * wv;
+        qSlicerIpoptOptimizer::Array jac(totalCon * nBixels, 0.0);
+        int rowOffset = 0;
+        for (auto& sc : *sharedSC)
+        {
+          int nv = static_cast<int>(sc.voxelIndices.size());
+          Eigen::VectorXd dStruct(nv);
+          for (int j = 0; j < nv; ++j) dStruct[j] = dose[sc.voxelIndices[j]];
+          Eigen::MatrixXd Jdose = sc.constraint->computeDoseConstraintJacobian(dStruct);
+          int numCon = static_cast<int>(Jdose.rows());
+          for (int ci = 0; ci < numCon; ++ci)
+          {
+            Eigen::VectorXd jFull = Eigen::VectorXd::Zero(sharedD->rows());
+            for (int j = 0; j < nv; ++j) jFull[sc.voxelIndices[j]] = Jdose(ci, j);
+            Eigen::VectorXd jW = sharedD->transpose() * jFull;
+            for (int j = 0; j < nBixels; ++j)
+              jac[(rowOffset + ci) * nBixels + j] = jW[j];
+          }
+          rowOffset += numCon;
+        }
+        return jac;
+      };
+    }
+  }
+
+  // ── Step 4: solve ──
+  emit progressInfoUpdated("Starting IPOPT optimization...");
+
+  // Scale initial weights so the mean dose in the most demanding MinDose
+  Array w0(totalBixels, 1.0 / totalBixels);
+
+  Result result = solveProblem(w0);
+  if (!result.success)
+    return QString("IPOPT solver did not converge (status %1)").arg(result.status);
+
+  // ── Step 5: compute and store result dose volume ──
+  Eigen::VectorXd wOpt = Eigen::Map<Eigen::VectorXd>(
+    result.solution.data(), result.solution.size());
+  Eigen::VectorXd doseOpt = (*sharedD) * wOpt;
+
+  vtkNew<vtkImageData> doseImg;
+  doseImg->SetDimensions(doseGridDim);
+  doseImg->AllocateScalars(VTK_FLOAT, 1);
+  float* ptr = static_cast<float*>(doseImg->GetScalarPointer());
+  for (int i = 0; i < numVoxels; ++i)
+    ptr[i] = static_cast<float>(doseOpt[i]);
+
+  resultOptimizationVolumeNode->SetAndObserveImageData(doseImg);
+  resultOptimizationVolumeNode->SetIJKToRASMatrix(doseIJKToRAS);
+  resultOptimizationVolumeNode->SetName(
+    (std::string(planNode->GetName()) + "_IpoptOptimizedDose").c_str());
+
+  emit progressInfoUpdated("IPOPT optimization complete.");
+  return QString(); // empty = success
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
@@ -1,0 +1,146 @@
+#ifndef __qSlicerIpoptOptimizer_h
+#define __qSlicerIpoptOptimizer_h
+
+// Qt includes
+#include <QObject>
+#include <QMap>
+#include <QVariant>
+#include <QString>
+
+// IPOPT includes
+#include "IpIpoptApplication.hpp"
+#include "IpTNLP.hpp"
+#include "IpSolveStatistics.hpp"
+
+// STL includes
+#include <vector>
+#include <map>
+#include <functional>
+#include <memory>
+#include <atomic>
+#include <thread>
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+
+using namespace Ipopt;
+
+class qSlicerIpoptOptimizerPrivate;
+
+/// \brief Interior Point Optimizer using IPOPT
+///
+/// This class provides a C++ interface to the IPOPT optimization library,
+/// translating the functionality from the Python OptimizerIpopt class.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerIpoptOptimizer : public QObject
+{
+  Q_OBJECT
+
+public:
+  typedef QObject Superclass;
+
+  /// Constructor
+  explicit qSlicerIpoptOptimizer(QObject* parent = nullptr);
+
+  /// Destructor
+  ~qSlicerIpoptOptimizer() override;
+
+  /// Optimizer properties
+  static const QString NAME;
+  static const QString SHORT_NAME;
+  static const bool GPU_COMPATIBLE;
+  static const bool ALLOW_KEYBOARD_CANCEL;
+
+  /// Default tolerances and limits
+  static const double DEFAULT_TOLERANCE;
+  static const double DEFAULT_ABS_OBJ_TOL;
+  static const int DEFAULT_MAX_ITER;
+  static const double DEFAULT_MAX_TIME;
+
+public:
+  /// Type definitions for arrays and callbacks
+  using Array = std::vector<double>;
+  using ObjectiveFunction = std::function<double(const Array&)>;
+  using GradientFunction = std::function<Array(const Array&)>;
+  using CallbackFunction = std::function<bool(int, double, const Array&)>;
+
+  /// Options container
+  struct Options {
+    int print_level = 5;
+    QString print_user_options = "no";
+    QString print_options_documentation = "no";
+    double tol = 1e-10;
+    double dual_inf_tol = 1e-4;
+    double constr_viol_tol = 1e-4;
+    double compl_inf_tol = 1e-4;
+    int acceptable_iter = 5;
+    double acceptable_tol = DEFAULT_ABS_OBJ_TOL;
+    double acceptable_constr_viol_tol = 1e-2;
+    double acceptable_dual_inf_tol = 1e10;
+    double acceptable_compl_inf_tol = 1e10;
+    double acceptable_obj_change_tol = 1e-4;
+    int max_iter = DEFAULT_MAX_ITER;
+    double max_cpu_time = DEFAULT_MAX_TIME;
+    QString mu_strategy = "adaptive";
+    QString hessian_approximation = "limited-memory";
+    int limited_memory_max_history = 20;
+    QString limited_memory_initialization = "scalar2";
+    QString linear_solver = "mumps";
+    QString print_timing_statistics = "yes";
+  };
+
+  /// Result structure
+  struct Result {
+    Array solution;
+    ApplicationReturnStatus status;
+    double final_objective_value = 0.0;
+    int iteration_count = 0;
+    bool success = false;
+  };
+
+public slots:
+  /// Set optimization parameters
+  void setMaxIterations(int maxIter);
+  void setMaxTime(double maxTime);
+  void setAbsoluteObjectiveTolerance(double tol);
+
+  /// Set objective and gradient functions
+  void setObjectiveFunction(ObjectiveFunction func);
+  void setGradientFunction(GradientFunction func);
+  void setIntermediateCallback(CallbackFunction callback);
+
+  /// Enable/disable keyboard cancellation
+  void setKeyboardCancelEnabled(bool enabled);
+
+  /// Request cancellation
+  void requestCancellation();
+
+public:
+  /// Solve the optimization problem
+  Result solveProblem(const Array& x0);
+
+  /// Get/set options
+  Options getOptions() const;
+  void setOptions(const Options& options);
+  void setOption(const QString& key, const QVariant& value);
+
+  /// Get the last result
+  Result getLastResult() const;
+
+signals:
+  /// Emitted during optimization iterations
+  void iterationUpdate(int iteration, double objectiveValue);
+
+  /// Emitted when optimization completes
+  void optimizationCompleted(bool success, const QString& message);
+
+private:
+  /// Private implementation
+  QScopedPointer<qSlicerIpoptOptimizerPrivate> d_ptr;
+  Q_DECLARE_PRIVATE(qSlicerIpoptOptimizer);
+  Q_DISABLE_COPY(qSlicerIpoptOptimizer);
+
+  /// Internal TNLP implementation
+  class IpoptProblem;
+  friend class IpoptProblem;
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
@@ -1,8 +1,12 @@
 #ifndef __qSlicerIpoptOptimizer_h
 #define __qSlicerIpoptOptimizer_h
 
+// ExternalBeamPlanning includes
+#include "qSlicerAbstractPlanOptimizer.h"
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+
 // Qt includes
-#include <QObject>
+#include <QList>
 #include <QMap>
 #include <QVariant>
 #include <QString>
@@ -17,52 +21,49 @@
 #include <map>
 #include <functional>
 #include <memory>
-#include <atomic>
-#include <thread>
 
-#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include <vtkSmartPointer.h>
 
 using namespace Ipopt;
 
 class qSlicerIpoptOptimizerPrivate;
+class vtkMRMLRTPlanNode;
+class vtkMRMLRTObjectiveNode;
+class vtkMRMLScalarVolumeNode;
 
 /// \brief Interior Point Optimizer using IPOPT
 ///
-/// This class provides a C++ interface to the IPOPT optimization library,
-/// translating the functionality from the Python OptimizerIpopt class.
-class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerIpoptOptimizer : public QObject
+/// Integrates the IPOPT solver with the SlicerRT plan optimization framework.
+/// Inherits from qSlicerAbstractPlanOptimizer so it can be registered with the
+/// plugin handler and invoked through the ExternalBeamPlanning module UI.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerIpoptOptimizer
+  : public qSlicerAbstractPlanOptimizer
 {
   Q_OBJECT
 
 public:
-  typedef QObject Superclass;
+  typedef qSlicerAbstractPlanOptimizer Superclass;
 
-  /// Constructor
   explicit qSlicerIpoptOptimizer(QObject* parent = nullptr);
-
-  /// Destructor
   ~qSlicerIpoptOptimizer() override;
 
-  /// Optimizer properties
   static const QString NAME;
   static const QString SHORT_NAME;
   static const bool GPU_COMPATIBLE;
   static const bool ALLOW_KEYBOARD_CANCEL;
 
-  /// Default tolerances and limits
-  static const double DEFAULT_TOLERANCE;
   static const double DEFAULT_ABS_OBJ_TOL;
   static const int DEFAULT_MAX_ITER;
   static const double DEFAULT_MAX_TIME;
 
+  /// Register all available objective and constraint types.
+  void setAvailableObjectives() override;
+
 public:
-  /// Type definitions for arrays and callbacks
   using Array = std::vector<double>;
   using ObjectiveFunction = std::function<double(const Array&)>;
   using GradientFunction = std::function<Array(const Array&)>;
-  using CallbackFunction = std::function<bool(int, double, const Array&)>;
 
-  /// Options container
   struct Options {
     int print_level = 5;
     QString print_user_options = "no";
@@ -76,8 +77,9 @@ public:
     double acceptable_constr_viol_tol = 1e-2;
     double acceptable_dual_inf_tol = 1e10;
     double acceptable_compl_inf_tol = 1e10;
-    double acceptable_obj_change_tol = 1e-4;
+    double acceptable_obj_change_tol = 1e-8;
     int max_iter = DEFAULT_MAX_ITER;
+    int max_resto_iter = 2000;
     double max_cpu_time = DEFAULT_MAX_TIME;
     QString mu_strategy = "adaptive";
     QString hessian_approximation = "limited-memory";
@@ -87,7 +89,6 @@ public:
     QString print_timing_statistics = "yes";
   };
 
-  /// Result structure
   struct Result {
     Array solution;
     ApplicationReturnStatus status;
@@ -97,48 +98,60 @@ public:
   };
 
 public slots:
-  /// Set optimization parameters
   void setMaxIterations(int maxIter);
   void setMaxTime(double maxTime);
   void setAbsoluteObjectiveTolerance(double tol);
 
-  /// Set objective and gradient functions
   void setObjectiveFunction(ObjectiveFunction func);
   void setGradientFunction(GradientFunction func);
-  void setIntermediateCallback(CallbackFunction callback);
 
-  /// Enable/disable keyboard cancellation
-  void setKeyboardCancelEnabled(bool enabled);
+  /// Python-friendly interface: build the objective from per-structure D matrices.
+  /// Call clearStructureTerms(), then addStructureTerm() once per structure,
+  /// then solveProblem(). No need to set objective/gradient functions manually.
+  ///
+  /// \param data    Nonzero values of D (CSR)
+  /// \param rowInd  Row index per nonzero
+  /// \param colInd  Column index per nonzero
+  /// \param nVoxels Number of rows (voxels in this structure)
+  /// \param nBixels Number of columns (total bixels)
+  /// \param objectiveType "SquaredOverdosing", "SquaredUnderdosing", or "SquaredDeviation"
+  /// \param bound   d_max / d_min / d_ref depending on objective type
+  /// \param weight  Penalty weight
+  void addStructureTerm(const QList<double>& data, const QList<int>& rowInd,
+                        const QList<int>& colInd, int nVoxels, int nBixels,
+                        const QString& objectiveType, double bound, double weight);
+  void clearStructureTerms();
 
-  /// Request cancellation
-  void requestCancellation();
+  /// Python-friendly solve: runs IPOPT and returns true on success.
+  /// Retrieve the solution afterwards with getSolution().
+  bool solve(const QList<double>& x0);
+  QList<double> getSolution() const;
 
 public:
-  /// Solve the optimization problem
   Result solveProblem(const Array& x0);
 
-  /// Get/set options
   Options getOptions() const;
   void setOptions(const Options& options);
   void setOption(const QString& key, const QVariant& value);
 
-  /// Get the last result
   Result getLastResult() const;
 
 signals:
-  /// Emitted during optimization iterations
   void iterationUpdate(int iteration, double objectiveValue);
-
-  /// Emitted when optimization completes
   void optimizationCompleted(bool success, const QString& message);
 
+protected:
+  /// Called by the ExternalBeamPlanning module to run the optimizer on a plan.
+  QString optimizePlanUsingOptimizer(
+    vtkMRMLRTPlanNode* planNode,
+    std::vector<vtkSmartPointer<vtkMRMLRTObjectiveNode>> objectives,
+    vtkMRMLScalarVolumeNode* resultOptimizationVolumeNode) override;
+
 private:
-  /// Private implementation
   QScopedPointer<qSlicerIpoptOptimizerPrivate> d_ptr;
   Q_DECLARE_PRIVATE(qSlicerIpoptOptimizer);
   Q_DISABLE_COPY(qSlicerIpoptOptimizer);
 
-  /// Internal TNLP implementation
   class IpoptProblem;
   friend class IpoptProblem;
 };

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
@@ -74,16 +74,16 @@ public:
     double compl_inf_tol = 1e-4;
     int acceptable_iter = 5;
     double acceptable_tol = DEFAULT_ABS_OBJ_TOL;
-    double acceptable_constr_viol_tol = 1e-2;
+    double acceptable_constr_viol_tol = 1e-4;
     double acceptable_dual_inf_tol = 1e10;
     double acceptable_compl_inf_tol = 1e10;
-    double acceptable_obj_change_tol = 1e-8;
+    double acceptable_obj_change_tol = 1e-4;
     int max_iter = DEFAULT_MAX_ITER;
     int max_resto_iter = 2000;
     double max_cpu_time = DEFAULT_MAX_TIME;
     QString mu_strategy = "adaptive";
     QString hessian_approximation = "limited-memory";
-    int limited_memory_max_history = 20;
+    int limited_memory_max_history = 50;
     QString limited_memory_initialization = "scalar2";
     QString linear_solver = "mumps";
     QString print_timing_statistics = "yes";
@@ -101,9 +101,15 @@ public slots:
   void setMaxIterations(int maxIter);
   void setMaxTime(double maxTime);
   void setAbsoluteObjectiveTolerance(double tol);
+  void setOption(const QString& key, const QVariant& value);
 
   void setObjectiveFunction(ObjectiveFunction func);
   void setGradientFunction(GradientFunction func);
+
+  /// Set the sparse Jacobian pattern from Python as (iRow, jCol) pairs in
+  /// row-major order. When set before solve(), C++ computes Jacobian values
+  /// only for these entries instead of the full dense m×n matrix.
+  void setConstraintJacobianSparsity(const QList<int>& iRow, const QList<int>& jCol);
 
   /// Python-friendly interface: build the objective from per-structure D matrices.
   /// Call clearStructureTerms(), then addStructureTerm() once per structure,
@@ -120,6 +126,19 @@ public slots:
   void addStructureTerm(const QList<double>& data, const QList<int>& rowInd,
                         const QList<int>& colInd, int nVoxels, int nBixels,
                         const QString& objectiveType, double bound, double weight);
+
+  /// Python-friendly interface: add a hard dose constraint enforced by IPOPT.
+  /// Uses a logsumexp smooth approximation (one constraint row per call).
+  ///
+  /// \param constraintType "MaxDose" → D·w ≤ bound (max dose limit)
+  ///                       "MinDose" → D·w ≥ bound (min dose coverage)
+  /// \param smoothingT     Logsumexp temperature (Gy). Smaller = tighter
+  ///                       approximation. Default 1e-3 matches the value used
+  ///                       by qSlicerMinMaxDoseConstraint and matRad.
+  void addStructureConstraint(const QList<double>& data, const QList<int>& rowInd,
+                               const QList<int>& colInd, int nVoxels, int nBixels,
+                               const QString& constraintType, double bound,
+                               double smoothingT = 1e-3);
   void clearStructureTerms();
 
   /// Python-friendly solve: runs IPOPT and returns true on success.
@@ -132,7 +151,6 @@ public:
 
   Options getOptions() const;
   void setOptions(const Options& options);
-  void setOption(const QString& key, const QVariant& value);
 
   Result getLastResult() const;
 

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.h
@@ -1,0 +1,177 @@
+#ifndef __qSlicerIpoptOptimizer_h
+#define __qSlicerIpoptOptimizer_h
+
+// ExternalBeamPlanning includes
+#include "qSlicerAbstractPlanOptimizer.h"
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+
+// Qt includes
+#include <QList>
+#include <QMap>
+#include <QVariant>
+#include <QString>
+
+// IPOPT includes
+#include "IpIpoptApplication.hpp"
+#include "IpTNLP.hpp"
+#include "IpSolveStatistics.hpp"
+
+// STL includes
+#include <vector>
+#include <map>
+#include <functional>
+#include <memory>
+
+#include <vtkSmartPointer.h>
+
+using namespace Ipopt;
+
+class qSlicerIpoptOptimizerPrivate;
+class vtkMRMLRTPlanNode;
+class vtkMRMLRTObjectiveNode;
+class vtkMRMLScalarVolumeNode;
+
+/// \brief Interior Point Optimizer using IPOPT
+///
+/// Integrates the IPOPT solver with the SlicerRT plan optimization framework.
+/// Inherits from qSlicerAbstractPlanOptimizer so it can be registered with the
+/// plugin handler and invoked through the ExternalBeamPlanning module UI.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerIpoptOptimizer
+  : public qSlicerAbstractPlanOptimizer
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractPlanOptimizer Superclass;
+
+  explicit qSlicerIpoptOptimizer(QObject* parent = nullptr);
+  ~qSlicerIpoptOptimizer() override;
+
+  static const QString NAME;
+  static const QString SHORT_NAME;
+  static const bool GPU_COMPATIBLE;
+  static const bool ALLOW_KEYBOARD_CANCEL;
+
+  static const double DEFAULT_ABS_OBJ_TOL;
+  static const int DEFAULT_MAX_ITER;
+  static const double DEFAULT_MAX_TIME;
+
+  /// Register all available objective and constraint types.
+  void setAvailableObjectives() override;
+
+public:
+  using Array = std::vector<double>;
+  using ObjectiveFunction = std::function<double(const Array&)>;
+  using GradientFunction = std::function<Array(const Array&)>;
+
+  struct Options {
+    int print_level = 5;
+    QString print_user_options = "no";
+    QString print_options_documentation = "no";
+    double tol = 1e-10;
+    double dual_inf_tol = 1e-4;
+    double constr_viol_tol = 1e-4;
+    double compl_inf_tol = 1e-4;
+    int acceptable_iter = 5;
+    double acceptable_tol = DEFAULT_ABS_OBJ_TOL;
+    double acceptable_constr_viol_tol = 1e-4;
+    double acceptable_dual_inf_tol = 1e10;
+    double acceptable_compl_inf_tol = 1e10;
+    double acceptable_obj_change_tol = 1e-4;
+    int max_iter = DEFAULT_MAX_ITER;
+    int max_resto_iter = 2000;
+    double max_cpu_time = DEFAULT_MAX_TIME;
+    QString mu_strategy = "adaptive";
+    QString hessian_approximation = "limited-memory";
+    int limited_memory_max_history = 50;
+    QString limited_memory_initialization = "scalar2";
+    QString linear_solver = "mumps";
+    QString print_timing_statistics = "yes";
+  };
+
+  struct Result {
+    Array solution;
+    ApplicationReturnStatus status;
+    double final_objective_value = 0.0;
+    int iteration_count = 0;
+    bool success = false;
+  };
+
+public slots:
+  void setMaxIterations(int maxIter);
+  void setMaxTime(double maxTime);
+  void setAbsoluteObjectiveTolerance(double tol);
+  void setOption(const QString& key, const QVariant& value);
+
+  void setObjectiveFunction(ObjectiveFunction func);
+  void setGradientFunction(GradientFunction func);
+
+  /// Set the sparse Jacobian pattern from Python as (iRow, jCol) pairs in
+  /// row-major order. When set before solve(), C++ computes Jacobian values
+  /// only for these entries instead of the full dense m×n matrix.
+  void setConstraintJacobianSparsity(const QList<int>& iRow, const QList<int>& jCol);
+
+  /// Python-friendly interface: build the objective from per-structure D matrices.
+  /// Call clearStructureTerms(), then addStructureTerm() once per structure,
+  /// then solveProblem(). No need to set objective/gradient functions manually.
+  ///
+  /// \param data    Nonzero values of D (CSR)
+  /// \param rowInd  Row index per nonzero
+  /// \param colInd  Column index per nonzero
+  /// \param nVoxels Number of rows (voxels in this structure)
+  /// \param nBixels Number of columns (total bixels)
+  /// \param objectiveType "SquaredOverdosing", "SquaredUnderdosing", or "SquaredDeviation"
+  /// \param bound   d_max / d_min / d_ref depending on objective type
+  /// \param weight  Penalty weight
+  void addStructureTerm(const QList<double>& data, const QList<int>& rowInd,
+                        const QList<int>& colInd, int nVoxels, int nBixels,
+                        const QString& objectiveType, double bound, double weight);
+
+  /// Python-friendly interface: add a hard dose constraint enforced by IPOPT.
+  /// Uses a logsumexp smooth approximation (one constraint row per call).
+  ///
+  /// \param constraintType "MaxDose" → D·w ≤ bound (max dose limit)
+  ///                       "MinDose" → D·w ≥ bound (min dose coverage)
+  /// \param smoothingT     Logsumexp temperature (Gy). Smaller = tighter
+  ///                       approximation. Default 1e-3 matches the value used
+  ///                       by qSlicerMinMaxDoseConstraint and matRad.
+  void addStructureConstraint(const QList<double>& data, const QList<int>& rowInd,
+                               const QList<int>& colInd, int nVoxels, int nBixels,
+                               const QString& constraintType, double bound,
+                               double smoothingT = 1e-3);
+  void clearStructureTerms();
+
+  /// Python-friendly solve: runs IPOPT and returns true on success.
+  /// Retrieve the solution afterwards with getSolution().
+  bool solve(const QList<double>& x0);
+  QList<double> getSolution() const;
+
+public:
+  Result solveProblem(const Array& x0);
+
+  Options getOptions() const;
+  void setOptions(const Options& options);
+
+  Result getLastResult() const;
+
+signals:
+  void iterationUpdate(int iteration, double objectiveValue);
+  void optimizationCompleted(bool success, const QString& message);
+
+protected:
+  /// Called by the ExternalBeamPlanning module to run the optimizer on a plan.
+  QString optimizePlanUsingOptimizer(
+    vtkMRMLRTPlanNode* planNode,
+    std::vector<vtkSmartPointer<vtkMRMLRTObjectiveNode>> objectives,
+    vtkMRMLScalarVolumeNode* resultOptimizationVolumeNode) override;
+
+private:
+  QScopedPointer<qSlicerIpoptOptimizerPrivate> d_ptr;
+  Q_DECLARE_PRIVATE(qSlicerIpoptOptimizer);
+  Q_DISABLE_COPY(qSlicerIpoptOptimizer);
+
+  class IpoptProblem;
+  friend class IpoptProblem;
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMaxDVHObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMaxDVHObjective.cxx
@@ -1,0 +1,47 @@
+#include "qSlicerMaxDVHObjective.h"
+#include "qSlicerDVHUtils.h"
+
+qSlicerMaxDVHObjective::qSlicerMaxDVHObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "Max DVH";
+  this->initializeParameters();
+}
+
+qSlicerMaxDVHObjective::~qSlicerMaxDVHObjective() = default;
+
+void qSlicerMaxDVHObjective::initializeParameters()
+{
+  this->objectivesParameters["doseRef"] = 30.0;
+  this->objectivesParameters["vMaxPercent"] = 95.0;
+}
+
+float qSlicerMaxDVHObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["doseRef"].toDouble();
+  double vMaxPercent = this->objectivesParameters["vMaxPercent"].toDouble();
+  double refVol = vMaxPercent / 100.0;
+  double dRef2 = qSlicerCalcInverseDVH(refVol, dose);
+
+  // Penalize voxels with dose in (dRef, dRef2)
+  DoseType deviation = dose.array() - dRef;
+  for (int i = 0; i < dose.size(); ++i)
+    if (dose[i] < dRef || dose[i] > dRef2) deviation[i] = 0.0;
+
+  return static_cast<float>(deviation.squaredNorm() / dose.size());
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerMaxDVHObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["doseRef"].toDouble();
+  double vMaxPercent = this->objectivesParameters["vMaxPercent"].toDouble();
+  double refVol = vMaxPercent / 100.0;
+  double dRef2 = qSlicerCalcInverseDVH(refVol, dose);
+
+  DoseType deviation = dose.array() - dRef;
+  for (int i = 0; i < dose.size(); ++i)
+    if (dose[i] < dRef || dose[i] > dRef2) deviation[i] = 0.0;
+
+  return (2.0 / dose.size()) * deviation;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMaxDVHObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMaxDVHObjective.h
@@ -1,0 +1,29 @@
+#ifndef __qSlicerMaxDVHObjective_h
+#define __qSlicerMaxDVHObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+/// Penalized Max DVH objective.
+/// Penalizes voxels between doseRef and the dose at which volume fraction = vMaxPercent.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMaxDVHObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerMaxDVHObjective(QObject* parent = nullptr);
+  ~qSlicerMaxDVHObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMaxDVHObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMeanDoseObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMeanDoseObjective.cxx
@@ -1,0 +1,50 @@
+#include "qSlicerMeanDoseObjective.h"
+
+#include <cmath>
+
+qSlicerMeanDoseObjective::qSlicerMeanDoseObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "Mean Dose";
+  this->initializeParameters();
+}
+
+qSlicerMeanDoseObjective::~qSlicerMeanDoseObjective() = default;
+
+void qSlicerMeanDoseObjective::initializeParameters()
+{
+  this->objectivesParameters["meanDoseRef"] = 0.0;
+  // 0 = Linear, 1 = Quadratic
+  this->objectivesParameters["mode"] = 0;
+}
+
+float qSlicerMeanDoseObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["meanDoseRef"].toDouble();
+  int mode = this->objectivesParameters["mode"].toInt();
+  double meanDose = dose.mean();
+
+  if (mode == 1)
+  {
+    double diff = meanDose - dRef;
+    return static_cast<float>(diff * diff);
+  }
+  // Linear (default)
+  return static_cast<float>(std::abs(meanDose - dRef));
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerMeanDoseObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["meanDoseRef"].toDouble();
+  int mode = this->objectivesParameters["mode"].toInt();
+  int n = static_cast<int>(dose.size());
+
+  if (mode == 1)
+  {
+    double meanDose = dose.mean();
+    return DoseType::Constant(n, 2.0 * (meanDose - dRef) / n);
+  }
+  // Linear: (1/n) * sign(dose_i - dRef) per-element as in matRad
+  return (1.0 / n) * (dose.array() - dRef).sign().matrix();
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMeanDoseObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMeanDoseObjective.h
@@ -1,0 +1,29 @@
+#ifndef __qSlicerMeanDoseObjective_h
+#define __qSlicerMeanDoseObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+/// Penalized mean dose objective.
+/// mode 0 = linear |mean(dose) - dRef|, mode 1 = quadratic (mean(dose) - dRef)^2
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMeanDoseObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerMeanDoseObjective(QObject* parent = nullptr);
+  ~qSlicerMeanDoseObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMeanDoseObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMinDVHObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinDVHObjective.cxx
@@ -1,0 +1,47 @@
+#include "qSlicerMinDVHObjective.h"
+#include "qSlicerDVHUtils.h"
+
+qSlicerMinDVHObjective::qSlicerMinDVHObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "Min DVH";
+  this->initializeParameters();
+}
+
+qSlicerMinDVHObjective::~qSlicerMinDVHObjective() = default;
+
+void qSlicerMinDVHObjective::initializeParameters()
+{
+  this->objectivesParameters["doseRef"] = 60.0;
+  this->objectivesParameters["vMinPercent"] = 95.0;
+}
+
+float qSlicerMinDVHObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["doseRef"].toDouble();
+  double vMinPercent = this->objectivesParameters["vMinPercent"].toDouble();
+  double refVol = vMinPercent / 100.0;
+  double dRef2 = qSlicerCalcInverseDVH(refVol, dose);
+
+  // Penalize voxels with dose in (dRef2, dRef)
+  DoseType deviation = dose.array() - dRef;
+  for (int i = 0; i < dose.size(); ++i)
+    if (dose[i] > dRef || dose[i] < dRef2) deviation[i] = 0.0;
+
+  return static_cast<float>(deviation.squaredNorm() / dose.size());
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerMinDVHObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double dRef = this->objectivesParameters["doseRef"].toDouble();
+  double vMinPercent = this->objectivesParameters["vMinPercent"].toDouble();
+  double refVol = vMinPercent / 100.0;
+  double dRef2 = qSlicerCalcInverseDVH(refVol, dose);
+
+  DoseType deviation = dose.array() - dRef;
+  for (int i = 0; i < dose.size(); ++i)
+    if (dose[i] > dRef || dose[i] < dRef2) deviation[i] = 0.0;
+
+  return (2.0 / dose.size()) * deviation;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMinDVHObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinDVHObjective.h
@@ -1,0 +1,29 @@
+#ifndef __qSlicerMinDVHObjective_h
+#define __qSlicerMinDVHObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+/// Penalized Min DVH objective.
+/// Penalizes voxels between d_ref2 (dose at vMinPercent) and doseRef.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMinDVHObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerMinDVHObjective(QObject* parent = nullptr);
+  ~qSlicerMinDVHObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMinDVHObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxDVHConstraint.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxDVHConstraint.cxx
@@ -1,0 +1,87 @@
+#include "qSlicerMinMaxDVHConstraint.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+qSlicerMinMaxDVHConstraint::qSlicerMinMaxDVHConstraint(QObject* parent)
+  : qSlicerAbstractConstraint(parent)
+{
+  this->m_Name = "DVH";
+  this->initializeParameters();
+}
+
+qSlicerMinMaxDVHConstraint::~qSlicerMinMaxDVHConstraint() = default;
+
+void qSlicerMinMaxDVHConstraint::initializeParameters()
+{
+  this->constraintParameters["doseRef"] = 30.0;
+  this->constraintParameters["vMinPercent"] = 0.0;
+  this->constraintParameters["vMaxPercent"] = 100.0;
+}
+
+int qSlicerMinMaxDVHConstraint::numConstraints(int /*numVoxels*/) const
+{
+  return 1;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDVHConstraint::computeDoseConstraintFunction(const DoseType& dose)
+{
+  double dRef = this->constraintParameters["doseRef"].toDouble();
+  int n = static_cast<int>(dose.size());
+  double fraction = 0.0;
+  for (int i = 0; i < n; ++i)
+    if (dose[i] >= dRef) fraction += 1.0;
+  fraction /= n;
+
+  DoseType result(1);
+  result[0] = fraction;
+  return result;
+}
+
+Eigen::MatrixXd
+qSlicerMinMaxDVHConstraint::computeDoseConstraintJacobian(const DoseType& dose)
+{
+  double dRef = this->constraintParameters["doseRef"].toDouble();
+  int n = static_cast<int>(dose.size());
+
+  // Logistic approximation of the step function
+  std::vector<double> sorted(dose.data(), dose.data() + n);
+  std::sort(sorted.begin(), sorted.end());
+
+  int noVoxels = std::max(static_cast<int>(std::ceil(n / 2.0)), 10);
+  std::vector<double> absDiff(n);
+  for (int i = 0; i < n; ++i)
+    absDiff[i] = std::abs(dRef - sorted[i]);
+  std::sort(absDiff.begin(), absDiff.end());
+  double deltaDoseMax = absDiff[std::min(static_cast<int>(std::ceil(noVoxels / 2.0)), n) - 1];
+
+  static const double refScaling = 0.01;
+  double dvhcScaling = std::min(std::log(1.0 / refScaling - 1.0) / (2.0 * deltaDoseMax), 250.0);
+
+  Eigen::MatrixXd jac(1, n);
+  for (int i = 0; i < n; ++i)
+  {
+    double d = dose[i] - dRef;
+    double e = std::exp(2.0 * dvhcScaling * d);
+    jac(0, i) = (2.0 / n) * dvhcScaling * e / ((e + 1.0) * (e + 1.0));
+  }
+  return jac;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDVHConstraint::upperBounds(int /*numVoxels*/)
+{
+  DoseType ub(1);
+  ub[0] = this->constraintParameters["vMaxPercent"].toDouble() / 100.0;
+  return ub;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDVHConstraint::lowerBounds(int /*numVoxels*/)
+{
+  DoseType lb(1);
+  lb[0] = this->constraintParameters["vMinPercent"].toDouble() / 100.0;
+  return lb;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxDVHConstraint.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxDVHConstraint.h
@@ -1,0 +1,32 @@
+#ifndef __qSlicerMinMaxDVHConstraint_h
+#define __qSlicerMinMaxDVHConstraint_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractConstraint.h"
+
+/// DVH constraint: vMin <= V(doseRef) <= vMax  (volume fractions in percent).
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMinMaxDVHConstraint
+  : public qSlicerAbstractConstraint
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractConstraint Superclass;
+  explicit qSlicerMinMaxDVHConstraint(QObject* parent = nullptr);
+  ~qSlicerMinMaxDVHConstraint() override;
+
+  int numConstraints(int numVoxels) const override;
+
+  Q_INVOKABLE DoseType computeDoseConstraintFunction(const DoseType& dose) override;
+  Q_INVOKABLE Eigen::MatrixXd computeDoseConstraintJacobian(const DoseType& dose) override;
+  Q_INVOKABLE DoseType upperBounds(int numVoxels) override;
+  Q_INVOKABLE DoseType lowerBounds(int numVoxels) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMinMaxDVHConstraint);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxDoseConstraint.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxDoseConstraint.cxx
@@ -1,0 +1,141 @@
+#include "qSlicerMinMaxDoseConstraint.h"
+
+#include <cmath>
+#include <limits>
+
+static const double EPSILON = 1e-3;
+
+qSlicerMinMaxDoseConstraint::qSlicerMinMaxDoseConstraint(QObject* parent)
+  : qSlicerAbstractConstraint(parent)
+{
+  this->m_Name = "Min/Max Dose";
+  this->initializeParameters();
+}
+
+qSlicerMinMaxDoseConstraint::~qSlicerMinMaxDoseConstraint() = default;
+
+void qSlicerMinMaxDoseConstraint::initializeParameters()
+{
+  this->constraintParameters["minDose"] = 0.0;
+  this->constraintParameters["maxDose"] = 30.0;
+  // 0 = log-sum-exp approximation, 1 = voxel-wise
+  this->constraintParameters["mode"] = 0;
+}
+
+bool qSlicerMinMaxDoseConstraint::hasMinConstraint() const
+{
+  return this->constraintParameters["minDose"].toDouble() > 0.0;
+}
+
+bool qSlicerMinMaxDoseConstraint::hasMaxConstraint() const
+{
+  double maxDose = this->constraintParameters["maxDose"].toDouble();
+  return std::isfinite(maxDose);
+}
+
+int qSlicerMinMaxDoseConstraint::numConstraints(int numVoxels) const
+{
+  int mode = this->constraintParameters["mode"].toInt();
+  if (mode == 1)
+    return numVoxels;
+
+  // log-sum-exp: 0, 1, or 2 scalar constraints
+  int count = 0;
+  if (hasMinConstraint()) ++count;
+  if (hasMaxConstraint()) ++count;
+  return count;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDoseConstraint::computeDoseConstraintFunction(const DoseType& dose)
+{
+  int mode = this->constraintParameters["mode"].toInt();
+  double dMin = this->constraintParameters["minDose"].toDouble();
+  double dMax = this->constraintParameters["maxDose"].toDouble();
+
+  if (mode == 1)
+    return dose; // voxel-wise: g_i = dose_i, bounds enforce limits
+
+  // log-sum-exp approximation
+  DoseType result;
+  int idx = 0;
+  bool doMin = hasMinConstraint();
+  bool doMax = hasMaxConstraint();
+  result.resize(doMin && doMax ? 2 : (doMin || doMax ? 1 : 0));
+
+  if (doMin)
+  {
+    double doseMin = dose.minCoeff();
+    double g = doseMin - EPSILON * std::log(((doseMin - dose.array()) / EPSILON).exp().sum());
+    result[idx++] = g;
+  }
+  if (doMax)
+  {
+    double doseMax = dose.maxCoeff();
+    double g = doseMax + EPSILON * std::log(((dose.array() - doseMax) / EPSILON).exp().sum());
+    result[idx++] = g;
+  }
+  return result;
+}
+
+Eigen::MatrixXd
+qSlicerMinMaxDoseConstraint::computeDoseConstraintJacobian(const DoseType& dose)
+{
+  int mode = this->constraintParameters["mode"].toInt();
+  int n = static_cast<int>(dose.size());
+
+  if (mode == 1)
+    return Eigen::MatrixXd::Identity(n, n);
+
+  int m = numConstraints(n);
+  Eigen::MatrixXd jac = Eigen::MatrixXd::Zero(m, n);
+  int row = 0;
+
+  if (hasMinConstraint())
+  {
+    double doseMin = dose.minCoeff();
+    Eigen::VectorXd w = ((doseMin - dose.array()) / EPSILON).exp().matrix();
+    jac.row(row++) = (w / w.sum()).transpose();
+  }
+  if (hasMaxConstraint())
+  {
+    double doseMax = dose.maxCoeff();
+    Eigen::VectorXd w = ((dose.array() - doseMax) / EPSILON).exp().matrix();
+    jac.row(row++) = (w / w.sum()).transpose();
+  }
+  return jac;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDoseConstraint::upperBounds(int numVoxels)
+{
+  int mode = this->constraintParameters["mode"].toInt();
+  double dMax = this->constraintParameters["maxDose"].toDouble();
+
+  if (mode == 1)
+    return DoseType::Constant(numVoxels, dMax);
+
+  int m = numConstraints(numVoxels);
+  DoseType ub(m);
+  int idx = 0;
+  if (hasMinConstraint()) ub[idx++] = std::numeric_limits<double>::infinity();
+  if (hasMaxConstraint()) ub[idx++] = dMax;
+  return ub;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxDoseConstraint::lowerBounds(int numVoxels)
+{
+  int mode = this->constraintParameters["mode"].toInt();
+  double dMin = this->constraintParameters["minDose"].toDouble();
+
+  if (mode == 1)
+    return DoseType::Constant(numVoxels, dMin);
+
+  int m = numConstraints(numVoxels);
+  DoseType lb(m);
+  int idx = 0;
+  if (hasMinConstraint()) lb[idx++] = dMin;
+  if (hasMaxConstraint()) lb[idx++] = 0.0;
+  return lb;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxDoseConstraint.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxDoseConstraint.h
@@ -1,0 +1,36 @@
+#ifndef __qSlicerMinMaxDoseConstraint_h
+#define __qSlicerMinMaxDoseConstraint_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractConstraint.h"
+
+/// Min/Max dose constraint using log-sum-exp smoothing (mode 0) or
+/// exact voxel-wise bounds (mode 1).
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMinMaxDoseConstraint
+  : public qSlicerAbstractConstraint
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractConstraint Superclass;
+  explicit qSlicerMinMaxDoseConstraint(QObject* parent = nullptr);
+  ~qSlicerMinMaxDoseConstraint() override;
+
+  int numConstraints(int numVoxels) const override;
+
+  Q_INVOKABLE DoseType computeDoseConstraintFunction(const DoseType& dose) override;
+  Q_INVOKABLE Eigen::MatrixXd computeDoseConstraintJacobian(const DoseType& dose) override;
+  Q_INVOKABLE DoseType upperBounds(int numVoxels) override;
+  Q_INVOKABLE DoseType lowerBounds(int numVoxels) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  bool hasMinConstraint() const;
+  bool hasMaxConstraint() const;
+
+  Q_DISABLE_COPY(qSlicerMinMaxDoseConstraint);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxEUDConstraint.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxEUDConstraint.cxx
@@ -1,0 +1,67 @@
+#include "qSlicerMinMaxEUDConstraint.h"
+
+#include <cmath>
+
+qSlicerMinMaxEUDConstraint::qSlicerMinMaxEUDConstraint(QObject* parent)
+  : qSlicerAbstractConstraint(parent)
+{
+  this->m_Name = "EUD";
+  this->initializeParameters();
+}
+
+qSlicerMinMaxEUDConstraint::~qSlicerMinMaxEUDConstraint() = default;
+
+void qSlicerMinMaxEUDConstraint::initializeParameters()
+{
+  this->constraintParameters["exponent"] = 5.0;
+  this->constraintParameters["eudMin"] = 0.0;
+  this->constraintParameters["eudMax"] = 30.0;
+}
+
+int qSlicerMinMaxEUDConstraint::numConstraints(int /*numVoxels*/) const
+{
+  return 1;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxEUDConstraint::computeDoseConstraintFunction(const DoseType& dose)
+{
+  double k = this->constraintParameters["exponent"].toDouble();
+  int n = static_cast<int>(dose.size());
+  double powerSum = dose.array().pow(k).sum();
+  double eud = std::pow(powerSum / n, 1.0 / k);
+
+  DoseType result(1);
+  result[0] = eud;
+  return result;
+}
+
+Eigen::MatrixXd
+qSlicerMinMaxEUDConstraint::computeDoseConstraintJacobian(const DoseType& dose)
+{
+  double k = this->constraintParameters["exponent"].toDouble();
+  int n = static_cast<int>(dose.size());
+
+  double powerSum = dose.array().pow(k).sum();
+  // d(EUD)/d(dose_i) = n^(-1/k) * powerSum^((1-k)/k) * dose_i^(k-1)
+  double scale = std::pow(1.0 / n, 1.0 / k) * std::pow(powerSum, (1.0 - k) / k);
+  Eigen::MatrixXd jac(1, n);
+  jac.row(0) = scale * dose.array().pow(k - 1.0).matrix().transpose();
+  return jac;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxEUDConstraint::upperBounds(int /*numVoxels*/)
+{
+  DoseType ub(1);
+  ub[0] = this->constraintParameters["eudMax"].toDouble();
+  return ub;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxEUDConstraint::lowerBounds(int /*numVoxels*/)
+{
+  DoseType lb(1);
+  lb[0] = this->constraintParameters["eudMin"].toDouble();
+  return lb;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxEUDConstraint.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxEUDConstraint.h
@@ -1,0 +1,32 @@
+#ifndef __qSlicerMinMaxEUDConstraint_h
+#define __qSlicerMinMaxEUDConstraint_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractConstraint.h"
+
+/// EUD constraint: eudMin <= EUD <= eudMax  where EUD = (mean(dose^k))^(1/k).
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMinMaxEUDConstraint
+  : public qSlicerAbstractConstraint
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractConstraint Superclass;
+  explicit qSlicerMinMaxEUDConstraint(QObject* parent = nullptr);
+  ~qSlicerMinMaxEUDConstraint() override;
+
+  int numConstraints(int numVoxels) const override;
+
+  Q_INVOKABLE DoseType computeDoseConstraintFunction(const DoseType& dose) override;
+  Q_INVOKABLE Eigen::MatrixXd computeDoseConstraintJacobian(const DoseType& dose) override;
+  Q_INVOKABLE DoseType upperBounds(int numVoxels) override;
+  Q_INVOKABLE DoseType lowerBounds(int numVoxels) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMinMaxEUDConstraint);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxMeanDoseConstraint.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxMeanDoseConstraint.cxx
@@ -1,0 +1,52 @@
+#include "qSlicerMinMaxMeanDoseConstraint.h"
+
+qSlicerMinMaxMeanDoseConstraint::qSlicerMinMaxMeanDoseConstraint(QObject* parent)
+  : qSlicerAbstractConstraint(parent)
+{
+  this->m_Name = "Mean Dose";
+  this->initializeParameters();
+}
+
+qSlicerMinMaxMeanDoseConstraint::~qSlicerMinMaxMeanDoseConstraint() = default;
+
+void qSlicerMinMaxMeanDoseConstraint::initializeParameters()
+{
+  this->constraintParameters["minMeanDose"] = 0.0;
+  this->constraintParameters["maxMeanDose"] = 30.0;
+}
+
+int qSlicerMinMaxMeanDoseConstraint::numConstraints(int /*numVoxels*/) const
+{
+  return 1;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxMeanDoseConstraint::computeDoseConstraintFunction(const DoseType& dose)
+{
+  DoseType result(1);
+  result[0] = dose.mean();
+  return result;
+}
+
+Eigen::MatrixXd
+qSlicerMinMaxMeanDoseConstraint::computeDoseConstraintJacobian(const DoseType& dose)
+{
+  int n = static_cast<int>(dose.size());
+  return Eigen::MatrixXd::Constant(1, n, 1.0 / n);
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxMeanDoseConstraint::upperBounds(int /*numVoxels*/)
+{
+  DoseType ub(1);
+  ub[0] = this->constraintParameters["maxMeanDose"].toDouble();
+  return ub;
+}
+
+qSlicerAbstractConstraint::DoseType
+qSlicerMinMaxMeanDoseConstraint::lowerBounds(int /*numVoxels*/)
+{
+  DoseType lb(1);
+  lb[0] = this->constraintParameters["minMeanDose"].toDouble();
+  return lb;
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerMinMaxMeanDoseConstraint.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerMinMaxMeanDoseConstraint.h
@@ -1,0 +1,32 @@
+#ifndef __qSlicerMinMaxMeanDoseConstraint_h
+#define __qSlicerMinMaxMeanDoseConstraint_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractConstraint.h"
+
+/// Mean dose constraint: minMeanDose <= mean(dose) <= maxMeanDose.
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerMinMaxMeanDoseConstraint
+  : public qSlicerAbstractConstraint
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractConstraint Superclass;
+  explicit qSlicerMinMaxMeanDoseConstraint(QObject* parent = nullptr);
+  ~qSlicerMinMaxMeanDoseConstraint() override;
+
+  int numConstraints(int numVoxels) const override;
+
+  Q_INVOKABLE DoseType computeDoseConstraintFunction(const DoseType& dose) override;
+  Q_INVOKABLE Eigen::MatrixXd computeDoseConstraintJacobian(const DoseType& dose) override;
+  Q_INVOKABLE DoseType upperBounds(int numVoxels) override;
+  Q_INVOKABLE DoseType lowerBounds(int numVoxels) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerMinMaxMeanDoseConstraint);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerSquaredOverdosingObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerSquaredOverdosingObjective.cxx
@@ -1,0 +1,30 @@
+#include "qSlicerSquaredOverdosingObjective.h"
+
+qSlicerSquaredOverdosingObjective::qSlicerSquaredOverdosingObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "Squared Overdosing";
+  this->initializeParameters();
+}
+
+qSlicerSquaredOverdosingObjective::~qSlicerSquaredOverdosingObjective() = default;
+
+void qSlicerSquaredOverdosingObjective::initializeParameters()
+{
+  this->objectivesParameters["maxDose"] = 30.0;
+}
+
+float qSlicerSquaredOverdosingObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double dMax = this->objectivesParameters["maxDose"].toDouble();
+  DoseType overdose = (dose.array() - dMax).max(0.0).matrix();
+  return static_cast<float>(overdose.squaredNorm() / dose.size());
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerSquaredOverdosingObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double dMax = this->objectivesParameters["maxDose"].toDouble();
+  DoseType overdose = (dose.array() - dMax).max(0.0).matrix();
+  return 2.0 * overdose / dose.size();
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerSquaredOverdosingObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerSquaredOverdosingObjective.h
@@ -1,0 +1,27 @@
+#ifndef __qSlicerSquaredOverdosingObjective_h
+#define __qSlicerSquaredOverdosingObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerSquaredOverdosingObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerSquaredOverdosingObjective(QObject* parent = nullptr);
+  ~qSlicerSquaredOverdosingObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerSquaredOverdosingObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/Widgets/qSlicerSquaredUnderdosingObjective.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerSquaredUnderdosingObjective.cxx
@@ -1,0 +1,30 @@
+#include "qSlicerSquaredUnderdosingObjective.h"
+
+qSlicerSquaredUnderdosingObjective::qSlicerSquaredUnderdosingObjective(QObject* parent)
+  : qSlicerAbstractObjective(parent)
+{
+  this->m_Name = "Squared Underdosing";
+  this->initializeParameters();
+}
+
+qSlicerSquaredUnderdosingObjective::~qSlicerSquaredUnderdosingObjective() = default;
+
+void qSlicerSquaredUnderdosingObjective::initializeParameters()
+{
+  this->objectivesParameters["minDose"] = 60.0;
+}
+
+float qSlicerSquaredUnderdosingObjective::computeDoseObjectiveFunction(const DoseType& dose)
+{
+  double dMin = this->objectivesParameters["minDose"].toDouble();
+  DoseType underdose = (dose.array() - dMin).min(0.0).matrix();
+  return static_cast<float>(underdose.squaredNorm() / dose.size());
+}
+
+qSlicerAbstractObjective::DoseType
+qSlicerSquaredUnderdosingObjective::computeDoseObjectiveGradient(const DoseType& dose)
+{
+  double dMin = this->objectivesParameters["minDose"].toDouble();
+  DoseType underdose = (dose.array() - dMin).min(0.0).matrix();
+  return 2.0 * underdose / dose.size();
+}

--- a/ExternalBeamPlanning/Widgets/qSlicerSquaredUnderdosingObjective.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerSquaredUnderdosingObjective.h
@@ -1,0 +1,27 @@
+#ifndef __qSlicerSquaredUnderdosingObjective_h
+#define __qSlicerSquaredUnderdosingObjective_h
+
+#include "qSlicerExternalBeamPlanningModuleWidgetsExport.h"
+#include "qSlicerAbstractObjective.h"
+
+class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerSquaredUnderdosingObjective
+  : public qSlicerAbstractObjective
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerAbstractObjective Superclass;
+  explicit qSlicerSquaredUnderdosingObjective(QObject* parent = nullptr);
+  ~qSlicerSquaredUnderdosingObjective() override;
+
+  Q_INVOKABLE float computeDoseObjectiveFunction(const DoseType& dose) override;
+  Q_INVOKABLE DoseType computeDoseObjectiveGradient(const DoseType& dose) override;
+
+protected:
+  void initializeParameters() override;
+
+private:
+  Q_DISABLE_COPY(qSlicerSquaredUnderdosingObjective);
+};
+
+#endif

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -53,6 +53,9 @@
 #include "qSlicerDoseEnginePluginHandler.h"
 #include "qSlicerMockDoseEngine.h"
 #include "qSlicerMockPlanOptimizer.h"
+#if defined(EXTENSION_BUILDS_IPOPT)
+#include "qSlicerIpoptOptimizer.h"
+#endif
 #include "qSlicerObjectiveLogic.h"
 #include "qSlicerObjectivePluginHandler.h"
 #include "qSlicerPlanOptimizerLogic.h"
@@ -234,6 +237,9 @@ void qSlicerExternalBeamPlanningModuleWidget::enter()
 
   // Register optimizers
   qSlicerPlanOptimizerPluginHandler::instance()->registerPlanOptimizer(new qSlicerMockPlanOptimizer());
+#if defined(EXTENSION_BUILDS_IPOPT)
+  qSlicerPlanOptimizerPluginHandler::instance()->registerPlanOptimizer(new qSlicerIpoptOptimizer());
+#endif
 
   // Python optimizers
   // (otherwise it would be the responsibility of the module that embeds the plan optimizer)

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -55,6 +55,7 @@
 #include "qSlicerMockPlanOptimizer.h"
 #if defined(EXTENSION_BUILDS_IPOPT)
 #include "qSlicerIpoptOptimizer.h"
+#include "IpLinearSolvers.h"
 #endif
 #include "qSlicerObjectiveLogic.h"
 #include "qSlicerObjectivePluginHandler.h"
@@ -376,6 +377,44 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
   // Plan Optimization
   connect( d->comboBox_PlanOptimizer, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(PlanOptimizerChanged(const QString&)));
   connect( d->pushButton_OptimizePlan, SIGNAL(clicked()), this, SLOT(optimizePlanClicked()));
+
+#if defined(EXTENSION_BUILDS_IPOPT)
+  // IPOPT Advanced Settings — hidden until the IPOPT optimizer is selected
+  d->CollapsibleButton_IpoptAdvancedSettings->setVisible(false);
+  connect(d->spinBox_Ipopt_max_iter,               SIGNAL(valueChanged(int)),           this, SLOT(ipoptMaxIterChanged(int)));
+  connect(d->spinBox_Ipopt_max_resto_iter,         SIGNAL(valueChanged(int)),           this, SLOT(ipoptMaxRestoIterChanged(int)));
+  connect(d->doubleSpinBox_Ipopt_max_cpu_time,     SIGNAL(valueChanged(double)),        this, SLOT(ipoptMaxCpuTimeChanged(double)));
+  connect(d->lineEdit_Ipopt_tol,                   SIGNAL(editingFinished()),           this, SLOT(ipoptTolChanged()));
+  connect(d->lineEdit_Ipopt_acceptable_tol,        SIGNAL(editingFinished()),           this, SLOT(ipoptAcceptableTolChanged()));
+  connect(d->spinBox_Ipopt_acceptable_iter,        SIGNAL(valueChanged(int)),           this, SLOT(ipoptAcceptableIterChanged(int)));
+  connect(d->comboBox_Ipopt_mu_strategy,           SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptMuStrategyChanged(QString)));
+  connect(d->comboBox_Ipopt_hessian_approximation, SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptHessianApproximationChanged(QString)));
+  connect(d->spinBox_Ipopt_lbfgs_history,          SIGNAL(valueChanged(int)),           this, SLOT(ipoptLbfgsHistoryChanged(int)));
+  connect(d->spinBox_Ipopt_print_level,            SIGNAL(valueChanged(int)),           this, SLOT(ipoptPrintLevelChanged(int)));
+  connect(d->comboBox_Ipopt_linear_solver,         SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptLinearSolverChanged(QString)));
+
+  {
+    // Query IPOPT at runtime for which solvers are actually available.
+    // buildinonly=0: include solvers loadable from shared libs (e.g. HSL).
+    // buildinonly=1: only solvers statically linked into the binary.
+    IpoptLinearSolver available = IpoptGetAvailableLinearSolvers(1);
+    QComboBox* cb = d->comboBox_Ipopt_linear_solver;
+    cb->blockSignals(true);
+    cb->clear();
+    if (available & IPOPTLINEARSOLVER_MUMPS)      cb->addItem("mumps");
+    if (available & IPOPTLINEARSOLVER_PARDISOMKL) cb->addItem("pardisomkl");
+    if (available & IPOPTLINEARSOLVER_PARDISO)    cb->addItem("pardiso");
+    if (available & IPOPTLINEARSOLVER_MA27)       cb->addItem("ma27");
+    if (available & IPOPTLINEARSOLVER_MA57)       cb->addItem("ma57");
+    if (available & IPOPTLINEARSOLVER_MA77)       cb->addItem("ma77");
+    if (available & IPOPTLINEARSOLVER_MA86)       cb->addItem("ma86");
+    if (available & IPOPTLINEARSOLVER_MA97)       cb->addItem("ma97");
+    if (available & IPOPTLINEARSOLVER_SPRAL)      cb->addItem("spral");
+    if (available & IPOPTLINEARSOLVER_WSMP)       cb->addItem("wsmp");
+    if (cb->count() == 0)                         cb->addItem("mumps"); // fallback
+    cb->blockSignals(false);
+  }
+#endif
 
   // Objective Table
   connect(d->pushButton_AddObjective, SIGNAL(clicked()), this, SLOT(addObjectiveClicked()));
@@ -1540,6 +1579,10 @@ void qSlicerExternalBeamPlanningModuleWidget::PlanOptimizerChanged(const QString
   planNode->SetPlanOptimizerName(selectedEngine->name().toUtf8().constData());
   planNode->DisableModifiedEventOff();
 
+#if defined(EXTENSION_BUILDS_IPOPT)
+  d->CollapsibleButton_IpoptAdvancedSettings->setVisible(text == qSlicerIpoptOptimizer::NAME);
+#endif
+
   selectedEngine->setAvailableObjectives();
   d->ObjectivesTableWidget->deleteObjectivesTable();
 }
@@ -1667,3 +1710,102 @@ void qSlicerExternalBeamPlanningModuleWidget::saveAvailableObjectives()
   qSlicerAbstractPlanOptimizer* selectedEngine =
     qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(planNode->GetPlanOptimizerName());
 }
+
+#if defined(EXTENSION_BUILDS_IPOPT)
+//-----------------------------------------------------------------------------
+// IPOPT Advanced Settings slot implementations
+//-----------------------------------------------------------------------------
+
+namespace {
+  qSlicerIpoptOptimizer* getIpoptOptimizer()
+  {
+    return qobject_cast<qSlicerIpoptOptimizer*>(
+      qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(qSlicerIpoptOptimizer::NAME));
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxRestoIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_resto_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxCpuTimeChanged(double value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_cpu_time", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptTolChanged()
+{
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  bool ok;
+  double val = d->lineEdit_Ipopt_tol->text().toDouble(&ok);
+  if (ok)
+    if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+      opt->setOption("tol", val);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptAcceptableTolChanged()
+{
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  bool ok;
+  double val = d->lineEdit_Ipopt_acceptable_tol->text().toDouble(&ok);
+  if (ok)
+    if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+      opt->setOption("acceptable_tol", val);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptAcceptableIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("acceptable_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMuStrategyChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("mu_strategy", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptHessianApproximationChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("hessian_approximation", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptLbfgsHistoryChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("limited_memory_max_history", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptPrintLevelChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("print_level", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptLinearSolverChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("linear_solver", value);
+}
+#endif

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -53,6 +53,10 @@
 #include "qSlicerDoseEnginePluginHandler.h"
 #include "qSlicerMockDoseEngine.h"
 #include "qSlicerMockPlanOptimizer.h"
+#if defined(EXTENSION_BUILDS_IPOPT)
+#include "qSlicerIpoptOptimizer.h"
+#include "IpLinearSolvers.h"
+#endif
 #include "qSlicerObjectiveLogic.h"
 #include "qSlicerObjectivePluginHandler.h"
 #include "qSlicerPlanOptimizerLogic.h"
@@ -234,6 +238,9 @@ void qSlicerExternalBeamPlanningModuleWidget::enter()
 
   // Register optimizers
   qSlicerPlanOptimizerPluginHandler::instance()->registerPlanOptimizer(new qSlicerMockPlanOptimizer());
+#if defined(EXTENSION_BUILDS_IPOPT)
+  qSlicerPlanOptimizerPluginHandler::instance()->registerPlanOptimizer(new qSlicerIpoptOptimizer());
+#endif
 
   // Python optimizers
   // (otherwise it would be the responsibility of the module that embeds the plan optimizer)
@@ -370,6 +377,44 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
   // Plan Optimization
   connect( d->comboBox_PlanOptimizer, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(PlanOptimizerChanged(const QString&)));
   connect( d->pushButton_OptimizePlan, SIGNAL(clicked()), this, SLOT(optimizePlanClicked()));
+
+#if defined(EXTENSION_BUILDS_IPOPT)
+  // IPOPT Advanced Settings — hidden until the IPOPT optimizer is selected
+  d->CollapsibleButton_IpoptAdvancedSettings->setVisible(false);
+  connect(d->spinBox_Ipopt_max_iter,               SIGNAL(valueChanged(int)),           this, SLOT(ipoptMaxIterChanged(int)));
+  connect(d->spinBox_Ipopt_max_resto_iter,         SIGNAL(valueChanged(int)),           this, SLOT(ipoptMaxRestoIterChanged(int)));
+  connect(d->doubleSpinBox_Ipopt_max_cpu_time,     SIGNAL(valueChanged(double)),        this, SLOT(ipoptMaxCpuTimeChanged(double)));
+  connect(d->lineEdit_Ipopt_tol,                   SIGNAL(editingFinished()),           this, SLOT(ipoptTolChanged()));
+  connect(d->lineEdit_Ipopt_acceptable_tol,        SIGNAL(editingFinished()),           this, SLOT(ipoptAcceptableTolChanged()));
+  connect(d->spinBox_Ipopt_acceptable_iter,        SIGNAL(valueChanged(int)),           this, SLOT(ipoptAcceptableIterChanged(int)));
+  connect(d->comboBox_Ipopt_mu_strategy,           SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptMuStrategyChanged(QString)));
+  connect(d->comboBox_Ipopt_hessian_approximation, SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptHessianApproximationChanged(QString)));
+  connect(d->spinBox_Ipopt_lbfgs_history,          SIGNAL(valueChanged(int)),           this, SLOT(ipoptLbfgsHistoryChanged(int)));
+  connect(d->spinBox_Ipopt_print_level,            SIGNAL(valueChanged(int)),           this, SLOT(ipoptPrintLevelChanged(int)));
+  connect(d->comboBox_Ipopt_linear_solver,         SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptLinearSolverChanged(QString)));
+
+  {
+    // Query IPOPT at runtime for which solvers are actually available.
+    // buildinonly=0: include solvers loadable from shared libs (e.g. HSL).
+    // buildinonly=1: only solvers statically linked into the binary.
+    IpoptLinearSolver available = IpoptGetAvailableLinearSolvers(1);
+    QComboBox* cb = d->comboBox_Ipopt_linear_solver;
+    cb->blockSignals(true);
+    cb->clear();
+    if (available & IPOPTLINEARSOLVER_MUMPS)      cb->addItem("mumps");
+    if (available & IPOPTLINEARSOLVER_PARDISOMKL) cb->addItem("pardisomkl");
+    if (available & IPOPTLINEARSOLVER_PARDISO)    cb->addItem("pardiso");
+    if (available & IPOPTLINEARSOLVER_MA27)       cb->addItem("ma27");
+    if (available & IPOPTLINEARSOLVER_MA57)       cb->addItem("ma57");
+    if (available & IPOPTLINEARSOLVER_MA77)       cb->addItem("ma77");
+    if (available & IPOPTLINEARSOLVER_MA86)       cb->addItem("ma86");
+    if (available & IPOPTLINEARSOLVER_MA97)       cb->addItem("ma97");
+    if (available & IPOPTLINEARSOLVER_SPRAL)      cb->addItem("spral");
+    if (available & IPOPTLINEARSOLVER_WSMP)       cb->addItem("wsmp");
+    if (cb->count() == 0)                         cb->addItem("mumps"); // fallback
+    cb->blockSignals(false);
+  }
+#endif
 
   // Objective Table
   connect(d->pushButton_AddObjective, SIGNAL(clicked()), this, SLOT(addObjectiveClicked()));
@@ -1545,6 +1590,10 @@ void qSlicerExternalBeamPlanningModuleWidget::PlanOptimizerChanged(const QString
   planNode->SetPlanOptimizerName(selectedEngine->name().toUtf8().constData());
   planNode->DisableModifiedEventOff();
 
+#if defined(EXTENSION_BUILDS_IPOPT)
+  d->CollapsibleButton_IpoptAdvancedSettings->setVisible(text == qSlicerIpoptOptimizer::NAME);
+#endif
+
   selectedEngine->setAvailableObjectives();
   d->ObjectivesTableWidget->deleteObjectivesTable();
 }
@@ -1672,3 +1721,102 @@ void qSlicerExternalBeamPlanningModuleWidget::saveAvailableObjectives()
   qSlicerAbstractPlanOptimizer* selectedEngine =
     qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(planNode->GetPlanOptimizerName());
 }
+
+#if defined(EXTENSION_BUILDS_IPOPT)
+//-----------------------------------------------------------------------------
+// IPOPT Advanced Settings slot implementations
+//-----------------------------------------------------------------------------
+
+namespace {
+  qSlicerIpoptOptimizer* getIpoptOptimizer()
+  {
+    return qobject_cast<qSlicerIpoptOptimizer*>(
+      qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(qSlicerIpoptOptimizer::NAME));
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxRestoIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_resto_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMaxCpuTimeChanged(double value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("max_cpu_time", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptTolChanged()
+{
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  bool ok;
+  double val = d->lineEdit_Ipopt_tol->text().toDouble(&ok);
+  if (ok)
+    if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+      opt->setOption("tol", val);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptAcceptableTolChanged()
+{
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  bool ok;
+  double val = d->lineEdit_Ipopt_acceptable_tol->text().toDouble(&ok);
+  if (ok)
+    if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+      opt->setOption("acceptable_tol", val);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptAcceptableIterChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("acceptable_iter", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMuStrategyChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("mu_strategy", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptHessianApproximationChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("hessian_approximation", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptLbfgsHistoryChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("limited_memory_max_history", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptPrintLevelChanged(int value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("print_level", value);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::ipoptLinearSolverChanged(const QString& value)
+{
+  if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
+    opt->setOption("linear_solver", value);
+}
+#endif

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
@@ -119,6 +119,21 @@ protected slots:
   void onProgressUpdated(double progress);
   void onOptimizerProgressInfoUpdated(QString info);
 
+#if defined(EXTENSION_BUILDS_IPOPT)
+  // IPOPT Advanced Settings slots
+  void ipoptMaxIterChanged(int value);
+  void ipoptMaxRestoIterChanged(int value);
+  void ipoptMaxCpuTimeChanged(double value);
+  void ipoptTolChanged();
+  void ipoptAcceptableTolChanged();
+  void ipoptAcceptableIterChanged(int value);
+  void ipoptMuStrategyChanged(const QString& value);
+  void ipoptHessianApproximationChanged(const QString& value);
+  void ipoptLbfgsHistoryChanged(int value);
+  void ipoptPrintLevelChanged(int value);
+  void ipoptLinearSolverChanged(const QString& value);
+#endif
+
 protected:
   void setup() override;
   void enter() override;

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -24,10 +24,10 @@ set(${proj}_DEPENDS
 
 # Add linear equation solver dependencies (MUMPS, HSL) if enabled and on UNIX
 if(EXTENSION_BUILDS_IPOPT AND UNIX)
-  list(APPEND ${proj}_DEPENDS
-    Mumps
-    HSL
-  )
+  list(APPEND ${proj}_DEPENDS Mumps)
+  if(EXTENSION_USES_HSL)
+    list(APPEND ${proj}_DEPENDS HSL)
+  endif()
 endif()
 
 # Add optimization dependencies Ipopt if enabled

--- a/SuperBuild/External_HSL.cmake
+++ b/SuperBuild/External_HSL.cmake
@@ -3,25 +3,31 @@ set(proj HSL)
 # HSL (Harwell Subroutines Library) - High-performance linear solvers for Ipopt
 # HSL can provide better performance than MUMPS for some optimization problems
 #
-# Note: HSL requires manual download of source code due to licensing restrictions
-# This configuration assumes you have obtained HSL sources from:
-# https://licences.stfc.ac.uk/product/coin-hsl
+# Two ways to use HSL on Linux — no license redistribution is possible either way:
 #
-# Instructions:
-# 1. Download the Coin-HSL archive from the link above
-# 2. Extract it to a 'coinhsl' directory in the HSL source directory
-# 3. The build system will automatically detect and use the HSL solvers
+# Option A — Runtime (no rebuild needed):
+#   1. Get libhsl.so from STFC (e.g. https://www.hsl.rl.ac.uk/download/MA57/3.11.3/)
+#   2. export LD_LIBRARY_PATH=/path/to/libhsl.so/dir:$LD_LIBRARY_PATH
+#   3. Set Ipopt option linear_solver=ma57 (or ma27/ma97) at runtime
+#
+# Option B — Compiled in (self-contained build, all HSL solvers):
+#   1. Download Coin-HSL source from https://licences.stfc.ac.uk/product/coin-hsl
+#   2. Extract the archive (gives a directory with MA27/MA57/MA77/MA86/MA97 source)
+#   3. cmake -DEXTENSION_HSL_SOURCE_DIR=/path/to/extracted/coinhsl ...
+#      The build system copies the source and compiles it automatically.
 
-# HSL requires optimization flag to be enabled and Unix-like system
-if(NOT EXTENSION_BUILDS_IPOPT)
-  message(STATUS "HSL build skipped. Enable with EXTENSION_BUILDS_IPOPT=ON")
+if(NOT EXTENSION_BUILDS_IPOPT OR NOT EXTENSION_USES_HSL)
+  message(STATUS "HSL build skipped. Enable with EXTENSION_BUILDS_IPOPT=ON and EXTENSION_USES_HSL=ON")
   ExternalProject_Add_Empty(${proj} DEPENDS "")
   mark_as_superbuild(${proj}_DIR:PATH)
   return()
 endif()
 
 if(WIN32)
-  message(WARNING "HSL build is only supported on Unix-like systems (Linux, macOS). Skipping on Windows.")
+  message(STATUS "HSL source build is not supported on Windows. "
+    "To use HSL on Windows, obtain libhsl.dll from https://licences.stfc.ac.uk/product/coin-hsl. "
+    "Option A (no rebuild): copy libhsl.dll next to ipopt-3.dll in the Slicer install directory. "
+    "Option B (automated, requires rebuild): set EXTENSION_HSL_DLL_DIR to the directory containing libhsl.dll.")
   ExternalProject_Add_Empty(${proj} DEPENDS "")
   mark_as_superbuild(${proj}_DIR:PATH)
   return()
@@ -77,6 +83,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     SOURCE_DIR ${EP_SOURCE_DIR}
     BINARY_DIR ${EP_BINARY_DIR}
     INSTALL_DIR ${EP_INSTALL_DIR}
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy_directory "${EXTENSION_HSL_SOURCE_DIR}" <SOURCE_DIR>/coinhsl
     CONFIGURE_COMMAND
       ${CMAKE_COMMAND} -E env
         CC=${CMAKE_C_COMPILER}

--- a/SuperBuild/External_Ipopt.cmake
+++ b/SuperBuild/External_Ipopt.cmake
@@ -66,7 +66,7 @@ endif()
 
 # Set dependency list
 set(${proj}_DEPENDS "")
-if(DEFINED Slicer_SOURCE_DIR)
+if(EXTENSION_BUILDS_IPOPT AND UNIX)
   list(APPEND ${proj}_DEPENDS
     Mumps
     HSL

--- a/SuperBuild/External_Ipopt.cmake
+++ b/SuperBuild/External_Ipopt.cmake
@@ -1,20 +1,18 @@
 set(proj Ipopt)
 
 # IPOPT - Interior Point Optimizer
-# Ipopt is configured with both MUMPS and HSL linear solvers for optimal performance.
+# UNIX: Built from source using autotools with system LAPACK/BLAS.
+#   Linear solvers:
+#   - MUMPS: statically linked, built automatically
+#   - HSL (MA27/MA57/MA77/MA86/MA97): two options:
+#       (a) Compile in: set EXTENSION_HSL_SOURCE_DIR to your Coin-HSL source
+#           (free academic license: https://licences.stfc.ac.uk/product/coin-hsl)
+#       (b) Runtime load: set LD_LIBRARY_PATH to a directory containing libhsl.so
+#           (e.g. https://www.hsl.rl.ac.uk/download/MA57/3.11.3/), no rebuild needed
 #
-# UNIX: This configuration supports Linux and macOS systems
-# and uses autotools build system with system LAPACK/BLAS libraries.
-#
-# Included Linear Solvers:
-# - MUMPS: Open-source, automatically downloaded and built
-# - HSL (Harwell Subroutines Library): High-performance solvers
-#   * Requires manual download due to licensing (free for academic use)
-#   * Download from: https://licences.stfc.ac.uk/product/coin-hsl
-#   * Extract to 'coinhsl' directory in HSL source tree
-#   * HSL provides MA27, MA57, MA77, MA86, MA97 solvers
-#
-# WINDOWS: Prebuilt binaries are downloaded and extracted, MUMPS included.
+# WINDOWS: Prebuilt binaries downloaded from COIN-OR releases (MUMPS included).
+#   HSL: place libhsl.dll directory in EXTENSION_HSL_DLL_DIR; the linear solver
+#   loader in ipopt-3.dll will find it automatically at runtime.
 #
 # For more information see: https://coin-or.github.io/Ipopt/INSTALL.html
 
@@ -53,6 +51,16 @@ if(WIN32)
   set(${proj}_DLL_DIR "${IPOPT_WIN_REAL_DIR}/bin")
   set(${proj}_DLL "${IPOPT_WIN_REAL_DIR}/bin/ipopt-3.dll")
 
+  # Copy HSL DLL alongside ipopt-3.dll so the linear solver loader finds it at runtime.
+  # This runs as a build-time step (after install) because the bin/ directory is
+  # populated by ExternalProject, not available at CMake configure time.
+  if(EXTENSION_USES_HSL)
+    ExternalProject_Add_Step(${proj} copy_hsl_dlls
+      COMMAND ${CMAKE_COMMAND} -E copy_directory "${EXTENSION_HSL_DLL_DIR}" "${IPOPT_WIN_REAL_DIR}/bin"
+      DEPENDEES install
+    )
+  endif()
+
   # Cache variables for downstream use
   set(Ipopt_DIR "${${proj}_DIR}" CACHE PATH "Ipopt root directory")
   set(Ipopt_INCLUDE_DIR "${${proj}_INCLUDE_DIR}" CACHE PATH "Ipopt include directory")
@@ -66,11 +74,11 @@ endif()
 
 # Set dependency list
 set(${proj}_DEPENDS "")
-if(DEFINED Slicer_SOURCE_DIR)
-  list(APPEND ${proj}_DEPENDS
-    Mumps
-    HSL
-    )
+if(EXTENSION_BUILDS_IPOPT AND UNIX)
+  list(APPEND ${proj}_DEPENDS Mumps)
+  if(EXTENSION_USES_HSL)
+    list(APPEND ${proj}_DEPENDS HSL)
+  endif()
 endif()
 
 # Include dependent projects if any
@@ -109,10 +117,17 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(EP_C_FLAGS "${ep_common_c_flags}")
   set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
 
-  # Set up linker flags as variables
+  # Set up linker flags
   set(MUMPS_LFLAGS "-L${Mumps_DIR}/lib -lcoinmumps -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
-  # Uncomment the following lines when HSL is available:
-  # set(HSL_LFLAGS "-L${HSL_DIR}/lib -lcoinhsl -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+
+  set(IPOPT_HSL_CONFIGURE_ARGS "")
+  if(EXTENSION_USES_HSL)
+    set(HSL_LFLAGS "-L${HSL_DIR}/lib -lcoinhsl -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+    set(IPOPT_HSL_CONFIGURE_ARGS
+      "--with-hsl-cflags=-I${HSL_DIR}/include/coin-or"
+      "--with-hsl-lflags=${HSL_LFLAGS}"
+    )
+  endif()
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
@@ -136,10 +151,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
         --enable-static=yes
         --with-mumps-cflags=-I${Mumps_DIR}/include/coin-or/mumps
         --with-mumps-lflags=${MUMPS_LFLAGS}
-        # Uncomment the following lines when HSL is available:
-        # --with-hsl-cflags=-I${HSL_DIR}/include/coin-or
-        # --with-hsl-lflags=${HSL_LFLAGS}
-        --disable-linear-solver-loader
+        ${IPOPT_HSL_CONFIGURE_ARGS}
     BUILD_COMMAND $(MAKE)
     INSTALL_COMMAND $(MAKE) install
     DEPENDS

--- a/SuperBuild/External_Ipopt.cmake
+++ b/SuperBuild/External_Ipopt.cmake
@@ -1,20 +1,18 @@
 set(proj Ipopt)
 
 # IPOPT - Interior Point Optimizer
-# Ipopt is configured with both MUMPS and HSL linear solvers for optimal performance.
+# UNIX: Built from source using autotools with system LAPACK/BLAS.
+#   Linear solvers:
+#   - MUMPS: statically linked, built automatically
+#   - HSL (MA27/MA57/MA77/MA86/MA97): two options:
+#       (a) Compile in: set EXTENSION_HSL_SOURCE_DIR to your Coin-HSL source
+#           (free academic license: https://licences.stfc.ac.uk/product/coin-hsl)
+#       (b) Runtime load: set LD_LIBRARY_PATH to a directory containing libhsl.so
+#           (e.g. https://www.hsl.rl.ac.uk/download/MA57/3.11.3/), no rebuild needed
 #
-# UNIX: This configuration supports Linux and macOS systems
-# and uses autotools build system with system LAPACK/BLAS libraries.
-#
-# Included Linear Solvers:
-# - MUMPS: Open-source, automatically downloaded and built
-# - HSL (Harwell Subroutines Library): High-performance solvers
-#   * Requires manual download due to licensing (free for academic use)
-#   * Download from: https://licences.stfc.ac.uk/product/coin-hsl
-#   * Extract to 'coinhsl' directory in HSL source tree
-#   * HSL provides MA27, MA57, MA77, MA86, MA97 solvers
-#
-# WINDOWS: Prebuilt binaries are downloaded and extracted, MUMPS included.
+# WINDOWS: Prebuilt binaries downloaded from COIN-OR releases (MUMPS included).
+#   HSL: place libhsl.dll directory in EXTENSION_HSL_DLL_DIR; the linear solver
+#   loader in ipopt-3.dll will find it automatically at runtime.
 #
 # For more information see: https://coin-or.github.io/Ipopt/INSTALL.html
 
@@ -53,6 +51,16 @@ if(WIN32)
   set(${proj}_DLL_DIR "${IPOPT_WIN_REAL_DIR}/bin")
   set(${proj}_DLL "${IPOPT_WIN_REAL_DIR}/bin/ipopt-3.dll")
 
+  # Copy HSL DLL alongside ipopt-3.dll so the linear solver loader finds it at runtime.
+  # This runs as a build-time step (after install) because the bin/ directory is
+  # populated by ExternalProject, not available at CMake configure time.
+  if(EXTENSION_USES_HSL)
+    ExternalProject_Add_Step(${proj} copy_hsl_dlls
+      COMMAND ${CMAKE_COMMAND} -E copy_directory "${EXTENSION_HSL_DLL_DIR}" "${IPOPT_WIN_REAL_DIR}/bin"
+      DEPENDEES install
+    )
+  endif()
+
   # Cache variables for downstream use
   set(Ipopt_DIR "${${proj}_DIR}" CACHE PATH "Ipopt root directory")
   set(Ipopt_INCLUDE_DIR "${${proj}_INCLUDE_DIR}" CACHE PATH "Ipopt include directory")
@@ -67,10 +75,10 @@ endif()
 # Set dependency list
 set(${proj}_DEPENDS "")
 if(EXTENSION_BUILDS_IPOPT AND UNIX)
-  list(APPEND ${proj}_DEPENDS
-    Mumps
-    HSL
-    )
+  list(APPEND ${proj}_DEPENDS Mumps)
+  if(EXTENSION_USES_HSL)
+    list(APPEND ${proj}_DEPENDS HSL)
+  endif()
 endif()
 
 # Include dependent projects if any
@@ -109,10 +117,17 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(EP_C_FLAGS "${ep_common_c_flags}")
   set(EP_CXX_FLAGS "${ep_common_cxx_flags}")
 
-  # Set up linker flags as variables
+  # Set up linker flags
   set(MUMPS_LFLAGS "-L${Mumps_DIR}/lib -lcoinmumps -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
-  # Uncomment the following lines when HSL is available:
-  # set(HSL_LFLAGS "-L${HSL_DIR}/lib -lcoinhsl -lmetis -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+
+  set(IPOPT_HSL_CONFIGURE_ARGS "")
+  if(EXTENSION_USES_HSL)
+    set(HSL_LFLAGS "-L${HSL_DIR}/lib -lcoinhsl -llapack -lblas -lgfortran -lm -lquadmath -lpthread")
+    set(IPOPT_HSL_CONFIGURE_ARGS
+      "--with-hsl-cflags=-I${HSL_DIR}/include/coin-or"
+      "--with-hsl-lflags=${HSL_LFLAGS}"
+    )
+  endif()
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
@@ -136,10 +151,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
         --enable-static=yes
         --with-mumps-cflags=-I${Mumps_DIR}/include/coin-or/mumps
         --with-mumps-lflags=${MUMPS_LFLAGS}
-        # Uncomment the following lines when HSL is available:
-        # --with-hsl-cflags=-I${HSL_DIR}/include/coin-or
-        # --with-hsl-lflags=${HSL_LFLAGS}
-        --disable-linear-solver-loader
+        ${IPOPT_HSL_CONFIGURE_ARGS}
     BUILD_COMMAND $(MAKE)
     INSTALL_COMMAND $(MAKE) install
     DEPENDS


### PR DESCRIPTION
A new class called qSlicerIpoptOptimizer was added to the ExternalBeamPlanning Widgets directory.

This class functions as an interface from which to use IPOPT. Also, a new test was added to the ExternalBeamPlanning module to verify that the class does indeed work, which it did:

```
...
44: ✓ All tests passed successfully!
1/1 Test #44: qSlicerIpoptOptimizerBasicTest ...   Passed    1.62 sec

The following tests passed:
	qSlicerIpoptOptimizerBasicTest

100% tests passed, 0 tests failed out of 1

Label Time Summary:
ExternalBeamPlanning    =   1.62 sec*proc (1 test)
IPOPT                   =   1.62 sec*proc (1 test)
Optimization            =   1.62 sec*proc (1 test)

Total Test time (real) =   1.62 sec
```

This class was created after: https://github.com/e0404/pyRadPlan/blob/main/pyRadPlan/optimization/solvers/_ipopt.py
However, some modifications were made to make it work in C++, while maintaining the functionality of the class mentioned above.

Re #298