### PR TITLE
ENH: Add "Move patient with table top" mode to RoomsEyeView

### DIFF
--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.cxx
@@ -74,7 +74,7 @@ void vtkSlicerBeamsModuleLogic::PrintSelf(ostream& os, vtkIndent indent)
 //-----------------------------------------------------------------------------
 void vtkSlicerBeamsModuleLogic::RegisterNodes()
 {
-  vtkMRMLScene* scene = this->GetMRMLScene(); 
+  vtkMRMLScene* scene = this->GetMRMLScene();
   if (!scene)
   {
     vtkErrorMacro("RegisterNodes: Invalid MRML scene");
@@ -158,7 +158,7 @@ void vtkSlicerBeamsModuleLogic::OnMRMLSceneEndImport()
     //   reason for this is possibly that the pipeline is set up with the file reader and on any modified
     //   event that pipeline is used instead of simply using the changed contents of the beam polydata.
     beamNode->SetAndObserveMesh(beamNode->GetMesh());
-    
+
     // Observe beam events
     vtkSmartPointer<vtkIntArray> events = vtkSmartPointer<vtkIntArray>::New();
     events->InsertNextValue(vtkMRMLRTBeamNode::BeamGeometryModified);
@@ -267,7 +267,7 @@ void vtkSlicerBeamsModuleLogic::ProcessMRMLNodesEvents(vtkObject* caller, unsign
       // Iterate through all beam nodes
       std::vector<vtkMRMLNode*> beamNodes;
       mrmlScene->GetNodesByClass("vtkMRMLRTBeamNode", beamNodes);
-      for (std::vector<vtkMRMLNode*>::iterator beamIterator = beamNodes.begin(); 
+      for (std::vector<vtkMRMLNode*>::iterator beamIterator = beamNodes.begin();
         beamIterator != beamNodes.end(); ++beamIterator)
       {
         // if caller node and referenced table node is the same
@@ -314,7 +314,7 @@ void vtkSlicerBeamsModuleLogic::UpdateTransformForBeam(vtkMRMLRTBeamNode* beamNo
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerBeamsModuleLogic::UpdateTransformForBeam(vtkMRMLScene* beamSequenceScene, 
+void vtkSlicerBeamsModuleLogic::UpdateTransformForBeam(vtkMRMLScene* beamSequenceScene,
   vtkMRMLRTBeamNode* beamNode, vtkMRMLLinearTransformNode* beamTransformNode, double* isocenter)
 {
   if (!beamNode)
@@ -426,16 +426,17 @@ void vtkSlicerBeamsModuleLogic::UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* b
 
   // Update fixed reference to RAS transform as well
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();
-  this->UpdateRASRelatedTransforms(nullptr, parentPlanNode, isocenter, true);
+  this->UpdateFixedReferenceToRASTransformForBeam(parentPlanNode, isocenter);
 }
 
 //-----------------------------------------------------------------------------
-void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(
-  vtkIECTransformLogic* iecLogic/*=nullptr*/, vtkMRMLRTPlanNode* planNode/*=nullptr*/, double* isocenter/*=nullptr*/, bool transformForBeam/*=false*/)
+void vtkSlicerBeamsModuleLogic::UpdateFixedReferenceToRASTransform(
+  vtkIECTransformLogic* iecLogic/*=nullptr*/, vtkMRMLRTPlanNode* planNode/*=nullptr*/,
+  vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode/*=nullptr*/)
 {
   if (!this->GetMRMLScene())
   {
-    vtkErrorMacro("UpdateRASRelatedTransforms: Invalid MRML scene");
+    vtkErrorMacro("UpdateFixedReferenceToRASTransform: Invalid MRML scene");
     return;
   }
   if (iecLogic == nullptr)
@@ -443,45 +444,87 @@ void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(
     iecLogic = this->IECLogic;
   }
 
-  // Update IEC FixedReference to RAS transform based on the isocenter defined in the beam's parent plan.
-  // Do the same for the RAS to Patient transform as well.
+  double isocenterPosition[3] = {0.0, 0.0, 0.0};
+  if (planNode)
+  {
+    if (!planNode->GetIsocenterPosition(isocenterPosition))
+    {
+      vtkErrorMacro("UpdateFixedReferenceToRASTransform: Failed to get isocenter position for plan " << planNode->GetName());
+    }
+  }
+
+  double tableCenterPosition[3] = {0.0, 0.0, 0.0};
+  if (tableCenterFiducialNode != nullptr &&
+      tableCenterFiducialNode->GetNumberOfControlPoints() > 0 &&
+      tableCenterFiducialNode->GetNthControlPointPositionStatus(0) == vtkMRMLMarkupsNode::PositionDefined)
+  {
+    tableCenterFiducialNode->GetNthControlPointPositionWorld(0, tableCenterPosition);
+  }
+
+  this->UpdateFixedReferenceToRASTransformInternal(iecLogic, isocenterPosition, tableCenterPosition, false);
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerBeamsModuleLogic::UpdateFixedReferenceToRASTransformForBeam(
+  vtkMRMLRTPlanNode* planNode, double* isocenterPosition/*=nullptr*/)
+{
+  if (!this->GetMRMLScene())
+  {
+    vtkErrorMacro("UpdateFixedReferenceToRASTransformForBeam: Invalid MRML scene");
+    return;
+  }
+
+  double isocenter[3] = {0.0, 0.0, 0.0};
+  if (isocenterPosition)
+  {
+    // Use provided isocenter position (for dynamic beams)
+    std::copy(isocenterPosition, isocenterPosition + 3, isocenter);
+  }
+  else if (planNode)
+  {
+    // Get isocenter from plan (for static beams)
+    if (!planNode->GetIsocenterPosition(isocenter))
+    {
+      vtkErrorMacro("UpdateFixedReferenceToRASTransformForBeam: Failed to get isocenter position for plan " << planNode->GetName());
+    }
+  }
+
+  double tableCenterPosition[3] = {0.0, 0.0, 0.0};
+  this->UpdateFixedReferenceToRASTransformInternal(this->IECLogic, isocenter, tableCenterPosition, true);
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerBeamsModuleLogic::UpdateFixedReferenceToRASTransformInternal(
+  vtkIECTransformLogic* iecLogic, double isocenterPosition[3], double tableCenterPosition[3],
+  bool useDynamicTransforms)
+{
+  // Update IEC FixedReference to RAS transform based on the isocenter and table center.
+  // Also updates RAS to Patient transform.
   vtkNew<vtkTransform> fixedReferenceToRASTransformBeamComponent;
   vtkTransform* rasToPatientReferenceTransform = iecLogic->GetElementaryTransformBetween(
     vtkIECTransformLogic::RAS, vtkIECTransformLogic::Patient);
   if (rasToPatientReferenceTransform == nullptr)
   {
-    vtkErrorMacro("UpdateRASRelatedTransforms: Failed to find RAS related transforms in the IEC logic");
+    vtkErrorMacro("UpdateFixedReferenceToRASTransformInternal: Failed to find RAS related transforms in the IEC logic");
     return;
   }
 
-  // Reset transforms before applying translation and rotations
+  // Reset transforms before applying translations and rotations
   fixedReferenceToRASTransformBeamComponent->Identity();
   rasToPatientReferenceTransform->Identity();
 
-  // Apply isocenter translation if requested for both transforms
-  if (planNode)
+  // Apply table center translation if provided
+  if (tableCenterPosition[0] != 0.0 || tableCenterPosition[1] != 0.0 || tableCenterPosition[2] != 0.0)
   {
-    if (isocenter)
-    {
-      // Once again the dirty hack for dynamic beams, the actual translation 
-      // will be in vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequence method
-      fixedReferenceToRASTransformBeamComponent->Translate(isocenter[0], isocenter[1], isocenter[2]); //TODO: This was always 0 before, confirm this change (to use isocenter if given as argument)
-      rasToPatientReferenceTransform->Translate(isocenter[0], isocenter[1], isocenter[2]);
-    }
-    else
-    {
-      // translation for a static beam
-      std::array<double, 3> isocenterPosition = { 0.0, 0.0, 0.0 };
-      if (planNode->GetIsocenterPosition(isocenterPosition.data()))
-      {
-        fixedReferenceToRASTransformBeamComponent->Translate(isocenterPosition[0], isocenterPosition[1], isocenterPosition[2]);
-        rasToPatientReferenceTransform->Translate(isocenterPosition[0], isocenterPosition[1], isocenterPosition[2]);
-      }
-      else
-      {
-        vtkErrorMacro("UpdateRASRelatedTransforms: Failed to get isocenter position for plan " << planNode->GetName());
-      }
-    }
+    fixedReferenceToRASTransformBeamComponent->Translate(tableCenterPosition);
+    rasToPatientReferenceTransform->Translate(tableCenterPosition);
+  }
+
+  // Apply isocenter translation
+  if (isocenterPosition[0] != 0.0 || isocenterPosition[1] != 0.0 || isocenterPosition[2] != 0.0)
+  {
+    fixedReferenceToRASTransformBeamComponent->Translate(isocenterPosition);
+    rasToPatientReferenceTransform->Translate(isocenterPosition);
   }
 
   // Set up RAS to Patient transform
@@ -502,21 +545,23 @@ void vtkSlicerBeamsModuleLogic::UpdateRASRelatedTransforms(
   // Set up concatenation for final fixed reference to RAS transform
   vtkNew<vtkGeneralTransform> tableTopToTableTopEccentricRotationGeneralTransform;
   iecLogic->GetTransformBetween(
-    vtkIECTransformLogic::TableTop, vtkIECTransformLogic::TableTopEccentricRotation, tableTopToTableTopEccentricRotationGeneralTransform, transformForBeam);
+    vtkIECTransformLogic::TableTop, vtkIECTransformLogic::TableTopEccentricRotation,
+    tableTopToTableTopEccentricRotationGeneralTransform, useDynamicTransforms);
   vtkNew<vtkTransform> tableTopToTableTopEccentricRotationLinearTransform;
   if (!vtkMRMLTransformNode::IsGeneralTransformLinear(tableTopToTableTopEccentricRotationGeneralTransform, tableTopToTableTopEccentricRotationLinearTransform))
   {
-    vtkErrorMacro("UpdateRASRelatedTransforms: IEC transform TableTop to TableTopEccentricRotation contains non-linear components");
+    vtkErrorMacro("UpdateFixedReferenceToRASTransformInternal: IEC transform TableTop to TableTopEccentricRotation contains non-linear components");
     return;
   }
 
   vtkNew<vtkGeneralTransform> patientSupportRotationToFixedReferenceGeneralTransform;
   iecLogic->GetTransformBetween(
-    vtkIECTransformLogic::PatientSupportRotation, vtkIECTransformLogic::FixedReference, patientSupportRotationToFixedReferenceGeneralTransform, transformForBeam);
+    vtkIECTransformLogic::PatientSupportRotation, vtkIECTransformLogic::FixedReference,
+    patientSupportRotationToFixedReferenceGeneralTransform, useDynamicTransforms);
   vtkNew<vtkTransform> patientSupportRotationToFixedReferenceLinearTransform;
   if (!vtkMRMLTransformNode::IsGeneralTransformLinear(patientSupportRotationToFixedReferenceGeneralTransform, patientSupportRotationToFixedReferenceLinearTransform))
   {
-    vtkErrorMacro("UpdateRASRelatedTransforms: IEC transform PatientSupportRotation to FixedReference contains non-linear components");
+    vtkErrorMacro("UpdateFixedReferenceToRASTransformInternal: IEC transform PatientSupportRotation to FixedReference contains non-linear components");
     return;
   }
 

--- a/Beams/Logic/vtkSlicerBeamsModuleLogic.h
+++ b/Beams/Logic/vtkSlicerBeamsModuleLogic.h
@@ -27,20 +27,21 @@
 #ifndef __vtkSlicerBeamsModuleLogic_h
 #define __vtkSlicerBeamsModuleLogic_h
 
+// Beams includes
+#include "vtkSlicerBeamsModuleLogicExport.h"
+#include "vtkMRMLRTBeamNode.h"
+
 // Slicer includes
 #include "vtkSlicerModuleLogic.h"
 
 // IEC Logic include
 #include <vtkIECTransformLogic.h>
 
-// Beams includes
-#include "vtkSlicerBeamsModuleLogicExport.h"
-#include "vtkMRMLRTBeamNode.h"
-
 // VTK includes
 #include <vtkNew.h>
 
 class vtkSlicerMLCPositionLogic;
+class vtkMRMLMarkupsFiducialNode;
 
 /// \ingroup SlicerRt_QtModules_Beams
 class VTK_SLICER_BEAMS_LOGIC_EXPORT vtkSlicerBeamsModuleLogic : public vtkSlicerModuleLogic
@@ -60,7 +61,7 @@ public:
   /// @param beamTransformNode - parent transform of the beam according to the beam parameters and isocenter
   /// @param isocenter - isocenter position
   /// \warning This method is used only in vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequence
-  void UpdateTransformForBeam(vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode, 
+  void UpdateTransformForBeam(vtkMRMLScene* beamSequenceScene, vtkMRMLRTBeamNode* beamNode,
     vtkMRMLLinearTransformNode* beamTransformNode, double isocenter[3]);
 
 public:
@@ -74,12 +75,21 @@ public:
   void UpdateIECTransformsFromBeam(vtkMRMLRTBeamNode* beamNode, double* isocenter=nullptr);
 
 public:
-  /// Update FixedReference to RAS and RAS to Patient transforms based on isocenter and patient support transforms.
-  /// \param iecLogic: IEC logic to use for the update. Useful if the Room's Eye View module wants to use this function with its own configuration.
+  /// Update FixedReference to RAS and RAS to Patient transforms.
+  /// Gets isocenter from plan node and table center from fiducial if available.
+  /// \param iecLogic: IEC logic to use (nullptr to use this->IECLogic). Useful for Room's Eye View module.
+  /// \param planNode: Plan node to get the isocenter position from (optional)
+  /// \param tableCenterFiducialNode: Table center point fiducial for positioning (optional)
+  void UpdateFixedReferenceToRASTransform(
+    vtkIECTransformLogic* iecLogic = nullptr,
+    vtkMRMLRTPlanNode* planNode = nullptr,
+    vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode = nullptr);
+
+  /// Update FixedReference to RAS transform for beam with dynamic transforms.
+  /// Automatically uses beam's parent plan and explicit isocenter position if provided.
   /// \param planNode: Plan node to get the isocenter position from
-  /// \param isocenter: Option to set any isocenter for dynamic beams
-  /// \param transformForBeam: calculate dynamic transformation for beam model or other models. False by default.
-  void UpdateRASRelatedTransforms(vtkIECTransformLogic* iecLogic=nullptr, vtkMRMLRTPlanNode* planNode=nullptr, double* isocenter=nullptr, bool transformForBeam=false);
+  /// \param isocenterPosition: Explicit isocenter coordinates (for dynamic beams), uses plan if nullptr
+  void UpdateFixedReferenceToRASTransformForBeam(vtkMRMLRTPlanNode* planNode, double* isocenterPosition = nullptr);
 
 public:
   vtkGetObjectMacro(MLCPositionLogic, vtkSlicerMLCPositionLogic);
@@ -106,10 +116,20 @@ protected:
 private:
   vtkSlicerBeamsModuleLogic(const vtkSlicerBeamsModuleLogic&) = delete;
   void operator=(const vtkSlicerBeamsModuleLogic&) = delete;
-  
-  vtkSlicerMLCPositionLogic* MLCPositionLogic;
+
+  /// Internal implementation for updating FixedReference to RAS transform
+  /// \param iecLogic: IEC logic to use for the update
+  /// \param isocenterPosition: Isocenter position in RAS coordinates
+  /// \param tableCenterPosition: Table center position in RAS coordinates
+  /// \param useDynamicTransforms: Use dynamic transforms for beam models
+  void UpdateFixedReferenceToRASTransformInternal(
+    vtkIECTransformLogic* iecLogic,
+    double isocenterPosition[3],
+    double tableCenterPosition[3],
+    bool useDynamicTransforms);
 
 private:
+  vtkSlicerMLCPositionLogic* MLCPositionLogic;
   vtkIECTransformLogic* IECLogic;
 };
 

--- a/Beams/Widgets/qMRMLBeamsTableView.cxx
+++ b/Beams/Widgets/qMRMLBeamsTableView.cxx
@@ -510,6 +510,11 @@ void qMRMLBeamsTableView::onBeamModified(vtkObject* caller, void* callData)
   {
     QString beamNodeID = d->BeamsTable->item(row, d->columnIndex("Number"))->data(IDRole).toString();
     vtkMRMLRTBeamNode* currentBeamNode = vtkMRMLRTBeamNode::SafeDownCast(beamNode->GetScene()->GetNodeByID(beamNodeID.toLatin1().constData()));
+    // If we could not get the beam node, then it means that the beam was removed from the scene, so we do not need to update the table
+    if (currentBeamNode == nullptr)
+    {
+      continue;
+    }
     if (beamNumber == currentBeamNode->GetBeamNumber())
     {
       foundRow = row;

--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
@@ -58,7 +58,7 @@ public:
     CalculateDoseUsingEngineMethod,
     CalculateDoseInfluenceMatrixUsingEngineMethod,
     UpdateBeamParametersForIonPlan
-    };
+  };
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
@@ -107,14 +107,14 @@ bool qSlicerScriptedDoseEngine::setPythonSource(const QString newPythonSource)
   Q_D(qSlicerScriptedDoseEngine);
 
   if (!Py_IsInitialized())
-    {
+  {
     return false;
-    }
+  }
 
   if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
-    {
+  {
     return false;
-    }
+  }
 
   // Extract moduleName from the provided filename
   QString moduleName = QFileInfo(newPythonSource).baseName();
@@ -122,9 +122,9 @@ bool qSlicerScriptedDoseEngine::setPythonSource(const QString newPythonSource)
   // In case the engine is within the main module file
   QString className = moduleName;
   if (!moduleName.endsWith("Engine"))
-    {
+  {
     className.append("Engine");
-    }
+  }
 
   // Get a reference to the main module and global dictionary
   PyObject * main_module = PyImport_AddModule("__main__");
@@ -139,25 +139,25 @@ bool qSlicerScriptedDoseEngine::setPythonSource(const QString newPythonSource)
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
   if (PyObject_HasAttrString(module, className.toUtf8()))
-    {
+  {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
-    }
+  }
   if (!classToInstantiate)
-    {
+  {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
     if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
-      {
+    {
       return false;
-      }
-    if (PyObject_HasAttrString(module, className.toUtf8()))
-      {
-      classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
-      }
     }
+    if (PyObject_HasAttrString(module, className.toUtf8()))
+    {
+      classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
+    }
+  }
 
   if (!classToInstantiate)
-    {
+  {
     PythonQt::self()->handleError();
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedDoseEngine::setPythonSource - "
@@ -165,23 +165,22 @@ bool qSlicerScriptedDoseEngine::setPythonSource(const QString newPythonSource)
                             "class %1 was not found in %2").arg(className).arg(newPythonSource).toUtf8());
     PythonQt::self()->handleError();
     return false;
-    }
+  }
 
   d->PythonCppAPI.setObjectName(className);
 
   PyObject* self = d->PythonCppAPI.instantiateClass(this, className, classToInstantiate);
   if (!self)
-    {
+  {
     return false;
-    }
+  }
 
   d->PythonSource = newPythonSource;
 
-  if (!qSlicerScriptedUtils::setModuleAttribute(
-        "slicer", className, self))
-    {
+  if (!qSlicerScriptedUtils::setModuleAttribute("slicer", className, self))
+  {
     qCritical() << "Failed to set" << ("slicer." + className);
-    }
+  }
 
   return true;
 }
@@ -229,10 +228,10 @@ QString qSlicerScriptedDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* b
 
   // Parse result
   if (!PyUnicode_Check(result))
-    {
+  {
     qWarning() << d->PythonSource << ": qSlicerScriptedDoseEngine: Function 'calculateDoseUsingEngine' is expected to return a string!";
     return QString();
-    }
+  }
 
   return PyUnicode_AsUTF8(result);
 }

--- a/RoomsEyeView/CMakeLists.txt
+++ b/RoomsEyeView/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MODULE_INCLUDE_DIRECTORIES
   ${qSlicerSubjectHierarchyModuleWidgets_INCLUDE_DIRS}
   ${vtkSlicerBeamsModuleMRML_INCLUDE_DIRS}
   ${qSlicerBeamsModuleWidgets_INCLUDE_DIRS}
+  ${qSlicerMarkupsModuleWidgets_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
@@ -51,6 +52,7 @@ set(MODULE_TARGET_LIBRARIES
   vtkSlicerBeamsModuleMRML
   vtkSlicerBeamsModuleLogic
   qSlicerBeamsModuleWidgets
+  qSlicerMarkupsModuleWidgets
   )
 
 set(MODULE_RESOURCES

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
@@ -65,7 +65,7 @@ static const char* TABLETOPECCENTRICROTATION_TO_PATIENTSUPPORT_TRANSFORM_NODE_RE
 
 static const char* BEAM_REFERENCE_ROLE = "beamRef";
 static const char* PATIENT_BODY_SEGMENTATION_REFERENCE_ROLE = "patientBodySegmentationRef";
-static const char* TABLE_CENTER_POINT_REFERENCE_ROLE = "tableCenterPointRef";
+static const char* TABLE_TOP_CENTER_POINT_REFERENCE_ROLE = "tableTopCenterPointRef";
 
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLRoomsEyeViewNode);
@@ -82,6 +82,12 @@ vtkMRMLRoomsEyeViewNode::vtkMRMLRoomsEyeViewNode()
   , VerticalTableTopDisplacement(0.0)
   , LongitudinalTableTopDisplacement(0.0)
   , LateralTableTopDisplacement(0.0)
+  , LateralTableTopDisplacementMin(-250.0)
+  , LateralTableTopDisplacementMax(250.0)
+  , LongitudinalTableTopDisplacementMin(0.0)
+  , LongitudinalTableTopDisplacementMax(1000.0)
+  , VerticalTableTopDisplacementMin(-500.0)
+  , VerticalTableTopDisplacementMax(299.0)
 {
   this->SetSingletonTag("IEC");
 }
@@ -521,22 +527,22 @@ void vtkMRMLRoomsEyeViewNode::SetAndObserveTableTopEccentricRotationToPatientSup
   this->SetNodeReferenceID(TABLETOPECCENTRICROTATION_TO_PATIENTSUPPORT_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
 
+
 //----------------------------------------------------------------------------
-vtkMRMLMarkupsFiducialNode* vtkMRMLRoomsEyeViewNode::GetTableCenterPointFiducialNode()
+vtkMRMLMarkupsFiducialNode* vtkMRMLRoomsEyeViewNode::GetTableTopCenterPointFiducialNode()
 {
-  return vtkMRMLMarkupsFiducialNode::SafeDownCast(this->GetNodeReference(TABLE_CENTER_POINT_REFERENCE_ROLE));
+  return vtkMRMLMarkupsFiducialNode::SafeDownCast(this->GetNodeReference(TABLE_TOP_CENTER_POINT_REFERENCE_ROLE));
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLRoomsEyeViewNode::SetAndObserveTableCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node)
+void vtkMRMLRoomsEyeViewNode::SetAndObserveTableTopCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node)
 {
   if (node && this->Scene != node->GetScene())
   {
     vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
     return;
   }
-
-  this->SetNodeReferenceID(TABLE_CENTER_POINT_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
+  this->SetNodeReferenceID(TABLE_TOP_CENTER_POINT_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
 
 //----------------------------------------------------------------------------

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.cxx
@@ -27,6 +27,7 @@
 // MRML includes
 #include <vtkMRMLScene.h>
 #include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLSegmentationNode.h>
 
 // VTK includes
@@ -64,6 +65,7 @@ static const char* TABLETOPECCENTRICROTATION_TO_PATIENTSUPPORT_TRANSFORM_NODE_RE
 
 static const char* BEAM_REFERENCE_ROLE = "beamRef";
 static const char* PATIENT_BODY_SEGMENTATION_REFERENCE_ROLE = "patientBodySegmentationRef";
+static const char* TABLE_CENTER_POINT_REFERENCE_ROLE = "tableCenterPointRef";
 
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLRoomsEyeViewNode);
@@ -108,7 +110,7 @@ void vtkMRMLRoomsEyeViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(LateralTableTopDisplacement, LateralTableTopDisplacement);
   vtkMRMLWriteXMLStringMacro(PatientBodySegmentID, PatientBodySegmentID);
   vtkMRMLWriteXMLStringMacro(TreatmentMachineDescriptorFilePath, TreatmentMachineDescriptorFilePath);
-  vtkMRMLWriteXMLEndMacro(); 
+  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -128,7 +130,7 @@ void vtkMRMLRoomsEyeViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(LateralTableTopDisplacement, LateralTableTopDisplacement);
   vtkMRMLReadXMLStringMacro(PatientBodySegmentID, PatientBodySegmentID);
   vtkMRMLReadXMLStringMacro(TreatmentMachineDescriptorFilePath, TreatmentMachineDescriptorFilePath);
-  vtkMRMLReadXMLEndMacro(); 
+  vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
 
@@ -155,7 +157,7 @@ void vtkMRMLRoomsEyeViewNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyFloatMacro(LateralTableTopDisplacement);
   vtkMRMLCopyStringMacro(PatientBodySegmentID);
   vtkMRMLCopyStringMacro(TreatmentMachineDescriptorFilePath);
-  vtkMRMLCopyEndMacro(); 
+  vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
 }
@@ -176,7 +178,7 @@ void vtkMRMLRoomsEyeViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(LateralTableTopDisplacement);
   vtkMRMLPrintStringMacro(PatientBodySegmentID);
   vtkMRMLPrintStringMacro(TreatmentMachineDescriptorFilePath);
-  vtkMRMLPrintEndMacro(); 
+  vtkMRMLPrintEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -517,6 +519,24 @@ void vtkMRMLRoomsEyeViewNode::SetAndObserveTableTopEccentricRotationToPatientSup
   }
 
   this->SetNodeReferenceID(TABLETOPECCENTRICROTATION_TO_PATIENTSUPPORT_TRANSFORM_NODE_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsFiducialNode* vtkMRMLRoomsEyeViewNode::GetTableCenterPointFiducialNode()
+{
+  return vtkMRMLMarkupsFiducialNode::SafeDownCast(this->GetNodeReference(TABLE_CENTER_POINT_REFERENCE_ROLE));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRoomsEyeViewNode::SetAndObserveTableCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node)
+{
+  if (node && this->Scene != node->GetScene())
+  {
+    vtkErrorMacro("Cannot set reference: the referenced and referencing node are not in the same scene");
+    return;
+  }
+
+  this->SetNodeReferenceID(TABLE_CENTER_POINT_REFERENCE_ROLE, (node ? node->GetID() : nullptr));
 }
 
 //----------------------------------------------------------------------------

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
@@ -28,6 +28,7 @@
 #include "vtkSlicerRoomsEyeViewModuleLogicExport.h"
 
 class vtkMRMLLinearTransformNode;
+class vtkMRMLMarkupsFiducialNode;
 class vtkMRMLSegmentationNode;
 class vtkMRMLRTBeamNode;
 
@@ -39,19 +40,19 @@ public:
   vtkTypeMacro(vtkMRMLRoomsEyeViewNode,vtkMRMLNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// Create instance of a GAD node. 
+  /// Create instance of a GAD node.
   vtkMRMLNode* CreateNodeInstance() override;
 
-  /// Set node attributes from name/value pairs 
+  /// Set node attributes from name/value pairs
   void ReadXMLAttributes( const char** atts) override;
 
-  /// Write this node's information to a MRML file in XML format. 
+  /// Write this node's information to a MRML file in XML format.
   void WriteXML(ostream& of, int indent) override;
 
-  /// Copy the node's attributes to this object 
+  /// Copy the node's attributes to this object
   void Copy(vtkMRMLNode *node) override;
 
-  /// Get unique node XML tag name (like Volume, Model) 
+  /// Get unique node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "RoomsEyeView"; };
 
 public:
@@ -73,7 +74,7 @@ public:
   vtkMRMLLinearTransformNode* GetLeftImagingPanelToLeftImagingPanelFixedReferenceIsocenterTransformNode();
   void SetAndObserveLeftImagingPanelToLeftImagingPanelFixedReferenceIsocenterTransformNode(vtkMRMLLinearTransformNode* node);
 
-  vtkMRMLLinearTransformNode* GetLeftImagingPanelFixedReferenceIsocenterToLeftImagingPanelRotatedTransformNode(); 
+  vtkMRMLLinearTransformNode* GetLeftImagingPanelFixedReferenceIsocenterToLeftImagingPanelRotatedTransformNode();
   void SetAndObserveLeftImagingPanelFixedReferenceIsocenterToLeftImagingPanelRotatedTransformNode(vtkMRMLLinearTransformNode* node);
 
   vtkMRMLLinearTransformNode* GetLeftImagingPanelRotatedToGantryTransformNode();
@@ -105,13 +106,16 @@ public:
 
   vtkMRMLLinearTransformNode* GetTableTopToTableTopEccentricRotationTransformNode();
   void SetAndObservePatientSupportScaledTranslatedToTableTopVerticalTranslationTransformNode(vtkMRMLLinearTransformNode* node);
-  
+
   vtkMRMLLinearTransformNode* GetTableTopEccentricRotationToPatientSupportTransformNode();
   void SetAndObserveTableTopToTableTopEccentricRotationTransformNode(vtkMRMLLinearTransformNode* node);
 
   vtkMRMLLinearTransformNode* GetPatientSupportScaledTranslatedToTableTopVerticalTranslationTransformNode();
   void SetAndObserveTableTopEccentricRotationToPatientSupportTransformNode(vtkMRMLLinearTransformNode* node);
- 
+
+  vtkMRMLMarkupsFiducialNode* GetTableCenterPointFiducialNode();
+  void SetAndObserveTableCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node);
+
   /// Get beam node
   vtkMRMLRTBeamNode* GetBeamNode();
   /// Set and observe beam node
@@ -170,16 +174,28 @@ protected:
   /// Path to the treatment machine descriptor JSON file
   char* TreatmentMachineDescriptorFilePath;
 
+  /// Enable/disable collision detection
   bool CollisionDetectionEnabled;
 
-  /// TODO:
+  /// Gantry rotation angle in degrees
   double GantryRotationAngle;
+  /// Collimator rotation angle in degrees
   double CollimatorRotationAngle;
-  double ImagingPanelMovement;
+  /// Patient support rotation angle in degrees
   double PatientSupportRotationAngle;
+  /// Table top vertical displacement in mm
+
   double VerticalTableTopDisplacement;
+  /// Table top longitudinal displacement in mm
   double LongitudinalTableTopDisplacement;
+  /// Table top lateral displacement in mm
   double LateralTableTopDisplacement;
+
+  /// Imaging panel movement
+  /// (custom range currently only supporting Varian TrueBeam: -68.5 to 0 rotation, then 0 to 500 translation outwards)
+  double ImagingPanelMovement;
+
+  /// Additional model displacement parameters //TODO: Currently not used
   double AdditionalModelVerticalDisplacement;
   double AdditionalModelLongitudinalDisplacement;
   double AdditionalModelLateralDisplacement;

--- a/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
+++ b/RoomsEyeView/Logic/vtkMRMLRoomsEyeViewNode.h
@@ -113,8 +113,8 @@ public:
   vtkMRMLLinearTransformNode* GetPatientSupportScaledTranslatedToTableTopVerticalTranslationTransformNode();
   void SetAndObserveTableTopEccentricRotationToPatientSupportTransformNode(vtkMRMLLinearTransformNode* node);
 
-  vtkMRMLMarkupsFiducialNode* GetTableCenterPointFiducialNode();
-  void SetAndObserveTableCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node);
+  vtkMRMLMarkupsFiducialNode* GetTableTopCenterPointFiducialNode();
+  void SetAndObserveTableTopCenterPointFiducialNode(vtkMRMLMarkupsFiducialNode* node);
 
   /// Get beam node
   vtkMRMLRTBeamNode* GetBeamNode();
@@ -161,6 +161,21 @@ public:
   vtkGetMacro(LateralTableTopDisplacement, double);
   vtkSetMacro(LateralTableTopDisplacement, double);
 
+  vtkGetMacro(LateralTableTopDisplacementMin, double);
+  vtkSetMacro(LateralTableTopDisplacementMin, double);
+  vtkGetMacro(LateralTableTopDisplacementMax, double);
+  vtkSetMacro(LateralTableTopDisplacementMax, double);
+
+  vtkGetMacro(LongitudinalTableTopDisplacementMin, double);
+  vtkSetMacro(LongitudinalTableTopDisplacementMin, double);
+  vtkGetMacro(LongitudinalTableTopDisplacementMax, double);
+  vtkSetMacro(LongitudinalTableTopDisplacementMax, double);
+
+  vtkGetMacro(VerticalTableTopDisplacementMin, double);
+  vtkSetMacro(VerticalTableTopDisplacementMin, double);
+  vtkGetMacro(VerticalTableTopDisplacementMax, double);
+  vtkSetMacro(VerticalTableTopDisplacementMax, double);
+
 protected:
   vtkMRMLRoomsEyeViewNode();
   ~vtkMRMLRoomsEyeViewNode();
@@ -183,13 +198,16 @@ protected:
   double CollimatorRotationAngle;
   /// Patient support rotation angle in degrees
   double PatientSupportRotationAngle;
-  /// Table top vertical displacement in mm
-
   double VerticalTableTopDisplacement;
-  /// Table top longitudinal displacement in mm
   double LongitudinalTableTopDisplacement;
-  /// Table top lateral displacement in mm
   double LateralTableTopDisplacement;
+
+  double LateralTableTopDisplacementMin;
+  double LateralTableTopDisplacementMax;
+  double LongitudinalTableTopDisplacementMin;
+  double LongitudinalTableTopDisplacementMax;
+  double VerticalTableTopDisplacementMin;
+  double VerticalTableTopDisplacementMax;
 
   /// Imaging panel movement
   /// (custom range currently only supporting Varian TrueBeam: -68.5 to 0 rotation, then 0 to 500 translation outwards)

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -28,6 +28,7 @@
 
 // SlicerRT includes
 #include "vtkMRMLRTBeamNode.h"
+#include "vtkMRMLRTPlanNode.h"
 #include "vtkSlicerBeamsModuleLogic.h"
 
 // MRML includes
@@ -56,6 +57,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkPolyDataReader.h>
 #include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
 #include <vtkTransform.h>
 #include <vtkTransformFilter.h>
 #include <vtkTransformPolyDataFilter.h>
@@ -100,10 +102,19 @@ public:
   std::string GetTreatmentMachinePartModelName(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType);
   vtkMRMLModelNode* GetTreatmentMachinePartModelNode(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType);
   vtkMRMLModelNode* EnsureTreatmentMachinePartModelNode(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType, bool optional=false);
-  vtkMRMLMarkupsFiducialNode* EnsureTableCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode);
+  vtkMRMLMarkupsFiducialNode* EnsureTableTopCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode);
 
-  /// Keep track of observers on the table center point fiducial node
-  std::vector<unsigned long> TableCenterPointFiducialNodeObserverTags;
+  /// Keep track of the currently observed POI markups node, its plan, param node, and observer tags
+  vtkMRMLMarkupsFiducialNode* ObservedPOIMarkupsFiducialNode{nullptr};
+  vtkMRMLRTPlanNode* ObservedPlanNode{nullptr};
+  vtkMRMLRoomsEyeViewNode* ObservedParamNode{nullptr};
+  std::vector<unsigned long> POIMarkupsFiducialNodeObserverTags;
+
+  /// Keep track of the currently observed TableTopCenter fiducial node and its observer tags.
+  /// Using vtkWeakPointer so the pointer auto-nulls if the node is deleted (e.g. scene clear).
+  vtkWeakPointer<vtkMRMLMarkupsFiducialNode> ObservedTableTopCenterFiducialNode;
+  vtkWeakPointer<vtkMRMLRoomsEyeViewNode> ObservedTableTopCenterParamNode;
+  std::vector<unsigned long> TableTopCenterFiducialNodeObserverTags;
 };
 
 //---------------------------------------------------------------------------
@@ -333,42 +344,39 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTreatment
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLMarkupsFiducialNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTableCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode)
+vtkMRMLMarkupsFiducialNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTableTopCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode)
 {
   vtkMRMLScene* scene = this->External->GetMRMLScene();
   if (!scene || !parameterNode)
   {
-    vtkErrorWithObjectMacro(this->External, "EnsureTableCenterPointFiducialNode: Invalid scene or parameter node");
+    vtkErrorWithObjectMacro(this->External, "EnsureTableTopCenterPointFiducialNode: Invalid scene or parameter node");
     return nullptr;
   }
-  if (parameterNode->GetTableCenterPointFiducialNode())
+  if (parameterNode->GetTableTopCenterPointFiducialNode())
   {
-    return parameterNode->GetTableCenterPointFiducialNode();
+    return parameterNode->GetTableTopCenterPointFiducialNode();
   }
   vtkMRMLSubjectHierarchyNode* shNode = scene->GetSubjectHierarchyNode();
   if (!shNode)
   {
-    vtkErrorWithObjectMacro(this->External, "EnsureTableCenterPointFiducialNode: Failed to access subject hierarchy node");
+    vtkErrorWithObjectMacro(this->External, "EnsureTableTopCenterPointFiducialNode: Failed to access subject hierarchy node");
     return nullptr;
   }
 
-  vtkMRMLMarkupsFiducialNode* fiducialNode = parameterNode->GetTableCenterPointFiducialNode();
-  if (!fiducialNode)
+  vtkMRMLMarkupsFiducialNode* fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(
+    scene->AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "TableTopCenter"));
+  fiducialNode->SetDisplayVisibility(false);
+  parameterNode->SetAndObserveTableTopCenterPointFiducialNode(fiducialNode);
+  // Only parent to the machine components folder if a machine has been loaded
+  if (parameterNode->GetTreatmentMachineDescriptorFilePath())
   {
-    fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "TableCenterPoint"));
-    fiducialNode->SetDisplayVisibility(false); // Hide fiducial by default
-    parameterNode->SetAndObserveTableCenterPointFiducialNode(fiducialNode);
-    // Set reference so that we can get the parameter node from the fiducial node later
-    fiducialNode->SetNodeReferenceID("parameterNodeRef", parameterNode->GetID());
-    // Add node to the SH under the treatment machine components folder
     vtkIdType rootFolderItem = this->EnsureMachineComponentsSubjectHierarchyFolder(parameterNode);
     vtkIdType fiducialItemID = shNode->GetItemByDataNode(fiducialNode);
     shNode->SetItemParent(fiducialItemID, rootFolderItem);
-    // Set up observer to handle changes
-    this->External->UpdateTableCenterPointObservers(parameterNode);
   }
   return fiducialNode;
 }
