### PR TITLE
BUG: Fix opacity not being reset after beam selection is None in rooms eye view

### DIFF
--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -461,6 +461,8 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamNodeChanged(vtkMRMLNode* node)
     shNode->SetItemDisplayVisibility(shNode->GetItemByDataNode(currentBeamNode), (currentBeamNode == beamNode ? 1 : 0) );
   }
 
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
+
   if (!beamNode)
   {
     return;
@@ -468,8 +470,6 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamNodeChanged(vtkMRMLNode* node)
 
   // Trigger update of transforms based on selected beam
   beamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamTransformModified);
-
-  this->setMachinePartsOpacityForBeamsEyeView(1.0);
 
   // Sync gantry angle slider from the selected beam
   d->GantryRotationSlider->setValue(beamNode->GetGantryAngle());


### PR DESCRIPTION
In rooms eye view, if you have used the 'Beam's eye view' button, the opacity of the machine is lowered. However, after the beam being set to None it should reset, as it does when changing to other beams or changing the gantry. It does not.

This is fixed by moving the call for the setting the opacity before the guard where it checks if the beam selected is None.