### PR TITLE
BUG: Fix beam's eye view camera orientation and dim machine parts when active

### DIFF
--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -1701,6 +1701,26 @@ const char* vtkSlicerRoomsEyeViewModuleLogic::GetTreatmentMachinePartTypeAsStrin
 }
 
 //---------------------------------------------------------------------------
+void vtkSlicerRoomsEyeViewModuleLogic::SetTreatmentMachinePartsOpacityForBeamsEyeView(
+  vtkMRMLRoomsEyeViewNode* parameterNode, double opacity)
+{
+  if (!parameterNode
+    || !parameterNode->GetTreatmentMachineDescriptorFilePath()
+    || strlen(parameterNode->GetTreatmentMachineDescriptorFilePath()) == 0)
+  {
+    return;
+  }
+  for (TreatmentMachinePartType part : { Gantry, Collimator, TableTop })
+  {
+    vtkMRMLModelNode* model = this->Internal->GetTreatmentMachinePartModelNode(parameterNode, part);
+    if (model && model->GetDisplayNode())
+    {
+      model->GetDisplayNode()->SetOpacity(opacity);
+    }
+  }
+}
+
+//---------------------------------------------------------------------------
 std::string vtkSlicerRoomsEyeViewModuleLogic::GetNameForPartType(std::string partType)
 {
   rapidjson::Value& partObject = this->Internal->GetTreatmentMachinePart(partType);

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.h
@@ -175,6 +175,9 @@ public:
   /// Valid states are "Disabled" (not loaded), "Active" (loaded and collisions computed), "Passive" (loaded but no collisions).
   std::string GetStateForPartType(std::string partType);
 
+  /// Set the opacity of the gantry, collimator, and table top models (used for beam's eye view).
+  void SetTreatmentMachinePartsOpacityForBeamsEyeView(vtkMRMLRoomsEyeViewNode* parameterNode, double opacity);
+
 // Set/get methods
 public:
   /// Get part type as string

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -1156,8 +1156,6 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewButtonClicked()
     cameraNode->SetViewUp(vup);
   }
 
-  cameraNode->GetCamera()->Elevation(-(d->GantryRotationSlider->value()));
-
   //TODO: Oblique slice updating real-time based on beam geometry
   //vtkMRMLSliceNode* redSliceNode = redSliceWidget->mrmlSliceNode();
   //redSliceNode->SetSliceVisible(1);

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -469,6 +469,8 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamNodeChanged(vtkMRMLNode* node)
   // Trigger update of transforms based on selected beam
   beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamTransformModified);
 
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
+
   // Sync gantry angle slider from the selected beam
   d->GantryRotationSlider->setValue(beamNode->GetGantryAngle());
 
@@ -794,6 +796,13 @@ void qSlicerRoomsEyeViewModuleWidget::loadTreatmentMachineFromFile(QString descr
   d->LateralTableTopDisplacementSlider->setEnabled(true);
   d->ImagingPanelMovementSlider->setEnabled(true);
 
+  // If a beam is already selected, sync the gantry (and related) sliders from it
+  vtkMRMLRTBeamNode* selectedBeamNode = paramNode ? vtkMRMLRTBeamNode::SafeDownCast(paramNode->GetBeamNode()) : nullptr;
+  if (selectedBeamNode)
+  {
+    d->GantryRotationSlider->setValue(selectedBeamNode->GetGantryAngle());
+  }
+
   // Hide controls that do not have corresponding parts loaded
   bool imagingPanelsLoaded = (std::find(loadedParts.begin(), loadedParts.end(), vtkSlicerRoomsEyeViewModuleLogic::ImagingPanelLeft) != loadedParts.end() ||
       std::find(loadedParts.begin(), loadedParts.end(), vtkSlicerRoomsEyeViewModuleLogic::ImagingPanelRight) != loadedParts.end());
@@ -879,6 +888,7 @@ void qSlicerRoomsEyeViewModuleWidget::onGantryRotationSliderValueChanged(double 
     beamNode->SetGantryAngle(value);
   }
 
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
   d->getLayoutManager()->resumeRender();
@@ -1097,6 +1107,14 @@ void qSlicerRoomsEyeViewModuleWidget::onMovePatientWithTableTopCheckBoxToggled(b
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerRoomsEyeViewModuleWidget::setMachinePartsOpacityForBeamsEyeView(double opacity)
+{
+  Q_D(qSlicerRoomsEyeViewModuleWidget);
+  vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
+  d->logic()->SetTreatmentMachinePartsOpacityForBeamsEyeView(paramNode, opacity);
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewButtonClicked()
 {
   //TODO: Move feature to beams module
@@ -1155,6 +1173,8 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewButtonClicked()
     }
     cameraNode->SetViewUp(vup);
   }
+
+  this->setMachinePartsOpacityForBeamsEyeView(0.1);
 
   //TODO: Oblique slice updating real-time based on beam geometry
   //vtkMRMLSliceNode* redSliceNode = redSliceWidget->mrmlSliceNode();

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
@@ -93,6 +93,8 @@ protected slots:
 
 protected:
   void applyTableTopPositionFromBodySegment(vtkMRMLRoomsEyeViewNode* paramNode);
+  /// Set opacity of the gantry, collimator, and table top models.
+  void setMachinePartsOpacityForBeamsEyeView(double opacity);
 
   QScopedPointer<qSlicerRoomsEyeViewModuleWidgetPrivate> d_ptr;
 


### PR DESCRIPTION
The beam's eye view in RoomsEyeView had two issues that are fixed in this PR.

The first is a camera orientation bug: when the gantry angle was non-zero, clicking the Beam's Eye View button would place the camera at the wrong position. The beam's world transform already fully encodes the gantry rotation, the source position, focal point, and view-up vector are all computed from it, so the additional `Elevation(-(gantryAngle))` call was double-applying the rotation and moving the camera away from the beam source. The fix is to remove that call.

As a related improvement, the gantry slider is now synced to the selected beam's angle when the treatment machine is loaded, so the machine and beam are always in a consistent state.

The second change improves the usability of the BEV: when the button is clicked, the gantry, collimator, and table top models are dimmed to 10% opacity, so the beam path is not obstructed by the machine geometry. Opacity is restored to 100% when the gantry angle is changed or the beam selection changes.