+
 
 //---------------------------------------------------------------------------
 // vtkSlicerRoomsEyeViewModuleLogic methods
@@ -545,7 +553,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
     {
       vtkSmartPointer<vtkMRMLLinearTransformNode> transformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::New();
       transformNode->SetName(transformNodeName.c_str());
-      // transformNode->SetHideFromEditors(1);  //TODO: Comment out for easier debugging
+      transformNode->SetHideFromEditors(1);
       std::string singletonTag = std::string("IEC_") + transformNodeName;
       transformNode->SetSingletonTag(singletonTag.c_str());
       this->GetMRMLScene()->AddNode(transformNode);
@@ -708,11 +716,19 @@ vtkSlicerRoomsEyeViewModuleLogic::LoadTreatmentMachine(vtkMRMLRoomsEyeViewNode* 
     return std::vector<TreatmentMachinePartType>();
   }
 
-  // Create a table center point fiducial node if it does not exist yet
-  this->Internal->EnsureTableCenterPointFiducialNode(parameterNode);
+  // Create the table top center point fiducial node if it does not exist yet
+  this->Internal->EnsureTableTopCenterPointFiducialNode(parameterNode);
 
   // Make sure the transform hierarchy is in place
   this->BuildRoomsEyeViewTransformHierarchy();
+
+  // Set up observers on the TableTopCenter fiducial node (must be after BuildRoomsEyeViewTransformHierarchy
+  // so that the transform nodes exist when the observer fires immediately)
+  this->UpdateTableTopCenterObservers(parameterNode);
+
+  // Set up observers on the plan's POI markups fiducial node (must be after BuildRoomsEyeViewTransformHierarchy
+  // so that the transform nodes exist when OnPlanPOIChanged fires immediately)
+  this->UpdatePlanPOIObservers(parameterNode);
 
   std::string moduleShareDirectory = this->GetModuleShareDirectory();
   std::string descriptorFilePath(parameterNode->GetTreatmentMachineDescriptorFilePath());
@@ -1106,6 +1122,45 @@ bool vtkSlicerRoomsEyeViewModuleLogic::GetPatientBodyPolyData(vtkMRMLRoomsEyeVie
 }
 
 //----------------------------------------------------------------------------
+bool vtkSlicerRoomsEyeViewModuleLogic::CalculateTableTopCenterFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode, double tableTopCenterRAS[3])
+{
+  if (!parameterNode)
+  {
+    vtkErrorMacro("CalculateTableTopCenterFromPatientBodySegment: Invalid parameter set node");
+    return false;
+  }
+
+  vtkNew<vtkPolyData> patientBodyPolyData;
+  if (!this->GetPatientBodyPolyData(parameterNode, patientBodyPolyData))
+  {
+    vtkErrorMacro("CalculateTableTopCenterFromPatientBodySegment: Failed to get patient body poly data");
+    return false;
+  }
+
+  double bounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  patientBodyPolyData->GetBounds(bounds);
+  tableTopCenterRAS[0] = (bounds[0] + bounds[1]) / 2.0;
+  tableTopCenterRAS[1] = bounds[2]; // posterior extent (min Y in RAS)
+  tableTopCenterRAS[2] = (bounds[4] + bounds[5]) / 2.0;
+
+  // Update the fiducial node position if it exists
+  vtkMRMLMarkupsFiducialNode* fiducialNode = this->Internal->EnsureTableTopCenterPointFiducialNode(parameterNode);
+  if (fiducialNode)
+  {
+    if (fiducialNode->GetNumberOfControlPoints() == 0)
+    {
+      fiducialNode->AddControlPointWorld(tableTopCenterRAS, "TableTopCenter");
+    }
+    else
+    {
+      fiducialNode->SetNthControlPointPositionWorld(0, tableTopCenterRAS);
+    }
+  }
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
 void vtkSlicerRoomsEyeViewModuleLogic::UpdateGantryToFixedReferenceTransform(vtkMRMLRoomsEyeViewNode* parameterNode)
 {
   if (!parameterNode)
@@ -1368,20 +1423,129 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopToTableTopEccentricRotation
     return;
   }
 
+  this->IECLogic->UpdateTableTopToTableTopEccentricRotationTransform(
+    parameterNode->GetLateralTableTopDisplacement(),
+    parameterNode->GetLongitudinalTableTopDisplacement(),
+    parameterNode->GetVerticalTableTopDisplacement(),
+    0.0, 0.0); // pitch and roll not yet exposed in parameter node
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
     this->GetTransformNodeBetween(vtkIECTransformLogic::TableTop, vtkIECTransformLogic::TableTopEccentricRotation);
-  vtkTransform* tableTopEccentricRotationToPatientSupportTransform = vtkTransform::SafeDownCast(
-    tableTopToTableTopEccentricRotationTransformNode->GetTransformToParent() );
+  tableTopToTableTopEccentricRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
+}
 
