### PR TITLE
BUG: PyUnicode_Check used to check string instead of PyFloat_Check

### DIFF
--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
@@ -228,7 +228,7 @@ QString qSlicerScriptedDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* b
     }
 
   // Parse result
-  if (!PyFloat_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": qSlicerScriptedDoseEngine: Function 'calculateDoseUsingEngine' is expected to return a string!";
     return QString();
@@ -253,7 +253,7 @@ QString qSlicerScriptedDoseEngine::calculateDoseInfluenceMatrixUsingEngine(vtkMR
   }
 
   // Parse result
-  if (!PyFloat_Check(result))
+  if (!PyUnicode_Check(result))
   {
     qWarning() << d->PythonSource << ": qSlicerScriptedDoseEngine: Function 'calculateDoseInfluenceMatrixUsingEngine' is expected to return a string!";
     return QString();

--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedPlanOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedPlanOptimizer.cxx
@@ -223,7 +223,7 @@ QString qSlicerScriptedPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNo
   }
 
   // Parse result
-  if (!PyFloat_Check(result))
+  if (!PyUnicode_Check(result))
   {
     qWarning() << d->PythonSource << ": qSlicerScriptedPlanOptimizer: Function 'optimizePlanUsingOptimizer' is expected to return a string!";
     return QString();


### PR DESCRIPTION
Whenever a dose engine ends, even when successful this warning appears:

```
[Qt] "...qt-scripted-modules/DoseEngines/pyRadPlanEngine.py" : qSlicerScriptedDoseEngine: Function 'calculateDoseUsingEngine' is expected to return a string!
```

This is because in `qSlicerScriptedDoseEngine.cxx` and `qSlicerScriptedPlanOptimizer.cxx` when checking what the dose engine/ plan optimizer return it does so by using `PyFloat_Check` instead of `PyUnicode_Check`, which should be the one used for checking a string.

This fixes this false warning by using the correct function.

