### PR TITLE
ENH: Disable unused beam geometry parameters and MLC tab for inverse planning

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -959,3 +959,13 @@ void vtkMRMLRTPlanNode::SetDoseGridSpacingToCTGridSpacing()
   this->SetDoseGridSpacingComponent(1, spacing[1]);
   this->SetDoseGridSpacingComponent(2, spacing[2]);
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTPlanNode::SetInversePlanFlag(bool InversePlanFlag)
+{
+  this->InversePlanFlag = InversePlanFlag;
+
+  // Invoke events
+  this->Modified();
+  this->InvokeEvent(vtkMRMLRTPlanNode::InversePlanFlagChanged, this);
+}

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -65,7 +65,9 @@ public:
     /// Fired if dose engine is changed
     DoseEngineChanged,
     /// Fired if optimization engine is changed
-    PlanOptimizerChanged
+    PlanOptimizerChanged,
+    /// Fired if optimization engine is changed
+    InversePlanFlagChanged
   };
 
 public:
@@ -218,9 +220,9 @@ public:
   void SetDoseGridSpacingToCTGridSpacing();
 
   /// Get flag for inverse plan
-  vtkGetMacro(InverseFlag, bool);
+  vtkGetMacro(InversePlanFlag, bool);
   /// Set flag for inverse plan
-  vtkSetMacro(InverseFlag, bool);
+  void SetInversePlanFlag(bool InversePlanFlag);
 
   /// Get flag for ion plan
   vtkGetMacro( IonPlanFlag, bool);
@@ -270,7 +272,7 @@ protected:
   double DoseGridSpacing[3]{ 5.0, 5.0, 5.0 };
 
   /// Flag, indicates that a plan node is currently doing inverse planning
-  bool InverseFlag{ false };
+  bool InversePlanFlag{ false };
 
   /// Flag, indicates that a plan node is an ion plan node
   bool IonPlanFlag{ false };

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -217,6 +217,11 @@ public:
   /// Set dose grid to ct grid
   void SetDoseGridSpacingToCTGridSpacing();
 
+  /// Get flag for inverse plan
+  vtkGetMacro(InverseFlag, bool);
+  /// Set flag for inverse plan
+  vtkSetMacro(InverseFlag, bool);
+
   /// Get flag for ion plan
   vtkGetMacro( IonPlanFlag, bool);
   /// Set flag for ion plan
@@ -263,6 +268,9 @@ protected:
   /// Allows user to specify dose volume resolution different from reference volume
   //TODO: Explain here why this is defined in the plan node as well as the beam node
   double DoseGridSpacing[3]{ 5.0, 5.0, 5.0 };
+
+  /// Flag, indicates that a plan node is currently doing inverse planning
+  bool InverseFlag{ false };
 
   /// Flag, indicates that a plan node is an ion plan node
   bool IonPlanFlag{ false };

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -404,22 +404,13 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
 
   // For inverse plans
   vtkMRMLRTPlanNode* planNode = d->BeamNode->GetParentPlanNode();
-  if (planNode->GetInverseFlag())
-  {
-    d->doubleSpinBox_SAD->setEnabled(false);
-    d->RangeWidget_XJawsPosition->setEnabled(false);
-    d->RangeWidget_YJawsPosition->setEnabled(false);
-    d->SliderWidget_CollimatorAngle->setEnabled(false);
-    d->tabMultiLeafCollimator->setEnabled(false);
-  }
-  else
-  {
-    d->doubleSpinBox_SAD->setEnabled(true);
-    d->RangeWidget_XJawsPosition->setEnabled(true);
-    d->RangeWidget_YJawsPosition->setEnabled(true);
-    d->SliderWidget_CollimatorAngle->setEnabled(true);
-    d->tabMultiLeafCollimator->setEnabled(true);
-  }
+  bool inversePlan = planNode->GetInverseFlag();
+
+  d->doubleSpinBox_SAD->setEnabled(!inversePlan);
+  d->RangeWidget_XJawsPosition->setEnabled(!inversePlan);
+  d->RangeWidget_YJawsPosition->setEnabled(!inversePlan);
+  d->SliderWidget_CollimatorAngle->setEnabled(!inversePlan);
+  d->tabMultiLeafCollimator->setEnabled(!inversePlan);
 }
 
 //-----------------------------------------------------------------------------

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -401,6 +401,25 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
       d->CollapsibleButton_RangeShifterParameters->setEnabled(false);
     }
   }