-  double translationArray[3] =
-    { parameterNode->GetLateralTableTopDisplacement(), parameterNode->GetLongitudinalTableTopDisplacement(), parameterNode->GetVerticalTableTopDisplacement() };
+//-----------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopCenterObservers(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  // Remove existing observers (node may have been deleted, in which case weak pointer is null)
+  if (this->Internal->ObservedTableTopCenterFiducialNode)
+  {
+    for (unsigned long tag : this->Internal->TableTopCenterFiducialNodeObserverTags)
+    {
+      this->Internal->ObservedTableTopCenterFiducialNode->RemoveObserver(tag);
+    }
+  }
+  this->Internal->TableTopCenterFiducialNodeObserverTags.clear();
+  this->Internal->ObservedTableTopCenterFiducialNode = nullptr;
+  this->Internal->ObservedTableTopCenterParamNode = nullptr;
 
-  vtkNew<vtkMatrix4x4> tableTopEccentricRotationToPatientSupportMatrix;
-  tableTopEccentricRotationToPatientSupportMatrix->SetElement(0,3, translationArray[0]);
-  tableTopEccentricRotationToPatientSupportMatrix->SetElement(1,3, translationArray[1]);
-  tableTopEccentricRotationToPatientSupportMatrix->SetElement(2,3, translationArray[2]);
-  tableTopEccentricRotationToPatientSupportTransform->SetMatrix(tableTopEccentricRotationToPatientSupportMatrix);
-  tableTopEccentricRotationToPatientSupportTransform->Modified(); // Modified call is needed because it does not update display in app
+  vtkMRMLMarkupsFiducialNode* fiducialNode = parameterNode ? parameterNode->GetTableTopCenterPointFiducialNode() : nullptr;
+  if (!fiducialNode)
+  {
+    return;
+  }
+
+  this->Internal->ObservedTableTopCenterFiducialNode = fiducialNode;
+  this->Internal->ObservedTableTopCenterParamNode = parameterNode;
+
+  vtkNew<vtkCallbackCommand> callbackCommand;
+  callbackCommand->SetClientData(this);
+  callbackCommand->SetCallback([](vtkObject*, unsigned long, void* clientData, void*)
+  {
+    auto* self = static_cast<vtkSlicerRoomsEyeViewModuleLogic*>(clientData);
+    self->UpdateTableTopDisplacementFromTableTopCenter(self->Internal->ObservedTableTopCenterParamNode);
+  });
+
+  this->Internal->TableTopCenterFiducialNodeObserverTags.push_back(
+    fiducialNode->AddObserver(vtkMRMLMarkupsNode::PointPositionDefinedEvent, callbackCommand));
+  this->Internal->TableTopCenterFiducialNodeObserverTags.push_back(
+    fiducialNode->AddObserver(vtkMRMLMarkupsNode::PointEndInteractionEvent, callbackCommand));
+  this->Internal->TableTopCenterFiducialNodeObserverTags.push_back(
+    fiducialNode->AddObserver(vtkMRMLMarkupsNode::PointModifiedEvent, callbackCommand));
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopDisplacementFromTableTopCenter(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  if (!parameterNode)
+  {
+    return;
+  }
+
+  vtkMRMLMarkupsFiducialNode* fiducialNode = parameterNode->GetTableTopCenterPointFiducialNode();
+  if (!fiducialNode || fiducialNode->GetNumberOfControlPoints() == 0)
+  {
+    return;
+  }
+
+  // Get the TableTopEccentricRotation → RAS composite transform
+  vtkMRMLLinearTransformNode* tteTransformNode = this->GetTransformNodeBetween(
+    vtkIECTransformLogic::TableTopEccentricRotation, vtkIECTransformLogic::PatientSupportRotation);
+  if (!tteTransformNode)
+  {
+    vtkErrorMacro("UpdateTableTopDisplacementFromTableTopCenter: Failed to get TableTopEccentricRotation transform node");
+    return;
+  }
+
+  vtkNew<vtkMatrix4x4> tteToRAS;
+  tteTransformNode->GetMatrixTransformToWorld(tteToRAS);
+
+  vtkNew<vtkMatrix4x4> rasToTTE;
+  vtkMatrix4x4::Invert(tteToRAS, rasToTTE);
+
+  // Get current table top model center in world RAS
+  vtkMRMLModelNode* tableTopModelNode = this->Internal->GetTreatmentMachinePartModelNode(parameterNode, TableTop);
+  if (!tableTopModelNode)
+  {
+    vtkErrorMacro("UpdateTableTopDisplacementFromTableTopCenter: Failed to get table top model node");
+    return;
+  }
+  double tableTopBounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  tableTopModelNode->GetRASBounds(tableTopBounds);
+  double tableTopCenterRAS[3] = {
+    (tableTopBounds[0] + tableTopBounds[1]) / 2.0,
+    (tableTopBounds[2] + tableTopBounds[3]) / 2.0,
+    (tableTopBounds[4] + tableTopBounds[5]) / 2.0
+  };
+
+  // Compute delta from current table top center to fiducial (in RAS), then convert to TTE space.
+  // Transform as a vector (w=0) so only the rotational part of rasToTTE is applied.
+  double fiducialRAS[3] = { 0.0, 0.0, 0.0 };
+  fiducialNode->GetNthControlPointPositionWorld(0, fiducialRAS);
+  double deltaRAS[4] = {
+    fiducialRAS[0] - tableTopCenterRAS[0],
+    fiducialRAS[1] - tableTopCenterRAS[1],
+    fiducialRAS[2] - tableTopCenterRAS[2],
+    0.0  // w=0: vector, not point — translation in rasToTTE does not apply
+  };
+  double deltaTTE[4] = { 0.0, 0.0, 0.0, 0.0 };
+  rasToTTE->MultiplyPoint(deltaRAS, deltaTTE);
+
+  double newLateral     = vtkMath::ClampValue(parameterNode->GetLateralTableTopDisplacement()     + deltaTTE[0],
+    parameterNode->GetLateralTableTopDisplacementMin(),     parameterNode->GetLateralTableTopDisplacementMax());
+  double newLongitudinal = vtkMath::ClampValue(parameterNode->GetLongitudinalTableTopDisplacement() + deltaTTE[1],
+    parameterNode->GetLongitudinalTableTopDisplacementMin(), parameterNode->GetLongitudinalTableTopDisplacementMax());
+  double newVertical    = vtkMath::ClampValue(parameterNode->GetVerticalTableTopDisplacement()    + deltaTTE[2],
+    parameterNode->GetVerticalTableTopDisplacementMin(),    parameterNode->GetVerticalTableTopDisplacementMax());
+
+  // Apply displacements without triggering a feedback loop through MRML events
+  parameterNode->DisableModifiedEventOn();
+  parameterNode->SetLateralTableTopDisplacement(newLateral);
+  parameterNode->SetLongitudinalTableTopDisplacement(newLongitudinal);
+  parameterNode->SetVerticalTableTopDisplacement(newVertical);
+  parameterNode->DisableModifiedEventOff();
+  parameterNode->Modified();
+
+  this->UpdateTableTopToTableTopEccentricRotationTransform(parameterNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1668,110 +1832,121 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::GetStateForPartType(std::string pa
   return stateStr;
 }
 
-//---------------------------------------------------------------------------
-void vtkSlicerRoomsEyeViewModuleLogic::AutoPlaceTableCenterPointFiducialFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode)
-{
-  if (!parameterNode)
-  {
-    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Invalid parameter set node");
-    return;
-  }
-  vtkMRMLMarkupsFiducialNode* tableCenterPointFiducialNode = parameterNode->GetTableCenterPointFiducialNode();
-  if (!tableCenterPointFiducialNode)
-  {
-    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Table center point fiducial node is not set");
-    return;
-  }
-
-  // Get patient body segmentation and segment
-  vtkMRMLSegmentationNode* segmentationNode = parameterNode->GetPatientBodySegmentationNode();
-  if (!segmentationNode || !parameterNode->GetPatientBodySegmentID())
-  {
-    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Patient body segmentation or segment ID not set");
-    return;
-  }
-  vtkSegment* patientBodySegment = segmentationNode->GetSegmentation()->GetSegment(parameterNode->GetPatientBodySegmentID());
-  if (!patientBodySegment)
-  {
-    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Failed to access patient body segment");
-    return;
-  }
-
-  // Calculate posterior center of the patient body segment
-  double bounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-  patientBodySegment->GetBounds(bounds);
-  double posteriorCenterRAS[3] = { (bounds[0] + bounds[1]) / 2.0, bounds[2], (bounds[4] + bounds[5]) / 2.0 };
-
-  // Set fiducial position
-  if (tableCenterPointFiducialNode->GetNumberOfControlPoints() == 0)
-  {
-    tableCenterPointFiducialNode->AddControlPointWorld(posteriorCenterRAS, "TableCenter");
-  }
-  else
-  {
-    tableCenterPointFiducialNode->SetNthControlPointPositionWorld(0, posteriorCenterRAS);
-  }
-}
 
 //-----------------------------------------------------------------------------
-void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableCenterPointObservers(vtkMRMLRoomsEyeViewNode* parameterNode)
+void vtkSlicerRoomsEyeViewModuleLogic::UpdatePlanPOIObservers(vtkMRMLRoomsEyeViewNode* parameterNode)
 {
   if (!this->GetMRMLScene())
   {
     return;
   }
-  vtkMRMLMarkupsFiducialNode* tableCenterPointNode = this->Internal->EnsureTableCenterPointFiducialNode(parameterNode);
-  if (!tableCenterPointNode)
+
+  // Get the plan's POI markups node via the beam node
+  vtkMRMLMarkupsFiducialNode* poiMarkupsNode = nullptr;
+  vtkMRMLRTPlanNode* planNode = nullptr;
+  vtkMRMLRTBeamNode* beamNode = parameterNode ? parameterNode->GetBeamNode() : nullptr;
+  if (beamNode)
+  {
+    planNode = beamNode->GetParentPlanNode();
+    if (planNode)
+    {
+      poiMarkupsNode = planNode->GetPoisMarkupsFiducialNode();
+    }
+  }
+
+  // Remove existing observers from the previously observed node
+  if (this->Internal->ObservedPOIMarkupsFiducialNode)
+  {
+    for (unsigned long tag : this->Internal->POIMarkupsFiducialNodeObserverTags)
+    {
+      this->Internal->ObservedPOIMarkupsFiducialNode->RemoveObserver(tag);
+    }
+    this->Internal->POIMarkupsFiducialNodeObserverTags.clear();
+    this->Internal->ObservedPOIMarkupsFiducialNode = nullptr;
+    this->Internal->ObservedPlanNode = nullptr;
+  }
+
+  if (!poiMarkupsNode)
   {
     return;
   }
 
-  // Remove existing observers
-  for (unsigned long tag : this->Internal->TableCenterPointFiducialNodeObserverTags)
-  {
-    tableCenterPointNode->RemoveObserver(tag);
-  }
-  this->Internal->TableCenterPointFiducialNodeObserverTags.clear();
+  this->Internal->ObservedPOIMarkupsFiducialNode = poiMarkupsNode;
+  this->Internal->ObservedPlanNode = planNode;
+  this->Internal->ObservedParamNode = parameterNode;
 
   vtkNew<vtkCallbackCommand> callbackCommand;
   callbackCommand->SetClientData(this);
   callbackCommand->SetCallback([](vtkObject* caller, unsigned long, void* clientData, void*)
   {
     auto* self = static_cast<vtkSlicerRoomsEyeViewModuleLogic*>(clientData);
-    self->OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode::SafeDownCast(caller));
+    self->OnPlanPOIChanged(vtkMRMLMarkupsFiducialNode::SafeDownCast(caller));
   });
 
-  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
-    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointPositionDefinedEvent, callbackCommand));
-  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
-    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointPositionUndefinedEvent, callbackCommand));
-  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
-    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointEndInteractionEvent, callbackCommand));
+  this->Internal->POIMarkupsFiducialNodeObserverTags.push_back(
+    poiMarkupsNode->AddObserver(vtkMRMLMarkupsNode::PointPositionDefinedEvent, callbackCommand));
+  this->Internal->POIMarkupsFiducialNodeObserverTags.push_back(
+    poiMarkupsNode->AddObserver(vtkMRMLMarkupsNode::PointPositionUndefinedEvent, callbackCommand));
+  this->Internal->POIMarkupsFiducialNodeObserverTags.push_back(
+    poiMarkupsNode->AddObserver(vtkMRMLMarkupsNode::PointEndInteractionEvent, callbackCommand));
+  this->Internal->POIMarkupsFiducialNodeObserverTags.push_back(
+    poiMarkupsNode->AddObserver(vtkMRMLMarkupsNode::PointModifiedEvent, callbackCommand));
 
-  this->OnTableCenterPointChanged(tableCenterPointNode);
+  this->OnPlanPOIChanged(poiMarkupsNode);
 }
 
 //-----------------------------------------------------------------------------
-void vtkSlicerRoomsEyeViewModuleLogic::OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode)
+void vtkSlicerRoomsEyeViewModuleLogic::UpdateFixedReferenceToRASTransform(vtkMRMLRoomsEyeViewNode* paramNode)
 {
   vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
   if (!beamsLogic)
   {
-    vtkErrorMacro("OnTableCenterPointChanged: Beams logic cannot be accessed");
-    return;
-  }
-  if (tableCenterFiducialNode == nullptr)
-  {
-    vtkErrorMacro("OnTableCenterPointChanged: Invalid table center point fiducial node");
-    return;
-  }
-  vtkMRMLRoomsEyeViewNode* parameterNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(
-    tableCenterFiducialNode->GetNodeReference("parameterNodeRef") );
-  if (!parameterNode)
-  {
-    vtkErrorMacro("OnTableCenterPointChanged: Parameter set node not found from table center point fiducial node");
+    vtkErrorMacro("UpdateFixedReferenceToRASTransform: Beams logic cannot be accessed");
     return;
   }
 
-  beamsLogic->UpdateFixedReferenceToRASTransform(this->IECLogic);
+  if (paramNode)
+  {
+    // Temporarily set the IEC table top displacement for the RAS transform computation:
+    // - Unchecked: zero displacement so the machine is positioned based on the POI only
+    // - Checked: apply displacement relative to the baseline captured when the mode was
+    //   enabled, so the patient does not jump on first activation
+    double effectiveLat  = this->MovePatientWithTableTop
+      ? paramNode->GetLateralTableTopDisplacement()      - this->TableTopBaselineLateral      : 0.0;
+    double effectiveLong = this->MovePatientWithTableTop
+      ? paramNode->GetLongitudinalTableTopDisplacement() - this->TableTopBaselineLongitudinal : 0.0;
+    double effectiveVert = this->MovePatientWithTableTop
+      ? paramNode->GetVerticalTableTopDisplacement()     - this->TableTopBaselineVertical     : 0.0;
+    this->IECLogic->UpdateTableTopToTableTopEccentricRotationTransform(effectiveLat, effectiveLong, effectiveVert, 0.0, 0.0);
+  }
+
+  beamsLogic->UpdateFixedReferenceToRASTransform(this->IECLogic, this->Internal->ObservedPlanNode, nullptr);
+
+  if (paramNode)
+  {
+    // Restore the actual slider values so the table top visual position is correct
+    this->IECLogic->UpdateTableTopToTableTopEccentricRotationTransform(
+      paramNode->GetLateralTableTopDisplacement(),
+      paramNode->GetLongitudinalTableTopDisplacement(),
+      paramNode->GetVerticalTableTopDisplacement(),
+      0.0, 0.0);
+    vtkMRMLLinearTransformNode* tableTopNode = this->GetTransformNodeBetween(
+      vtkIECTransformLogic::TableTop, vtkIECTransformLogic::TableTopEccentricRotation);
+    if (tableTopNode)
+    {
+      tableTopNode->Modified();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::OnPlanPOIChanged(vtkMRMLMarkupsFiducialNode* poiMarkupsFiducialNode)
+{
+  if (poiMarkupsFiducialNode == nullptr)
+  {
+    vtkErrorMacro("OnPlanPOIChanged: Invalid POI markups fiducial node");
+    return;
+  }
+
+  this->UpdateFixedReferenceToRASTransform(this->Internal->ObservedParamNode);
 }

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -33,10 +33,11 @@
 // MRML includes
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLScene.h>
-#include "vtkMRMLSubjectHierarchyNode.h"
+#include <vtkMRMLSubjectHierarchyNode.h>
 #include <vtkMRMLViewNode.h>
 
 // Slicer includes
@@ -48,7 +49,8 @@
 
 // VTK includes
 #include <vtkAppendPolyData.h>
-#include "vtkCollisionDetectionFilter.h"
+#include <vtkCallbackCommand.h>
+#include <vtkCollisionDetectionFilter.h>
 #include <vtkGeneralTransform.h>
 #include <vtkMatrix4x4.h>
 #include <vtkObjectFactory.h>
@@ -84,7 +86,7 @@ public:
   vtkInternal(vtkSlicerRoomsEyeViewModuleLogic* external);
   ~vtkInternal();
 
-  vtkSlicerRoomsEyeViewModuleLogic* External; 
+  vtkSlicerRoomsEyeViewModuleLogic* External;
   rapidjson::Document* CurrentTreatmentMachineDescription{nullptr};
 
   /// Utility function to get element for treatment machine part
@@ -92,11 +94,16 @@ public:
   rapidjson::Value& GetTreatmentMachinePart(TreatmentMachinePartType partType);
   rapidjson::Value& GetTreatmentMachinePart(std::string partTypeStr);
 
+  vtkIdType EnsureMachineComponentsSubjectHierarchyFolder(vtkMRMLRoomsEyeViewNode* parameterNode);
   std::string GetTreatmentMachinePartFullFilePath(vtkMRMLRoomsEyeViewNode* parameterNode, std::string partPath);
   std::string GetTreatmentMachineFileNameWithoutExtension(vtkMRMLRoomsEyeViewNode* parameterNode);
   std::string GetTreatmentMachinePartModelName(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType);
   vtkMRMLModelNode* GetTreatmentMachinePartModelNode(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType);
   vtkMRMLModelNode* EnsureTreatmentMachinePartModelNode(vtkMRMLRoomsEyeViewNode* parameterNode, TreatmentMachinePartType partType, bool optional=false);
+  vtkMRMLMarkupsFiducialNode* EnsureTableCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode);
+
+  /// Keep track of observers on the table center point fiducial node
+  std::vector<unsigned long> TableCenterPointFiducialNodeObserverTags;
 };
 
 //---------------------------------------------------------------------------
@@ -160,6 +167,35 @@ rapidjson::Value& vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::GetTreatmentMac
 
   // Not found
   return JSON_EMPTY_VALUE;
+}
+
+//---------------------------------------------------------------------------
+vtkIdType vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureMachineComponentsSubjectHierarchyFolder(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  vtkMRMLScene* scene = this->External->GetMRMLScene();
+  if (!scene || !parameterNode)
+  {
+    vtkErrorWithObjectMacro(this->External, "EnsureMachineComponentsSubjectHierarchyFolder: Invalid scene or parameter node");
+    return vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
+  }
+  vtkMRMLSubjectHierarchyNode* shNode = scene->GetSubjectHierarchyNode();
+  if (!shNode)
+  {
+    vtkErrorWithObjectMacro(this->External, "EnsureMachineComponentsSubjectHierarchyFolder: Failed to access subject hierarchy node");
+    return vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
+  }
+
+  // Get root SH item
+  std::string machineType = this->GetTreatmentMachineFileNameWithoutExtension(parameterNode);
+  std::string rootFolderName = machineType + std::string("_Components");
+  vtkIdType rootFolderItem = shNode->GetItemChildWithName(shNode->GetSceneItemID(), rootFolderName);
+  if (!rootFolderItem)
+  {
+    // Create subject hierarchy folder so that the treatment machine can be shown/hidden easily
+    rootFolderItem = shNode->CreateFolderItem(shNode->GetSceneItemID(), rootFolderName);
+    shNode->SetItemAttribute(rootFolderItem, TREATMENT_MACHINE_DESCRIPTOR_FILE_PATH_ATTRIBUTE_NAME, parameterNode->GetTreatmentMachineDescriptorFilePath());
+  }
+  return rootFolderItem;
 }
 
 //---------------------------------------------------------------------------