+
+  // For inverse plans
+  vtkMRMLRTPlanNode* planNode = d->BeamNode->GetParentPlanNode();
+  if (planNode->GetInverseFlag())
+  {
+    d->doubleSpinBox_SAD->setEnabled(false);
+    d->RangeWidget_XJawsPosition->setEnabled(false);
+    d->RangeWidget_YJawsPosition->setEnabled(false);
+    d->SliderWidget_CollimatorAngle->setEnabled(false);
+    d->tabMultiLeafCollimator->setEnabled(false);
+  }
+  else
+  {
+    d->doubleSpinBox_SAD->setEnabled(true);
+    d->RangeWidget_XJawsPosition->setEnabled(true);
+    d->RangeWidget_YJawsPosition->setEnabled(true);
+    d->SliderWidget_CollimatorAngle->setEnabled(true);
+    d->tabMultiLeafCollimator->setEnabled(true);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -164,9 +164,23 @@ void qMRMLBeamParametersTabWidget::setBeamNode(vtkMRMLNode* node)
   Q_D(qMRMLBeamParametersTabWidget);
 
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(node);
+  vtkMRMLRTPlanNode* oldPlanNode = nullptr;
+  if (d->BeamNode)
+  {
+    oldPlanNode = d->BeamNode->GetParentPlanNode();
+  }
+  vtkMRMLRTPlanNode* planNode = nullptr;
+  if (beamNode)
+  {
+    planNode = beamNode->GetParentPlanNode();
+  }
 
   // Connect display modified event to population of the table
   qvtkReconnect( d->BeamNode, beamNode, vtkCommand::ModifiedEvent,
+                 this, SLOT( updateWidgetFromMRML() ) );
+
+  // Connect inverse plan flag modified event to population of the table (for enabling/disabling unused geometry and MLC parameters)
+  qvtkReconnect( oldPlanNode, planNode, vtkMRMLRTPlanNode::InversePlanFlagChanged,
                  this, SLOT( updateWidgetFromMRML() ) );
 
   d->BeamNode = beamNode;
@@ -404,7 +418,7 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
 
   // For inverse plans
   vtkMRMLRTPlanNode* planNode = d->BeamNode->GetParentPlanNode();
-  bool inversePlan = planNode->GetInverseFlag();
+  bool inversePlan = planNode->GetInversePlanFlag();
 
   d->doubleSpinBox_SAD->setEnabled(!inversePlan);
   d->RangeWidget_XJawsPosition->setEnabled(!inversePlan);

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -492,6 +492,9 @@ void qSlicerExternalBeamPlanningModuleWidget::setPlanNode(vtkMRMLNode* node)
       planNode->SetIonPlanFlag(true);
     }
 
+    // Set inverse flag according to plan
+    d->checkBox_InversePlanning->setChecked(planNode->GetInverseFlag());
+
     // Set input segmentation and reference volume if specified by DICOM
     vtkIdType planShItemID = shNode->GetItemByDataNode(planNode);
     if (!planShItemID)
@@ -1000,24 +1003,31 @@ void qSlicerExternalBeamPlanningModuleWidget::inversePlanningCheckboxStateChange
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
-  //TODO: should we write the inverse planning flag to the plan node?
+  vtkMRMLRTPlanNode* planNode = vtkMRMLRTPlanNode::SafeDownCast(d->MRMLNodeComboBox_RtPlan->currentNode());
+  if (!planNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": Invalid RT plan node";
+    return;
+  }
+
+  if (d->checkBox_InversePlanning->isChecked())
+  {
+    d->pushButton_OptimizePlan->setEnabled(true);
+    planNode->SetInverseFlag(true);
+    d->CollapsibleButton_Objectives->setEnabled(true);
+  }
+  else
+  {
+    d->pushButton_OptimizePlan->setEnabled(false);
+    planNode->SetInverseFlag(false);
+    d->CollapsibleButton_Objectives->setEnabled(false);
+  }
 
   // Update dose engines
   this->updateDoseEngines();
 
   // Update Optimization engines
   this->updatePlanOptimizers();