@@ -234,26 +270,17 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTreatment
   vtkMRMLScene* scene = this->External->GetMRMLScene();
   if (!scene || !parameterNode)
   {
-    vtkErrorWithObjectMacro(this->External, "GetTreatmentMachinePartModelName: Invalid scene or parameter node");
+    vtkErrorWithObjectMacro(this->External, "EnsureTreatmentMachinePartModelNode: Invalid scene or parameter node");
     return nullptr;
   }
   vtkMRMLSubjectHierarchyNode* shNode = scene->GetSubjectHierarchyNode();
   if (!shNode)
   {
-    vtkErrorWithObjectMacro(this->External, "LoadTreatmentMachine: Failed to access subject hierarchy node");
+    vtkErrorWithObjectMacro(this->External, "EnsureTreatmentMachinePartModelNode: Failed to access subject hierarchy node");
     return nullptr;
   }
 
-  // Get root SH item
-  std::string machineType = this->GetTreatmentMachineFileNameWithoutExtension(parameterNode);
-  std::string rootFolderName = machineType + std::string("_Components");
-  vtkIdType rootFolderItem = shNode->GetItemChildWithName(shNode->GetSceneItemID(), rootFolderName);
-  if (!rootFolderItem)
-  {
-    // Create subject hierarchy folder so that the treatment machine can be shown/hidden easily
-    rootFolderItem = shNode->CreateFolderItem(shNode->GetSceneItemID(), rootFolderName);
-  }
-
+  vtkIdType rootFolderItem = this->EnsureMachineComponentsSubjectHierarchyFolder(parameterNode);
   std::string partName = this->GetTreatmentMachinePartModelName(parameterNode, partType);
   vtkMRMLModelNode* partModelNode = this->GetTreatmentMachinePartModelNode(parameterNode, partType);
   if (!partModelNode)
@@ -268,10 +295,10 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTreatment
       }
       else
       {
-        vtkWarningWithObjectMacro(this->External, "LoadTreatmentMachine: State for part "
+        vtkWarningWithObjectMacro(this->External, "EnsureTreatmentMachinePartModelNode: State for part "
           << partName << " is set to Disabled but the part is mandatory. Loading anyway.");
       }
-    }     
+    }
     // Get model file path
     std::string partModelFilePath = this->External->GetFilePathForPartType(
       this->External->GetTreatmentMachinePartTypeAsString(partType));
@@ -279,7 +306,7 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTreatment
     {
       if (!optional)
       {
-        vtkErrorWithObjectMacro(this->External, "LoadTreatmentMachine: Failed get file path for part "
+        vtkErrorWithObjectMacro(this->External, "EnsureTreatmentMachinePartModelNode: Failed get file path for part "
           << partName << ". This mandatory part may be missing from the descriptor file");
       }
       return nullptr;
@@ -298,11 +325,49 @@ vtkMRMLModelNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTreatment
     }
     else if (!optional)
     {
-      vtkErrorWithObjectMacro(this->External, "LoadTreatmentMachine: Failed to load " << partName << " model from file " << partModelFilePath);
+      vtkErrorWithObjectMacro(this->External, "EnsureTreatmentMachinePartModelNode: Failed to load " << partName << " model from file " << partModelFilePath);
       return nullptr;
     }
   }
   return partModelNode;
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLMarkupsFiducialNode* vtkSlicerRoomsEyeViewModuleLogic::vtkInternal::EnsureTableCenterPointFiducialNode(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  vtkMRMLScene* scene = this->External->GetMRMLScene();
+  if (!scene || !parameterNode)
+  {
+    vtkErrorWithObjectMacro(this->External, "EnsureTableCenterPointFiducialNode: Invalid scene or parameter node");
+    return nullptr;
+  }
+  if (parameterNode->GetTableCenterPointFiducialNode())
+  {
+    return parameterNode->GetTableCenterPointFiducialNode();
+  }
+  vtkMRMLSubjectHierarchyNode* shNode = scene->GetSubjectHierarchyNode();
+  if (!shNode)
+  {
+    vtkErrorWithObjectMacro(this->External, "EnsureTableCenterPointFiducialNode: Failed to access subject hierarchy node");
+    return nullptr;
+  }
+
+  vtkMRMLMarkupsFiducialNode* fiducialNode = parameterNode->GetTableCenterPointFiducialNode();
+  if (!fiducialNode)
+  {
+    fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "TableCenterPoint"));
+    fiducialNode->SetDisplayVisibility(false); // Hide fiducial by default
+    parameterNode->SetAndObserveTableCenterPointFiducialNode(fiducialNode);
+    // Set reference so that we can get the parameter node from the fiducial node later
+    fiducialNode->SetNodeReferenceID("parameterNodeRef", parameterNode->GetID());
+    // Add node to the SH under the treatment machine components folder
+    vtkIdType rootFolderItem = this->EnsureMachineComponentsSubjectHierarchyFolder(parameterNode);
+    vtkIdType fiducialItemID = shNode->GetItemByDataNode(fiducialNode);
+    shNode->SetItemParent(fiducialItemID, rootFolderItem);
+    // Set up observer to handle changes
+    this->External->UpdateTableCenterPointObservers(parameterNode);
+  }
+  return fiducialNode;
 }
 
 //---------------------------------------------------------------------------
@@ -316,7 +381,7 @@ vtkSlicerRoomsEyeViewModuleLogic::vtkSlicerRoomsEyeViewModuleLogic()
   , CollimatorPatientCollisionDetection(nullptr)
   , CollimatorTableTopCollisionDetection(nullptr)
 {
-  this->Internal = new vtkInternal(this); 
+  this->Internal = new vtkInternal(this);
 
   this->IECLogic = vtkIECTransformLogic::New();
 
@@ -480,7 +545,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
     {
       vtkSmartPointer<vtkMRMLLinearTransformNode> transformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::New();
       transformNode->SetName(transformNodeName.c_str());
-      transformNode->SetHideFromEditors(1);
+      // transformNode->SetHideFromEditors(1);  //TODO: Comment out for easier debugging
       std::string singletonTag = std::string("IEC_") + transformNodeName;
       transformNode->SetSingletonTag(singletonTag.c_str());
       this->GetMRMLScene()->AddNode(transformNode);
@@ -618,7 +683,7 @@ void vtkSlicerRoomsEyeViewModuleLogic::BuildRoomsEyeViewTransformHierarchy()
 
 
   // Make sure the fixed reference to RAS is correct
-  beamsLogic->UpdateRASRelatedTransforms(this->IECLogic);
+  beamsLogic->UpdateFixedReferenceToRASTransform(this->IECLogic);
 }
 
 //----------------------------------------------------------------------------
@@ -643,34 +708,34 @@ vtkSlicerRoomsEyeViewModuleLogic::LoadTreatmentMachine(vtkMRMLRoomsEyeViewNode* 
     return std::vector<TreatmentMachinePartType>();
   }
 
+  // Create a table center point fiducial node if it does not exist yet
+  this->Internal->EnsureTableCenterPointFiducialNode(parameterNode);
+
   // Make sure the transform hierarchy is in place
   this->BuildRoomsEyeViewTransformHierarchy();
 
   std::string moduleShareDirectory = this->GetModuleShareDirectory();
   std::string descriptorFilePath(parameterNode->GetTreatmentMachineDescriptorFilePath());
-  std::string machineType = this->Internal->GetTreatmentMachineFileNameWithoutExtension(parameterNode);
 
   // Load treatment machine JSON descriptor file
-  FILE *fp = fopen(descriptorFilePath.c_str(), "r");
+  FILE* fp = fopen(descriptorFilePath.c_str(), "r");
   if (!fp)
-    {
-      vtkErrorMacro("LoadTreatmentMachine: Failed to load treatment machine descriptor file '" << descriptorFilePath << "'");
-      return std::vector<TreatmentMachinePartType>();
-    }
+  {
+    vtkErrorMacro("LoadTreatmentMachine: Failed to load treatment machine descriptor file '" << descriptorFilePath << "'");
+    return std::vector<TreatmentMachinePartType>();
+  }
   char buffer[4096];
   rapidjson::FileReadStream fs(fp, buffer, sizeof(buffer));
   if (this->Internal->CurrentTreatmentMachineDescription->ParseStream(fs).HasParseError())
-    {
-      vtkErrorMacro("LoadTreatmentMachine: Failed to load treatment machine descriptor file '" << descriptorFilePath << "'");
-      fclose(fp);
-      return std::vector<TreatmentMachinePartType>();
-    }
+  {
+    vtkErrorMacro("LoadTreatmentMachine: Failed to load treatment machine descriptor file '" << descriptorFilePath << "'");
+    fclose(fp);
+    return std::vector<TreatmentMachinePartType>();
+  }
   fclose(fp);
 
-  // Create subject hierarchy folder so that the treatment machine can be shown/hidden easily
-  std::string subjectHierarchyFolderName = machineType + std::string("_Components");
-  vtkIdType rootFolderItem = shNode->CreateFolderItem(shNode->GetSceneItemID(), subjectHierarchyFolderName);
-  shNode->SetItemAttribute(rootFolderItem, TREATMENT_MACHINE_DESCRIPTOR_FILE_PATH_ATTRIBUTE_NAME, descriptorFilePath);
+  // Make sure we have a subject hierarchy folder so that the treatment machine can be shown/hidden easily
+  this->Internal->EnsureMachineComponentsSubjectHierarchyFolder(parameterNode);
 
   // Load treatment machine models
 
@@ -1601,4 +1666,112 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::GetStateForPartType(std::string pa
   }
 
   return stateStr;
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::AutoPlaceTableCenterPointFiducialFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  if (!parameterNode)
+  {
+    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Invalid parameter set node");
+    return;
+  }
+  vtkMRMLMarkupsFiducialNode* tableCenterPointFiducialNode = parameterNode->GetTableCenterPointFiducialNode();
+  if (!tableCenterPointFiducialNode)
+  {
+    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Table center point fiducial node is not set");
+    return;
+  }
+
+  // Get patient body segmentation and segment
+  vtkMRMLSegmentationNode* segmentationNode = parameterNode->GetPatientBodySegmentationNode();
+  if (!segmentationNode || !parameterNode->GetPatientBodySegmentID())
+  {
+    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Patient body segmentation or segment ID not set");
+    return;
+  }
+  vtkSegment* patientBodySegment = segmentationNode->GetSegmentation()->GetSegment(parameterNode->GetPatientBodySegmentID());
+  if (!patientBodySegment)
+  {
+    vtkErrorMacro("AutoPlaceTableCenterPointFiducialFromPatientBodySegment: Failed to access patient body segment");
+    return;
+  }
+
+  // Calculate posterior center of the patient body segment
+  double bounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  patientBodySegment->GetBounds(bounds);
+  double posteriorCenterRAS[3] = { (bounds[0] + bounds[1]) / 2.0, bounds[2], (bounds[4] + bounds[5]) / 2.0 };
+
+  // Set fiducial position
+  if (tableCenterPointFiducialNode->GetNumberOfControlPoints() == 0)
+  {
+    tableCenterPointFiducialNode->AddControlPointWorld(posteriorCenterRAS, "TableCenter");
+  }
+  else
+  {
+    tableCenterPointFiducialNode->SetNthControlPointPositionWorld(0, posteriorCenterRAS);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableCenterPointObservers(vtkMRMLRoomsEyeViewNode* parameterNode)
+{
+  if (!this->GetMRMLScene())
+  {
+    return;
+  }
+  vtkMRMLMarkupsFiducialNode* tableCenterPointNode = this->Internal->EnsureTableCenterPointFiducialNode(parameterNode);
+  if (!tableCenterPointNode)
+  {
+    return;
+  }
+
+  // Remove existing observers
+  for (unsigned long tag : this->Internal->TableCenterPointFiducialNodeObserverTags)
+  {
+    tableCenterPointNode->RemoveObserver(tag);
+  }
+  this->Internal->TableCenterPointFiducialNodeObserverTags.clear();
+
+  vtkNew<vtkCallbackCommand> callbackCommand;
+  callbackCommand->SetClientData(this);
+  callbackCommand->SetCallback([](vtkObject* caller, unsigned long, void* clientData, void*)
+  {
+    auto* self = static_cast<vtkSlicerRoomsEyeViewModuleLogic*>(clientData);
+    self->OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode::SafeDownCast(caller));
+  });
+
+  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
+    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointPositionDefinedEvent, callbackCommand));
+  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
+    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointPositionUndefinedEvent, callbackCommand));
+  this->Internal->TableCenterPointFiducialNodeObserverTags.push_back(
+    tableCenterPointNode->AddObserver(vtkMRMLMarkupsNode::PointEndInteractionEvent, callbackCommand));
+
+  this->OnTableCenterPointChanged(tableCenterPointNode);
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode)
+{
+  vtkSlicerBeamsModuleLogic* beamsLogic = this->GetBeamsLogic();
+  if (!beamsLogic)
+  {
+    vtkErrorMacro("OnTableCenterPointChanged: Beams logic cannot be accessed");
+    return;
+  }
+  if (tableCenterFiducialNode == nullptr)
+  {
+    vtkErrorMacro("OnTableCenterPointChanged: Invalid table center point fiducial node");
+    return;
+  }
+  vtkMRMLRoomsEyeViewNode* parameterNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(
+    tableCenterFiducialNode->GetNodeReference("parameterNodeRef") );
+  if (!parameterNode)
+  {
+    vtkErrorMacro("OnTableCenterPointChanged: Parameter set node not found from table center point fiducial node");
+    return;
+  }
+
+  beamsLogic->UpdateFixedReferenceToRASTransform(this->IECLogic);
 }

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -117,6 +117,14 @@ public:
   /// Update TableTopToTableTopEccentricRotation based on all three table top translations
   void UpdateTableTopToTableTopEccentricRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
 
+  /// Set up / refresh observers on the TableTopCenter fiducial node so that moving it drives the table top sliders
+  void UpdateTableTopCenterObservers(vtkMRMLRoomsEyeViewNode* parameterNode);
+
+  /// Compute the lateral/longitudinal/vertical displacements required to bring the table top center
+  /// to the current TableTopCenter fiducial position, and apply them to the parameter node.
+  /// Clamps each axis to the corresponding min/max stored in the parameter node.
+  void UpdateTableTopDisplacementFromTableTopCenter(vtkMRMLRoomsEyeViewNode* parameterNode);
+
   /// Update orientation marker based on the current transforms
   vtkMRMLModelNode* UpdateTreatmentOrientationMarker(vtkMRMLRoomsEyeViewNode* parameterNode);
 
@@ -124,13 +132,32 @@ public:
   /// \return string indicating whether collision occurred
   std::string CheckForCollisions(vtkMRMLRoomsEyeViewNode* parameterNode);
 
-  /// Automatically place the table center point fiducial to the posterior center of the patient body segment
-  void AutoPlaceTableCenterPointFiducialFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode);
+  /// Update observers on the plan's POI markups fiducial node
+  void UpdatePlanPOIObservers(vtkMRMLRoomsEyeViewNode* parameterNode);
+  /// Handle plan POI fiducial changed event
+  void OnPlanPOIChanged(vtkMRMLMarkupsFiducialNode* poiMarkupsFiducialNode);
 
-  /// Update observers on the table center point fiducial node
-  void UpdateTableCenterPointObservers(vtkMRMLRoomsEyeViewNode* parameterNode);
-  /// Handle table center point changed event
-  void OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode);
+  /// Update the FixedReference-to-RAS transform, respecting the MovePatientWithTableTop flag.
+  /// When MovePatientWithTableTop is false, the table top displacement is not factored into the
+  /// machine position (the machine is positioned based on the POI only).
+  void UpdateFixedReferenceToRASTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
+
+  /// Set whether table top displacement should reposition the entire machine (true) or only
+  /// move the table top within the IEC hierarchy (false, default).
+  void SetMovePatientWithTableTop(bool movePatientWithTableTop) { this->MovePatientWithTableTop = movePatientWithTableTop; }
+
+  /// Set the table top displacement baseline used when MovePatientWithTableTop is true.
+  /// The effective displacement applied to the RAS transform is (current - baseline), so that
+  /// the patient does not jump when the mode is first enabled.
+  void SetTableTopBaseline(double lateral, double longitudinal, double vertical)
+  {
+    this->TableTopBaselineLateral = lateral;
+    this->TableTopBaselineLongitudinal = longitudinal;
+    this->TableTopBaselineVertical = vertical;
+  }
+  double GetTableTopBaselineLateral()      const { return this->TableTopBaselineLateral; }
+  double GetTableTopBaselineLongitudinal() const { return this->TableTopBaselineLongitudinal; }
+  double GetTableTopBaselineVertical()     const { return this->TableTopBaselineVertical; }
 
 // Get treatment machine properties from descriptor file
 public:
@@ -173,6 +200,11 @@ public:
   vtkMRMLLinearTransformNode* GetTransformNodeBetween(
     vtkIECTransformLogic::CoordinateSystemIdentifier fromFrame, vtkIECTransformLogic::CoordinateSystemIdentifier toFrame);
 
+  /// Calculate the table top center point (posterior-center of patient body segment bounds) in RAS coordinates.
+  /// \param tableTopCenterRAS Output array of 3 doubles. Only written on success.
+  /// \return true on success, false if segmentation/segment is not set or bounds are invalid.
+  bool CalculateTableTopCenterFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode, double tableTopCenterRAS[3]);
+
 protected:
   /// Get patient body closed surface poly data from segmentation node and segment selection in the parameter node
   bool GetPatientBodyPolyData(vtkMRMLRoomsEyeViewNode* parameterNode, vtkPolyData* patientBodyPolyData);
@@ -183,6 +215,10 @@ protected:
 protected:
   vtkIECTransformLogic* IECLogic;
   vtkSlicerBeamsModuleLogic* BeamsLogic{nullptr};
+  bool MovePatientWithTableTop{false};
+  double TableTopBaselineLateral{0.0};
+  double TableTopBaselineLongitudinal{0.0};
+  double TableTopBaselineVertical{0.0};
 
   vtkCollisionDetectionFilter* GantryPatientCollisionDetection;
   vtkCollisionDetectionFilter* GantryTableTopCollisionDetection;

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -44,8 +44,9 @@ class vtkMatrix4x4;
 class vtkPolyData;
 class vtkVector3d;
 
-class vtkMRMLRoomsEyeViewNode;
+class vtkMRMLMarkupsFiducialNode;
 class vtkMRMLModelNode;
+class vtkMRMLRoomsEyeViewNode;
 
 /// \ingroup SlicerRt_QtModules_RoomsEyeView
 class VTK_SLICER_ROOMSEYEVIEW_LOGIC_EXPORT vtkSlicerRoomsEyeViewModuleLogic : public vtkSlicerModuleLogic