-
-  if (d->checkBox_InversePlanning->isChecked())
-  {
-      d->pushButton_OptimizePlan->setEnabled(true);
-   d->CollapsibleButton_Objectives->setEnabled(true);
-  }
-  else
-  {
-      d->pushButton_OptimizePlan->setEnabled(false);
-   d->CollapsibleButton_Objectives->setEnabled(false);
-  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1152,9 +1162,6 @@ void qSlicerExternalBeamPlanningModuleWidget::updatePlanOptimizers()
   // Apply engine selection (signals are blocked, plus if first index has been selected and it has
   // not been applied, then it needs to be done now)
   this->PlanOptimizerChanged(d->comboBox_PlanOptimizer->currentText());
-
-  // Update beam parameter tab visibility
-  //d->PlanOptimizerLogic->applyDoseEngineInPlan(planNode);
 
   d->comboBox_PlanOptimizer->blockSignals(false);
 }

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -1010,18 +1010,9 @@ void qSlicerExternalBeamPlanningModuleWidget::inversePlanningCheckboxStateChange
     return;
   }
 
-  if (d->checkBox_InversePlanning->isChecked())
-  {
-    d->pushButton_OptimizePlan->setEnabled(true);
-    planNode->SetInverseFlag(true);
-    d->CollapsibleButton_Objectives->setEnabled(true);
-  }
-  else
-  {
-    d->pushButton_OptimizePlan->setEnabled(false);
-    planNode->SetInverseFlag(false);
-    d->CollapsibleButton_Objectives->setEnabled(false);
-  }
+  d->pushButton_OptimizePlan->setEnabled(state);
+  planNode->SetInverseFlag(state);
+  d->CollapsibleButton_Objectives->setEnabled(state);
 
   // Update dose engines
   this->updateDoseEngines();

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -493,7 +493,7 @@ void qSlicerExternalBeamPlanningModuleWidget::setPlanNode(vtkMRMLNode* node)
     }
 
     // Set inverse flag according to plan
-    d->checkBox_InversePlanning->setChecked(planNode->GetInverseFlag());
+    d->checkBox_InversePlanning->setChecked(planNode->GetInversePlanFlag());
 
     // Set input segmentation and reference volume if specified by DICOM
     vtkIdType planShItemID = shNode->GetItemByDataNode(planNode);
@@ -1011,7 +1011,7 @@ void qSlicerExternalBeamPlanningModuleWidget::inversePlanningCheckboxStateChange
   }
 
   d->pushButton_OptimizePlan->setEnabled(state);
-  planNode->SetInverseFlag(state);
+  planNode->SetInversePlanFlag(state);
   d->CollapsibleButton_Objectives->setEnabled(state);
 
   // Update dose engines


### PR DESCRIPTION
### Problem:
Currently, when a plan is set to use inverse planning, unused beam geometry parameters and MLC parameters remain editable in the Beam Module. This can lead to user confusion, as these values are not currently used by inverse planning dose engines (e.g. _pyRadPlan_ dose engine).


### Solution:

- Added an `InverseFlag `to `vtkMRMLRTPlanNode` to track whether inverse planning is active.
- Updated `qMRMLBeamParametersTabWidget::updateWidgetFromMRML() ` to enable/disable beam geometry and MLC widgets based on the current plan’s inverse flag.
- Ensured that widgets are always explicitly enabled/disabled depending on the inverse flag, preventing stale UI state when switching plans.


### Behavior Changes:

- Beam geometry and MLC widgets are now grayed out when using inverse plans.
- Switching between inverse and non-inverse plans correctly restores the enabled state.


### Remaining Questions:
- Currently explicitly enabling/disabling SAD, jaws, collimator angle and MLC tab. Are there other parameters to include here?
- Should the available parameters be dependent on the selected dose engine?

### See issue:
[issue 306](https://github.com/SlicerRt/SlicerRT/issues/306)