@@ -66,14 +67,14 @@ public:
     ApplicatorHolder,
     ElectronApplicator,
     LastPartType
-    }; 
+    };
 
   static const char* ORIENTATION_MARKER_MODEL_NODE_NAME;
   static const char* TREATMENT_MACHINE_DESCRIPTOR_FILE_PATH_ATTRIBUTE_NAME;
   static unsigned long MAX_TRIANGLE_NUMBER_PRODUCT_FOR_COLLISIONS;
 
 public:
-  static vtkSlicerRoomsEyeViewModuleLogic *New();
+  static vtkSlicerRoomsEyeViewModuleLogic* New();
   vtkTypeMacro(vtkSlicerRoomsEyeViewModuleLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent);
 
@@ -115,13 +116,21 @@ public:
   void UpdateTableTopEccentricRotationToPatientSupportRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
   /// Update TableTopToTableTopEccentricRotation based on all three table top translations
   void UpdateTableTopToTableTopEccentricRotationTransform(vtkMRMLRoomsEyeViewNode* parameterNode);
- 
+
   /// Update orientation marker based on the current transforms
   vtkMRMLModelNode* UpdateTreatmentOrientationMarker(vtkMRMLRoomsEyeViewNode* parameterNode);
 
   /// Check for collisions between pieces of linac model using vtkCollisionDetectionFilter
   /// \return string indicating whether collision occurred
   std::string CheckForCollisions(vtkMRMLRoomsEyeViewNode* parameterNode);
+
+  /// Automatically place the table center point fiducial to the posterior center of the patient body segment
+  void AutoPlaceTableCenterPointFiducialFromPatientBodySegment(vtkMRMLRoomsEyeViewNode* parameterNode);
+
+  /// Update observers on the table center point fiducial node
+  void UpdateTableCenterPointObservers(vtkMRMLRoomsEyeViewNode* parameterNode);
+  /// Handle table center point changed event
+  void OnTableCenterPointChanged(vtkMRMLMarkupsFiducialNode* tableCenterFiducialNode);
 
 // Get treatment machine properties from descriptor file
 public:

--- a/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
+++ b/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
@@ -69,14 +69,24 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="MovePatientWithTableTopCheckBox">
+        <property name="text">
+         <string>Move patient with table top</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Gantry angle:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="ctkSliderWidget" name="CollimatorRotationSlider">
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -92,7 +102,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="ctkSliderWidget" name="GantryRotationSlider">
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -105,21 +115,21 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="labelImagingPanel">
         <property name="text">
          <string>Imaging panel:</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="LateralTableTopDisplacementLabel">
         <property name="text">
          <string>Table top (lateral):</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="ctkSliderWidget" name="PatientSupportRotationSlider">
         <property name="minimum">
          <double>-180.000000000000000</double>
@@ -135,7 +145,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="ctkSliderWidget" name="LongitudinalTableTopDisplacementSlider">
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -151,7 +161,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="ctkSliderWidget" name="LateralTableTopDisplacementSlider">
         <property name="minimum">
          <double>-230.000000000000000</double>
@@ -167,28 +177,28 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="VerticalTableTopDisplacementLabel">
         <property name="text">
          <string>Table top (vertical):</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="PatientSupportRotationLabel">
         <property name="text">
          <string>Patient support rotation:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="LongitudinalTableTopDisplacementLabel">
         <property name="text">
          <string>Table top (longitudinal):</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="ctkSliderWidget" name="VerticalTableTopDisplacementSlider">
         <property name="minimum">
          <double>-500.000000000000000</double>
@@ -204,14 +214,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Collimator angle:</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <widget class="ctkSliderWidget" name="ImagingPanelMovementSlider">
         <property name="minimum">
          <double>-68.500000000000000</double>

--- a/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
+++ b/RoomsEyeView/Resources/UI/qSlicerRoomsEyeViewModule.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>345</width>
-    <height>490</height>
+    <width>373</width>
+    <height>544</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -296,8 +296,8 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="qMRMLSegmentSelectorWidget" name="SegmentSelectorWidget_PatientBody" native="true">
-        <property name="noneEnabled" stdset="0">
+       <widget class="qMRMLSegmentSelectorWidget" name="SegmentSelectorWidget_PatientBody">
+        <property name="noneEnabled">
          <bool>true</bool>
         </property>
        </widget>
@@ -310,21 +310,6 @@
      <property name="leftMargin">
       <number>4</number>
      </property>
-     <item row="1" column="1">
-      <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Beam" native="true">
-       <property name="nodeTypes" stdset="0">
-        <stringlist>
-         <string>vtkMRMLRTBeamNode</string>
-        </stringlist>
-       </property>
-       <property name="noneEnabled" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QComboBox" name="TreatmentMachineComboBox"/>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -339,14 +324,41 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_ParameterSet" native="true">
-       <property name="nodeTypes" stdset="0">
+     <item row="1" column="1">
+      <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Beam">
+       <property name="nodeTypes">
         <stringlist>
-         <string>vtkMRMLRoomsEyeViewNode</string>
+         <string>vtkMRMLRTBeamNode</string>
         </stringlist>
        </property>
+       <property name="noneEnabled">
+        <bool>true</bool>
+       </property>
       </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QComboBox" name="TreatmentMachineComboBox"/>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Fix 3D camera in 'fixed reference' frame:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="FixedCameraCheckBox">
+         <property name="toolTip">
+          <string>If enabled, the treatment machine will stay fixed in 3D while adjusting machine transforms. Otherwise, the camera will be fixed in RAS and the patient stays still.</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="2" column="1">
       <widget class="QPushButton" name="LoadTreatmentMachineButton">
@@ -355,10 +367,12 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="2">
-      <widget class="QCheckBox" name="FixedCameraCheckBox">
-       <property name="text">
-        <string>Fix 3D camera in FixedReference frame</string>
+     <item row="0" column="1">
+      <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_ParameterSet">
+       <property name="nodeTypes">
+        <stringlist>
+         <string>vtkMRMLRoomsEyeViewNode</string>
+        </stringlist>
        </property>
       </widget>
      </item>
@@ -367,17 +381,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ctkCollapsibleButton</class>
-   <extends>QWidget</extends>
-   <header>ctkCollapsibleButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
-  </customwidget>
   <customwidget>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
@@ -401,6 +404,17 @@
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentSelectorWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -428,7 +442,7 @@
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
+     <x>372</x>
      <y>3</y>
     </hint>
     <hint type="destinationlabel">
@@ -448,8 +462,8 @@
      <y>2</y>
     </hint>
     <hint type="destinationlabel">
-     <x>329</x>
-     <y>118</y>
+     <x>360</x>
+     <y>218</y>
     </hint>
    </hints>
   </connection>

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -39,6 +39,7 @@
 #include <qSlicerLayoutManager.h>
 #include <qSlicerIOManager.h>
 #include <qSlicerDataDialog.h>
+#include <qSlicerMarkupsPlaceWidget.h>
 #include <qSlicerSaveDataDialog.h>
 #include <qSlicerSubjectHierarchyFolderPlugin.h>
 #include <qSlicerSubjectHierarchyPluginHandler.h>
@@ -47,29 +48,32 @@
 #include <qMRMLThreeDView.h>
 
 // MRML includes
-#include <vtkMRMLScene.h>
-#include <vtkMRMLLinearTransformNode.h>
-#include <vtkMRMLDisplayNode.h>
-#include <vtkMRMLModelNode.h>
-#include <vtkMRMLSegmentationNode.h>
 #include <vtkMRMLCameraNode.h>
-#include <vtkMRMLViewNode.h>
+#include <vtkMRMLDisplayNode.h>
+#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLModelNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSegmentationNode.h>
 #include <vtkMRMLSliceNode.h>
-#include <vtkMRMLTransformNode.h>
 #include <vtkMRMLSubjectHierarchyNode.h>
+#include <vtkMRMLTransformNode.h>
+#include <vtkMRMLViewNode.h>
 
 // Qt includes
+#include <QAction>
 #include <QDebug>
 #include <QDir>
 #include <QFileDialog>
 
 // CTK includes
+#include <ctkColorPickerButton.h>
 #include <ctkMessageBox.h>
 #include <ctkSliderWidget.h>
 
 // VTK includes
 #include <vtkCamera.h>
-#include "vtkCollisionDetectionFilter.h"
+#include <vtkCollisionDetectionFilter.h>
 #include <vtkPolyData.h>
 #include <vtkMatrix4x4.h>
 #include <vtkTransform.h>
@@ -314,6 +318,13 @@ void qSlicerRoomsEyeViewModuleWidget::setParameterNode(vtkMRMLNode *node)
     {
       paramNode->SetPatientBodySegmentID(d->SegmentSelectorWidget_PatientBody->currentSegmentID().toUtf8().constData());
     }
+    // If body is selected, then initialize the table center point fiducial node
+    if (paramNode->GetPatientBodySegmentationNode() && paramNode->GetPatientBodySegmentID())
+    {
+      //TODO: Only auto-place the fiducial if the user has not changed it manually
+      d->logic()->AutoPlaceTableCenterPointFiducialFromPatientBodySegment(paramNode);
+      d->logic()->UpdateTableCenterPointObservers(paramNode);
+    }
   }
 
   this->updateWidgetFromMRML();
@@ -448,8 +459,7 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamNodeChanged(vtkMRMLNode* node)
   for (std::vector<vtkMRMLNode*>::iterator beamIt=beamNodes.begin(); beamIt!=beamNodes.end(); ++beamIt)
   {
     vtkMRMLRTBeamNode* currentBeamNode = vtkMRMLRTBeamNode::SafeDownCast(*beamIt);
-    shNode->SetItemDisplayVisibility(
-      shNode->GetItemByDataNode(currentBeamNode), (currentBeamNode == beamNode ? 1 : 0) );
+    shNode->SetItemDisplayVisibility(shNode->GetItemByDataNode(currentBeamNode), (currentBeamNode == beamNode ? 1 : 0) );
   }
 
   if (!beamNode)
@@ -528,6 +538,9 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientBodySegmentChanged(QString segmen
   paramNode->DisableModifiedEventOn();
   paramNode->SetPatientBodySegmentID(segmentID.toUtf8().constData());
   paramNode->DisableModifiedEventOff();
+
+  // Automatically place table center point fiducial to the posterior center of the patient body segment
+  d->logic()->AutoPlaceTableCenterPointFiducialFromPatientBodySegment(paramNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -818,7 +831,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
 
   // Update IEC transform
   d->logic()->UpdatePatientSupportRotationToFixedReferenceTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
 
   // Update beam parameter
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
@@ -864,7 +877,7 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
 
   d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -893,7 +906,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -924,7 +937,7 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateRASRelatedTransforms(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode));
+  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -1079,8 +1092,7 @@ void qSlicerRoomsEyeViewModuleWidget::setFixedReferenceCameraEnabled(bool toggle
 
   // Get FixedReference -> RAS transform node
   vtkMRMLLinearTransformNode* fixedReferenceToRasTransformNode = d->logic()->GetTransformNodeBetween(
-    vtkIECTransformLogic::FixedReference,
-    vtkIECTransformLogic::RAS);
+    vtkIECTransformLogic::FixedReference, vtkIECTransformLogic::RAS);
 
   vtkNew<vtkMatrix4x4> fixedReferenceToRasTransformMatrix;
   fixedReferenceToRasTransformMatrix->Identity();

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -318,12 +318,10 @@ void qSlicerRoomsEyeViewModuleWidget::setParameterNode(vtkMRMLNode *node)
     {
       paramNode->SetPatientBodySegmentID(d->SegmentSelectorWidget_PatientBody->currentSegmentID().toUtf8().constData());
     }
-    // If body is selected, then initialize the table center point fiducial node
-    if (paramNode->GetPatientBodySegmentationNode() && paramNode->GetPatientBodySegmentID())
+    // Set up POI markups observers if a beam is already selected
+    if (paramNode->GetBeamNode())
     {
-      //TODO: Only auto-place the fiducial if the user has not changed it manually
-      d->logic()->AutoPlaceTableCenterPointFiducialFromPatientBodySegment(paramNode);
-      d->logic()->UpdateTableCenterPointObservers(paramNode);
+      d->logic()->UpdatePlanPOIObservers(paramNode);
     }
   }
 
@@ -393,6 +391,7 @@ void qSlicerRoomsEyeViewModuleWidget::setup()
   connect(d->VerticalTableTopDisplacementSlider, SIGNAL(valueChanged(double)), this, SLOT(onVerticalTableTopDisplacementSliderValueChanged(double)));
   connect(d->LongitudinalTableTopDisplacementSlider, SIGNAL(valueChanged(double)), this, SLOT(onLongitudinalTableTopDisplacementSliderValueChanged(double)));
   connect(d->LateralTableTopDisplacementSlider, SIGNAL(valueChanged(double)), this, SLOT(onLateralTableTopDisplacementSliderValueChanged(double)));
+  connect(d->MovePatientWithTableTopCheckBox, SIGNAL(toggled(bool)), this, SLOT(onMovePatientWithTableTopCheckBoxToggled(bool)));
 
   connect(d->BeamsEyeViewButton, SIGNAL(clicked()), this, SLOT(onBeamsEyeViewButtonClicked()));
 
@@ -470,6 +469,12 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamNodeChanged(vtkMRMLNode* node)
   // Trigger update of transforms based on selected beam
   beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamTransformModified);
 
+  // Sync gantry angle slider from the selected beam
+  d->GantryRotationSlider->setValue(beamNode->GetGantryAngle());
+
+  // Update POI markups observers for the new beam's plan
+  d->logic()->UpdatePlanPOIObservers(paramNode);
+
   // Select patient segmentation
   vtkMRMLRTPlanNode* planNode = beamNode->GetParentPlanNode();
   if (!planNode)
@@ -539,8 +544,75 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientBodySegmentChanged(QString segmen
   paramNode->SetPatientBodySegmentID(segmentID.toUtf8().constData());
   paramNode->DisableModifiedEventOff();
 
-  // Automatically place table center point fiducial to the posterior center of the patient body segment
-  d->logic()->AutoPlaceTableCenterPointFiducialFromPatientBodySegment(paramNode);
+  this->applyTableTopPositionFromBodySegment(paramNode);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerRoomsEyeViewModuleWidget::applyTableTopPositionFromBodySegment(vtkMRMLRoomsEyeViewNode* paramNode)
+{
+  Q_D(qSlicerRoomsEyeViewModuleWidget);
+
+  if (!paramNode)
+  {
+    return;
+  }
+
+  bool autoPositionNeeded = d->MovePatientWithTableTopCheckBox->isChecked() && d->GantryRotationSlider->isEnabled();
+  if (autoPositionNeeded)
+  {
+    d->logic()->SetTableTopBaseline(
+      paramNode->GetLateralTableTopDisplacement(),
+      paramNode->GetLongitudinalTableTopDisplacement(),
+      paramNode->GetVerticalTableTopDisplacement());
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+
+    // Block slider signals so the paramNode->Modified() fired inside
+    // UpdateTableTopDisplacementFromTableTopCenter does not re-enter slider callbacks.
+    d->LateralTableTopDisplacementSlider->blockSignals(true);
+    d->LongitudinalTableTopDisplacementSlider->blockSignals(true);
+    d->VerticalTableTopDisplacementSlider->blockSignals(true);
+  }
+
+  // Recompute the TableTopCenter fiducial — synchronously fires the observer which
+  // calls UpdateTableTopDisplacementFromTableTopCenter and updates paramNode slider values
+  double tableTopCenterRAS[3] = { 0.0, 0.0, 0.0 };
+  bool fiducialOk = d->logic()->CalculateTableTopCenterFromPatientBodySegment(paramNode, tableTopCenterRAS);
+
+  if (autoPositionNeeded)
+  {
+    d->LateralTableTopDisplacementSlider->blockSignals(false);
+    d->LongitudinalTableTopDisplacementSlider->blockSignals(false);
+    d->VerticalTableTopDisplacementSlider->blockSignals(false);
+  }
+
+  // Only auto-position the table top when the mode is active and the machine is loaded
+  if (!d->MovePatientWithTableTopCheckBox->isChecked() || !d->GantryRotationSlider->isEnabled() || !fiducialOk)
+  {
+    return;
+  }
+
+  // The observer already updated paramNode slider values and the IEC table top transform.
+  // Update patient support (required for vertical) and sync the UI sliders.
+  d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
+
+  d->LateralTableTopDisplacementSlider->blockSignals(true);
+  d->LongitudinalTableTopDisplacementSlider->blockSignals(true);
+  d->VerticalTableTopDisplacementSlider->blockSignals(true);
+  d->LateralTableTopDisplacementSlider->setValue(paramNode->GetLateralTableTopDisplacement());
+  d->LongitudinalTableTopDisplacementSlider->setValue(paramNode->GetLongitudinalTableTopDisplacement());
+  d->VerticalTableTopDisplacementSlider->setValue(paramNode->GetVerticalTableTopDisplacement());
+  d->LateralTableTopDisplacementSlider->blockSignals(false);
+  d->LongitudinalTableTopDisplacementSlider->blockSignals(false);
+  d->VerticalTableTopDisplacementSlider->blockSignals(false);
+
+  // Reset the baseline so effective displacement stays zero after auto-positioning
+  // (machine stays at isocenter — no jump when user subsequently moves sliders)
+  d->logic()->SetTableTopBaseline(
+    paramNode->GetLateralTableTopDisplacement(),
+    paramNode->GetLongitudinalTableTopDisplacement(),
+    paramNode->GetVerticalTableTopDisplacement());
+
+  d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -698,6 +770,17 @@ void qSlicerRoomsEyeViewModuleWidget::loadTreatmentMachineFromFile(QString descr
     d->LateralTableTopDisplacementSlider->setMaximum(250.0);
   }
 
+  // Propagate slider limits to paramNode so the logic can clamp displacements from the fiducial
+  if (paramNode)
+  {
+    paramNode->SetLateralTableTopDisplacementMin(d->LateralTableTopDisplacementSlider->minimum());
+    paramNode->SetLateralTableTopDisplacementMax(d->LateralTableTopDisplacementSlider->maximum());
+    paramNode->SetLongitudinalTableTopDisplacementMin(d->LongitudinalTableTopDisplacementSlider->minimum());
+    paramNode->SetLongitudinalTableTopDisplacementMax(d->LongitudinalTableTopDisplacementSlider->maximum());
+    paramNode->SetVerticalTableTopDisplacementMin(d->VerticalTableTopDisplacementSlider->minimum());
+    paramNode->SetVerticalTableTopDisplacementMax(d->VerticalTableTopDisplacementSlider->maximum());
+  }
+
   // Reset camera
   qSlicerApplication* slicerApplication = qSlicerApplication::application();
   slicerApplication->layoutManager()->resetThreeDViews();
@@ -721,6 +804,22 @@ void qSlicerRoomsEyeViewModuleWidget::loadTreatmentMachineFromFile(QString descr
   //TODO: Add new option 'Treatment room' to orientation marker choices and merged model with actual colors (surface scalars?)
   //vtkMRMLViewNode* viewNode = threeDView->mrmlViewNode();
   //viewNode->SetOrientationMarkerHumanModelNodeID(this->mrmlScene()->GetFirstNodeByName("EBRTOrientationMarkerModel")->GetID());
+
+  // Ensure the machine is positioned using effective displacement (current - baseline) before
+  // auto-positioning from segment. BuildRoomsEyeViewTransformHierarchy (called inside
+  // LoadTreatmentMachine) uses actual IEC state, not effective displacement, so when
+  // baseline != 0 the machine ends up at the wrong position until we correct it here.
+  if (d->MovePatientWithTableTopCheckBox->isChecked())
+  {
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+  }
+
+  // If a body segment is already selected and the checkbox is checked, auto-position the table top.
+  // applyTableTopPositionFromBodySegment resets the baseline internally after auto-positioning.
+  if (paramNode->GetPatientBodySegmentationNode() && paramNode->GetPatientBodySegmentID())
+  {
+    this->applyTableTopPositionFromBodySegment(paramNode);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -818,11 +917,6 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
   {
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    return;
-  }
   d->getLayoutManager()->pauseRender();
 
   paramNode->DisableModifiedEventOn();
@@ -831,7 +925,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
 
   // Update IEC transform
   d->logic()->UpdatePatientSupportRotationToFixedReferenceTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
+  d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
 
   // Update beam parameter
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode());
@@ -864,11 +958,6 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
   {
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    return;
-  }
   d->getLayoutManager()->pauseRender();
 
   paramNode->DisableModifiedEventOn();
@@ -877,7 +966,10 @@ void qSlicerRoomsEyeViewModuleWidget::onVerticalTableTopDisplacementSliderValueC
 
   d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
+  if (d->MovePatientWithTableTopCheckBox->isChecked())
+  {
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+  }
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -894,11 +986,6 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   {
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    return;
-  }
   d->getLayoutManager()->pauseRender();
 
   paramNode->DisableModifiedEventOn();
@@ -906,7 +993,10 @@ void qSlicerRoomsEyeViewModuleWidget::onLongitudinalTableTopDisplacementSliderVa
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
+  if (d->MovePatientWithTableTopCheckBox->isChecked())
+  {
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+  }
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
@@ -925,11 +1015,6 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   {
     return;
   }
-  vtkSlicerBeamsModuleLogic* beamsLogic = vtkSlicerBeamsModuleLogic::SafeDownCast(d->logic()->GetModuleLogic("Beams"));
-  if (!beamsLogic)
-  {
-    return;
-  }
   d->getLayoutManager()->pauseRender();
 
   paramNode->DisableModifiedEventOn();
@@ -937,11 +1022,78 @@ void qSlicerRoomsEyeViewModuleWidget::onLateralTableTopDisplacementSliderValueCh
   paramNode->DisableModifiedEventOff();
 
   d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
-  beamsLogic->UpdateFixedReferenceToRASTransform(d->logic()->GetIECLogic(), d->currentPlanNode(paramNode), paramNode->GetTableCenterPointFiducialNode());
+  if (d->MovePatientWithTableTopCheckBox->isChecked())
+  {
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+  }
 
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
   d->getLayoutManager()->resumeRender();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerRoomsEyeViewModuleWidget::onMovePatientWithTableTopCheckBoxToggled(bool checked)
+{
+  Q_D(qSlicerRoomsEyeViewModuleWidget);
+
+  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
+  if (!paramNode || !d->ModuleWindowInitialized)
+  {
+    return;
+  }
+  if (checked)
+  {
+    if (paramNode->GetBeamNode())
+    {
+      QMessageBox::warning(this, tr("Move patient with table top"),
+        tr("There is a plan isocenter defined. By enabling this option you will move this isocenter "
+           "away from the machine isocenter. You can return to matching isocenters any time by turning it back off."));
+    }
+
+    d->MRMLNodeComboBox_Beam->setCurrentNode(nullptr);
+
+    // Capture current slider positions as the baseline so the patient does not jump
+    // when the mode is first enabled. Subsequent movements apply incrementally from here.
+    d->logic()->SetTableTopBaseline(
+      paramNode->GetLateralTableTopDisplacement(),
+      paramNode->GetLongitudinalTableTopDisplacement(),
+      paramNode->GetVerticalTableTopDisplacement());
+  }
+
+  d->logic()->SetMovePatientWithTableTop(checked);
+
+  if (!checked)
+  {
+    // Restore table top sliders and paramNode to the baseline values captured when checking,
+    // so both the table top and the patient return to where they were before the mode was enabled
+    double lat  = d->logic()->GetTableTopBaselineLateral();
+    double longg = d->logic()->GetTableTopBaselineLongitudinal();
+    double vert = d->logic()->GetTableTopBaselineVertical();
+
+    d->LateralTableTopDisplacementSlider->blockSignals(true);
+    d->LongitudinalTableTopDisplacementSlider->blockSignals(true);
+    d->VerticalTableTopDisplacementSlider->blockSignals(true);
+    d->LateralTableTopDisplacementSlider->setValue(lat);
+    d->LongitudinalTableTopDisplacementSlider->setValue(longg);
+    d->VerticalTableTopDisplacementSlider->setValue(vert);
+    d->LateralTableTopDisplacementSlider->blockSignals(false);
+    d->LongitudinalTableTopDisplacementSlider->blockSignals(false);
+    d->VerticalTableTopDisplacementSlider->blockSignals(false);
+
+    paramNode->DisableModifiedEventOn();
+    paramNode->SetLateralTableTopDisplacement(lat);
+    paramNode->SetLongitudinalTableTopDisplacement(longg);
+    paramNode->SetVerticalTableTopDisplacement(vert);
+    paramNode->DisableModifiedEventOff();
+
+    d->logic()->UpdatePatientSupportToPatientSupportRotationTransform(paramNode);
+    d->logic()->UpdateTableTopToTableTopEccentricRotationTransform(paramNode);
+
+    // Resync machine position back to POI-only with table top at baseline
+    d->logic()->UpdateFixedReferenceToRASTransform(paramNode);
+  }
+  // When checking: effective displacement is (current - baseline) = 0, so no position change occurs
 }
 
 //-----------------------------------------------------------------------------

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
@@ -32,6 +32,7 @@
 
 class qSlicerRoomsEyeViewModuleWidgetPrivate;
 class vtkMRMLNode;
+class vtkMRMLRoomsEyeViewNode;
 
 /// \ingroup SlicerRt_QtModules_RoomsEyeView
 class Q_SLICER_QTMODULES_ROOMSEYEVIEW_EXPORT qSlicerRoomsEyeViewModuleWidget :
@@ -80,6 +81,7 @@ protected slots:
   void onVerticalTableTopDisplacementSliderValueChanged(double);
   void onLongitudinalTableTopDisplacementSliderValueChanged(double);
   void onLateralTableTopDisplacementSliderValueChanged(double);
+  void onMovePatientWithTableTopCheckBoxToggled(bool);
 
   void onBeamsEyeViewButtonClicked();
 
@@ -90,6 +92,8 @@ protected slots:
   void onLogicModified();
 
 protected:
+  void applyTableTopPositionFromBodySegment(vtkMRMLRoomsEyeViewNode* paramNode);
+
   QScopedPointer<qSlicerRoomsEyeViewModuleWidgetPrivate> d_ptr;
 
 protected:


### PR DESCRIPTION
Introduces a new dual-mode behavior for the table top displacement sliders, controlled by a new "Move patient with table top" checkbox (default: unchecked).

- Unchecked (new default): sliders move only the table top within the IEC hierarchy; the machine remains anchored to the plan isocenter in RAS.
- Checked (previous behavior): sliders reposition the entire machine in RAS, keeping the table stationary.

To support this, `UpdateFixedReferenceToRASTransform` is now a method on `vtkSlicerRoomsEyeViewModuleLogic`. When `MovePatientWithTableTop` is false, it temporarily zeros the table top displacement before computing machine position (so the machine is placed at the isocenter only), then restores the actual slider values so the table top renders correctly.

Additional changes:
- Replace auto-placement from patient body segment with observers on the plan's POI markups node (isocenter), so machine position tracks it automatically.
- Store slider min/max bounds in `vtkMRMLRoomsEyeViewNode` so the logic can clamp fiducial-driven displacements independently of the UI.
- Rework the table center fiducial (renamed `TableCenterPoint` → `TableTopCenter`): it now auto-positions to the patient body center when a segment is selected, driving the displacement sliders to match (clamped to the slider min/max ranges).
- Selecting a beam now updates the gantry angle slider to match the beam's stored gantry angle.

<img width="1508" height="722" alt="image" src="https://github.com/user-attachments/assets/576e5b81-003e-414a-b0b6-a2f543493bd7" />
