### PR TITLE
ENH: Auto-create body segment and convert segmentation representation in pyRadPlan dose/optimization engine

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -67,6 +67,7 @@ vtkMRMLRTPlanNode::vtkMRMLRTPlanNode()
 vtkMRMLRTPlanNode::~vtkMRMLRTPlanNode()
 {
   this->SetTargetSegmentID(nullptr);
+  this->SetBodySegmentID(nullptr);
   this->SetDoseEngineName(nullptr);
   this->SetPlanOptimizerName(nullptr);
 }
@@ -80,6 +81,7 @@ void vtkMRMLRTPlanNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLIntMacro(NextBeamNumber, NextBeamNumber);
   vtkMRMLWriteXMLStringMacro(TargetSegmentID, TargetSegmentID);
+  vtkMRMLWriteXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLWriteXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLWriteXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
   vtkMRMLWriteXMLFloatMacro(RxDose, RxDose);
@@ -98,6 +100,7 @@ void vtkMRMLRTPlanNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLIntMacro(NextBeamNumber, NextBeamNumber);
   vtkMRMLReadXMLStringMacro(TargetSegmentID, TargetSegmentID);
+  vtkMRMLReadXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLReadXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLReadXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
   vtkMRMLReadXMLFloatMacro(RxDose, RxDose);
@@ -124,6 +127,7 @@ void vtkMRMLRTPlanNode::Copy(vtkMRMLNode *anode)
 
   vtkMRMLCopyBeginMacro(node);
   vtkMRMLCopyStringMacro(TargetSegmentID);
+  vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
   vtkMRMLCopyStringMacro(DoseEngineName);
@@ -164,6 +168,7 @@ void vtkMRMLRTPlanNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
   vtkMRMLCopyBeginMacro(node);
   vtkMRMLCopyFloatMacro(RxDose);
   vtkMRMLCopyStringMacro(TargetSegmentID);
+  vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
   vtkMRMLCopyStringMacro(DoseEngineName);
@@ -181,6 +186,7 @@ void vtkMRMLRTPlanNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintIntMacro(NextBeamNumber);
   vtkMRMLPrintStringMacro(TargetSegmentID);
+  vtkMRMLPrintStringMacro(BodySegmentID);
   vtkMRMLPrintStringMacro(DoseEngineName);
   vtkMRMLPrintStringMacro(PlanOptimizerName);
   vtkMRMLPrintFloatMacro(RxDose);

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -180,6 +180,11 @@ public:
   /// Set target segment ID
   vtkSetStringMacro(TargetSegmentID);
 
+  /// Get body segment ID
+  vtkGetStringMacro(BodySegmentID);
+  /// Set body segment ID
+  vtkSetStringMacro(BodySegmentID);
+
   /// Get isocenter specification
   vtkGetMacro(IsocenterSpecification, vtkMRMLRTPlanNode::IsocenterSpecificationType);
 
@@ -253,6 +258,9 @@ protected:
 
   /// Target segment ID in target segmentation node
   char* TargetSegmentID{ nullptr };
+
+  /// Body segment ID in segmentation node
+  char* BodySegmentID{ nullptr };
 
   /// Isocenter specification determining whether it can be an arbitrary point or
   /// always calculated to be at the center of the target structure

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -32,7 +32,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="sizeConstraint">
-      <enum>QLayout::SetFixedSize</enum>
+      <enum>QLayout::SizeConstraint::SetFixedSize</enum>
      </property>
      <item>
       <widget class="QLabel" name="label_RTPlanNode">
@@ -53,7 +53,7 @@
      <item>
       <widget class="QCheckBox" name="checkBox_IonPlanFlag">
        <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
+        <enum>Qt::LayoutDirection::LeftToRight</enum>
        </property>
        <property name="text">
         <string>Ion plan</string>
@@ -68,32 +68,41 @@
       <string>Plan parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <property name="spacing">
-       <number>4</number>
-      </property>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_Isocenter">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_ReferenceVolume">
         <property name="text">
-         <string>Isocenter:</string>
+         <string>Reference volume:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_ReferenceVolume" native="true">
+        <property name="nodeTypes" stdset="0">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="noneDisplay" stdset="0">
+         <string>Please select node</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_PlanSegmentation">
         <property name="enabled">
          <bool>true</bool>
@@ -103,7 +112,54 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_PlanSegmentation" native="true">
+        <property name="nodeTypes" stdset="0">
+         <stringlist>
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="noneEnabled" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay" stdset="0">
+         <string>Please select node</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_POIs">
+        <property name="text">
+         <string>Points of interest:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_PlanPOIs" native="true">
+        <property name="nodeTypes" stdset="0">
+         <stringlist>
+          <string>vtkMRMLMarkupsFiducialNode</string>
+         </stringlist>
+        </property>
+        <property name="addEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_Isocenter">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="text">
+         <string>Isocenter:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="qMRMLCoordinatesWidget" name="MRMLCoordinatesWidget_IsocenterCoordinates" native="true">
@@ -128,130 +184,30 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_ReferenceVolume" native="true">
-        <property name="nodeTypes" stdset="0">
-         <stringlist>
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="noneDisplay" stdset="0">
-         <string>Please select node</string>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="checkBox_InversePlanning">
+        <property name="text">
+         <string>Inverse Treatment Planning?</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_PlanPOIs" native="true">
-        <property name="nodeTypes" stdset="0">
-         <stringlist>
-          <string>vtkMRMLMarkupsFiducialNode</string>
-         </stringlist>
-        </property>
-        <property name="addEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_PlanSegmentation" native="true">
-        <property name="nodeTypes" stdset="0">
-         <stringlist>
-          <string>vtkMRMLSegmentationNode</string>
-         </stringlist>
-        </property>
-        <property name="noneEnabled" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="noneDisplay" stdset="0">
-         <string>Please select node</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0" colspan="2">
-       <layout class="QGridLayout" name="gridLayout_4">
-        <property name="horizontalSpacing">
-         <number>12</number>
-        </property>
-        <property name="verticalSpacing">
-         <number>4</number>
-        </property>
-        <item row="0" column="4">
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <property name="spacing">
-           <number>8</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Isocenter at target center:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="checkBox_IsocenterAtTargetCenter">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>20</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="4">
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
-          <item>
-           <widget class="QLabel" name="label_RxDose">
-            <property name="text">
-             <string>Rx dose (Gy):</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="doubleSpinBox_RxDose">
-            <property name="maximum">
-             <double>200.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="1" rowspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_9">
+      <item row="5" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
              <widget class="QLabel" name="label_TargetVolume">
               <property name="text">
                <string>Target volume:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_BodyVolume">
+              <property name="text">
+               <string>Body volume:</string>
               </property>
              </widget>
             </item>
@@ -283,6 +239,22 @@
              </widget>
             </item>
             <item>
+             <widget class="qMRMLSegmentSelectorWidget" name="MRMLSegmentSelectorWidget_BodyStructure" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="noneEnabled" stdset="0">
+               <bool>true</bool>
+              </property>
+              <property name="segmentationNodeSelectorVisible" stdset="0">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QComboBox" name="comboBox_DoseEngine">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -296,31 +268,65 @@
           </item>
          </layout>
         </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Isocenter at target center:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBox_IsocenterAtTargetCenter">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="label_RxDose">
+              <property name="text">
+               <string>Rx dose (Gy):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="doubleSpinBox_RxDose">
+              <property name="maximum">
+               <double>200.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
        </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_ReferenceVolume">
-        <property name="text">
-         <string>Reference volume:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_POIs">
-        <property name="text">
-         <string>Points of interest:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="checkBox_InversePlanning">
-        <property name="text">
-         <string>Inverse Treatment Planning?</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
@@ -378,7 +384,7 @@
         <item>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -466,7 +472,7 @@
         <item>
          <spacer name="horizontalSpacer_4">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -564,52 +570,52 @@
        </widget>
       </item>
       <item row="2" column="0">
-      <widget class="QLabel" name="label_DoseGridSpacing">
+       <widget class="QLabel" name="label_DoseGridSpacing">
         <property name="text">
-        <string>Dose grid spacing:</string>
+         <string>Dose grid spacing:</string>
         </property>
-      </widget>
+       </widget>
       </item>
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_DoseGrid">
         <item>
-          <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingX">
-          <property name="value">
-            <number>5</number>
-          </property>
+         <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingX">
           <property name="minimum">
-            <number>0.01</number>
+           <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-            <number>100</number>
+           <double>100.000000000000000</double>
           </property>
-          </widget>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+         </widget>
         </item>
         <item>
-          <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingY">
-          <property name="value">
-            <number>5</number>
-          </property>
+         <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingY">
           <property name="minimum">
-            <number>0.01</number>
+           <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-            <number>100</number>
+           <double>100.000000000000000</double>
           </property>
-          </widget>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+         </widget>
         </item>
         <item>
-          <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingZ">
-          <property name="value">
-            <number>5</number>
-          </property>
+         <widget class="QDoubleSpinBox" name="doubleSpinBox_DoseGridSpacingZ">
           <property name="minimum">
-            <number>0.01</number>
+           <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-            <number>100</number>
+           <double>100.000000000000000</double>
           </property>
-          </widget>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_UseCTGridForDoseGridSpacing">
@@ -629,7 +635,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0,0,0">
      <property name="sizeConstraint">
-      <enum>QLayout::SetFixedSize</enum>
+      <enum>QLayout::SizeConstraint::SetFixedSize</enum>
      </property>
      <item>
       <widget class="QLabel" name="label_CalculateDoseStatus">
@@ -641,7 +647,6 @@
        </property>
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -700,7 +705,6 @@
       <widget class="QLabel" name="label_OptimizationStatus">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -708,7 +712,7 @@
         <string>Status Information here</string>
        </property>
        <property name="textFormat">
-        <enum>Qt::PlainText</enum>
+        <enum>Qt::TextFormat::PlainText</enum>
        </property>
       </widget>
      </item>
@@ -907,6 +911,22 @@
   <connection>
    <sender>qSlicerExternalBeamPlanningModule</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLSegmentSelectorWidget_BodyStructure</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>182</x>
+     <y>3</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>192</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerExternalBeamPlanningModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>MRMLCoordinatesWidget_IsocenterCoordinates</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
@@ -921,4 +941,7 @@
    </hints>
   </connection>
  </connections>
+ <slots>
+  <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+ </slots>
 </ui>

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/pyRadPlanEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/pyRadPlanEngine.py
@@ -16,6 +16,7 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
     scriptedEngine.name = 'pyRadPlan'
     scriptedEngine.isInverse = True #pyRadPlan has Inverse planning capabilities, i.e., it can compute a dose influence matrix
     scriptedEngine.canDoIonPlan = True
+    scriptedEngine.supportsBodySegment = True
     AbstractScriptedDoseEngine.__init__(self, scriptedEngine)
 
   #------------------------------------------------------------------------------
@@ -35,15 +36,15 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
   #------------------------------------------------------------------------------
   def updateBeamParametersForIonPlan(self, isIonPlanActive):
     if isIonPlanActive:
-      available_radiation_modes = ["protons", "carbons"]
-      parameter_label = "radiation mode (ion)"
+      availableRadiationModes = ["protons", "carbons"]
+      parameterLabel = "radiation mode (ion)"
     else:
-      available_radiation_modes = ["photons", "protons", "carbons"]
-      parameter_label = "radiation mode"
+      availableRadiationModes = ["photons", "protons", "carbons"]
+      parameterLabel = "radiation mode"
     
     self.scriptedEngine.updateBeamParameterComboBox(
-    "pyRadPlan parameters", "radiationMode", parameter_label,
-    "comment", available_radiation_modes, 0)
+    "pyRadPlan parameters", "radiationMode", parameterLabel,
+    "comment", availableRadiationModes, 0)
 
   #------------------------------------------------------------------------------
   def calculateDoseUsingEngine(self, beamNode, resultDoseVolumeNode):
@@ -54,39 +55,37 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
       calc_dose_influence
     )
 
-    logging.basicConfig(level=logging.INFO)
-
 
     ##################################### Prepare data structures ########################################
     # Prepare the ct
-    t_start = time.time()
+    tStart = time.time()
     ct = prepareCt(beamNode)
-    t_end = time.time()
-    print(f"Time to prepare CT: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to prepare CT: {tEnd - tStart}")
 
     # Prepare the cst (segmentations)
-    t_start = time.time()
+    tStart = time.time()
     cst = prepareCst(beamNode, ct)
-    t_end = time.time()
-    print(f"Time to prepare CST: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to prepare CST: {tEnd - tStart}")
 
     # Prepare the plan configuration
-    t_start = time.time()
+    tStart = time.time()
     pln = preparePln(beamNode, ct)
-    t_end = time.time()
-    print(f"Time to prepare PLN: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to prepare PLN: {tEnd - tStart}")
 
     # Generate Steering Geometry ("stf")
-    t_start = time.time()
+    tStart = time.time()
     stf = generate_stf(ct, cst, pln)
-    t_end = time.time()
-    print(f"Time to generate STF: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to generate STF: {tEnd - tStart}")
 
     # Calculate Dose Influence Matrix ("dij")
-    t_start = time.time()
+    tStart = time.time()
     dij = calc_dose_influence(ct, cst, stf, pln)
-    t_end = time.time()
-    print(f"Time to calculate Dij: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to calculate Dij: {tEnd - tStart}")
 
 
     ##################################### Visualize dose in Slicer #######################################
@@ -100,7 +99,7 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
 
     # Push total dose to volumeNode in Slicer, set name & overlay on CT
     sitkUtils.PushVolumeToSlicer(totalDose, targetNode = resultDoseVolumeNode)
-    resultDoseNodeName = str(planNode.GetName())+"_pyRadDose_" + beamNode.GetName()
+    resultDoseNodeName = str(planNode.GetName())+"_pyRadPlanDose_" + beamNode.GetName()
     resultDoseVolumeNode.SetName(resultDoseNodeName)
     slicer.util.setSliceViewerLayers(background=referenceVolumeNode, foreground=resultDoseVolumeNode)
     slicer.util.setSliceViewerLayers(foregroundOpacity=1)
@@ -116,52 +115,50 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
       calc_dose_influence
     )
 
-    logging.basicConfig(level=logging.INFO)
 
-        
     ##################################### Prepare data structures ########################################
     # Prepare the ct
-    t_start = time.time()
+    tStart = time.time()
     ct = prepareCt(beamNode)
-    t_end = time.time()
-    print(f"Time to prepare CT: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to prepare CT: {tEnd - tStart}")
 
     # Prepare the cst (segmentations)
-    t_start = time.time()
-    cst = prepareCst(beamNode, ct)
-    t_end = time.time()
-    print(f"Time to prepare CST: {t_end - t_start}")
+    tStart = time.time()
+    cst = prepareCst(beamNode, ct, needBody=True)
+    tEnd = time.time()
+    logging.info(f"Time to prepare CST: {tEnd - tStart}")
 
     # Prepare the plan configuration
-    t_start = time.time()
+    tStart = time.time()
     pln = preparePln(beamNode, ct)
-    t_end = time.time()
-    print(f"Time to prepare PLN: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to prepare PLN: {tEnd - tStart}")
 
     # Generate Steering Geometry ("stf")
-    t_start = time.time()
+    tStart = time.time()
     stf = generate_stf(ct, cst, pln)
-    t_end = time.time()
-    print(f"Time to generate STF: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to generate STF: {tEnd - tStart}")
 
     # Calculate Dose Influence Matrix ("dij")
-    t_start = time.time()
+    tStart = time.time()
     dij = calc_dose_influence(ct, cst, stf, pln)
-    t_end = time.time()
-    print(f"Time to calculate Dij: {t_end - t_start}")
+    tEnd = time.time()
+    logging.info(f"Time to calculate Dij: {tEnd - tStart}")
 
 
     ###################################### Store dose in beamNode ########################################
 
     # Optimize storage such that we don't have multiple instances in memory
     # we use a coo matrix here as it is the most efficient way to get the matrix into slicer
-    dose_matrix = coo_matrix(dij.physical_dose.flat[0])
+    doseMatrix = coo_matrix(dij.physical_dose.flat[0])
 
     beamNode.SetDoseInfluenceMatrixFromTriplets(
-      dose_matrix.shape[0], dose_matrix.shape[1],
-      dose_matrix.row,
-      dose_matrix.col,
-      dose_matrix.data,
+      doseMatrix.shape[0], doseMatrix.shape[1],
+      doseMatrix.row,
+      doseMatrix.col,
+      doseMatrix.data,
       dij.dose_grid.dimensions, #set dimensions of dose grid in beamNode for which the dose influence matrix is defined
       dij.dose_grid.resolution_vector #set spacing of dose grid in beamNode for which the dose influence matrix is defined
     )

--- a/ExternalBeamPlanning/Widgets/Python/PlanOptimizers/pyRadPlanPlanOptimizer.py
+++ b/ExternalBeamPlanning/Widgets/Python/PlanOptimizers/pyRadPlanPlanOptimizer.py
@@ -22,20 +22,20 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
     """
 
     from pyRadPlan.optimization.objectives import get_available_objectives
-    availableObjectives_dict = {}
+    availableObjectivesDict = {}
 
-    for obj_name, obj_class in get_available_objectives().items():
-      obj_instance = obj_class()
-      parameter_dict = {}
-      parameterNames = obj_instance.parameter_names
-      parameterDefaultValues = obj_instance.parameters
+    for objName, objClass in get_available_objectives().items():
+      objInstance = objClass()
+      parameterDict = {}
+      parameterNames = objInstance.parameter_names
+      parameterDefaultValues = objInstance.parameters
       for i in range(len(parameterNames)):
-          parameter_dict[parameterNames[i]] = {
+          parameterDict[parameterNames[i]] = {
               "default": parameterDefaultValues[i],
           }
-      availableObjectives_dict[obj_name] = parameter_dict
+      availableObjectivesDict[objName] = parameterDict
 
-    return availableObjectives_dict
+    return availableObjectivesDict
 
   #------------------------------------------------------------------------------
   def optimizePlanUsingOptimizer(self, planNode, objectives, resultOptimizationVolumeNode):
@@ -48,57 +48,65 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
     from pyRadPlan.dij import Dij, compose_beam_dijs
     from pyRadPlan.optimization.objectives import get_objective
 
-    logging.basicConfig(level=logging.INFO)
 
     ########################### Get objectives from Slicer objectives table ##############################
-    objectives_dict = {}
+    objectivesDict = {}
 
     # Loop through all objectives in the Slicer objectives table
-    for node_dict in objectives:
+    for nodeDict in objectives:
 
       # Get objective node
-      objective_node = node_dict['ObjectiveNode']
-      if not objective_node:
+      objectiveNode = nodeDict['ObjectiveNode']
+      if not objectiveNode:
         raise ValueError("Objective node is not set. Please select an objective node in the Slicer objectives table.")
 
       # Get segmentation
-      segmentationNode = objective_node.GetSegmentationNode()
+      segmentationNode = objectiveNode.GetSegmentationNode()
       if not segmentationNode:
         raise ValueError("Segmentation node is not set for objective node. Please select a segmentation node in the Slicer objectives table.")
-      segmentID = objective_node.GetSegmentID()
+      segmentID = objectiveNode.GetSegmentID()
       if not segmentID:
         raise ValueError("Segment ID is not set for objective node. Please select a segment in the Slicer objectives table.")
       segmentName = segmentationNode.GetSegmentation().GetSegment(segmentID).GetName()
 
       # Get objective information
-      objective_info = {
-        'objectiveName': objective_node.GetName(),
-        'overlapPriority': objective_node.GetAttribute('overlapPriority'),
-        'penalty': objective_node.GetAttribute('penalty'),
-        'parameters': {name: objective_node.GetAttribute(name) for name in objective_node.GetAttributeNames() if name != 'overlapPriority' and name != 'penalty'}
+      objectiveInfo = {
+        'objectiveName': objectiveNode.GetName(),
+        'overlapPriority': objectiveNode.GetAttribute('overlapPriority'),
+        'penalty': objectiveNode.GetAttribute('penalty'),
+        'parameters': {name: objectiveNode.GetAttribute(name) for name in objectiveNode.GetAttributeNames() if name != 'overlapPriority' and name != 'penalty'}
       }
 
       # Save objectives for each segmentation
-      if segmentName not in objectives_dict:
-        objectives_dict[segmentName] = [objective_info]
+      if segmentName not in objectivesDict:
+        objectivesDict[segmentName] = [objectiveInfo]
       else:
-        objectives_dict[segmentName].append(objective_info)
+        objectivesDict[segmentName].append(objectiveInfo)
 
+    msg = "Objectives extracted from Slicer objectives table:\n"
+    for segmentName, objectivesList in objectivesDict.items():
+        msg += f"  Segment: {segmentName}\n"
+        for objectiveInfo in objectivesList:
+            msg += f"    Objective: {objectiveInfo['objectiveName']}\n"
+            msg += f"      Overlap Priority: {objectiveInfo['overlapPriority']}\n"
+            msg += f"      Penalty: {objectiveInfo['penalty']}\n"
+            msg += f"      Parameters: {objectiveInfo['parameters']}\n"
+    logging.info(msg)
 
     ###################################### Get overlap priorites #########################################
-    overlap_priority_dict = {}
+    overlapPriorityDict = {}
 
-    # Extract overlap priorities from objectives_dict (saved for each objective, but needed for each VOI)
-    for voi_name, objectives_list in objectives_dict.items():
+    # Extract overlap priorities from objectivesDict (saved for each objective, but needed for each VOI)
+    for voiName, objectivesList in objectivesDict.items():
 
       # Take first overlap priority for each VOI
-      overlap_priority = objectives_list[0]['overlapPriority']
-      overlap_priority_dict[voi_name] = overlap_priority
+      overlapPriority = objectivesList[0]['overlapPriority']
+      overlapPriorityDict[voiName] = overlapPriority
 
       # Check if all objectives for this VOI have the same overlap priority
-      for objective in objectives_list:
-        if objective['overlapPriority'] != overlap_priority:
-          raise ValueError(f"Overlap priorities do not match for VOI '{voi_name}' in objectives table. All objectives for a VOI must have the same overlap priority.")
+      for objective in objectivesList:
+        if objective['overlapPriority'] != overlapPriority:
+          raise ValueError(f"Overlap priorities do not match for VOI '{voiName}' in objectives table. All objectives for a VOI must have the same overlap priority.")
 
 
     ############################ Get dose influence matrices from beam nodes #############################
@@ -106,26 +114,26 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
 
     # Get beams in plan
     numberOfBeams = planNode.GetNumberOfBeams()
-    beam_names = []
-    tried_beam_index = 0
-    while (len(beam_names) < numberOfBeams):
+    beamNames = []
+    triedBeamIndex = 0
+    while (len(beamNames) < numberOfBeams):
       try:
-        beam = planNode.GetBeamByNumber(tried_beam_index)
-        beam_names.append(beam.GetName())
-        tried_beam_index += 1
+        beam = planNode.GetBeamByNumber(triedBeamIndex)
+        beamNames.append(beam.GetName())
+        triedBeamIndex += 1
       except:
-        tried_beam_index += 1
+        triedBeamIndex += 1
 
     # Get dij of each beam
-    dij_list = []
-    beam_index = 0
-    for beam_name in beam_names:
+    dijList = []
+    beamIndex = 0
+    for beamName in beamNames:
 
-      beam_index += 1
-      self.scriptedPlanOptimizer.progressInfoUpdated("get dijs ("+ str(beam_index) + "/" + str(numberOfBeams) + ")")
+      beamIndex += 1
+      self.scriptedPlanOptimizer.progressInfoUpdated("get dijs ("+ str(beamIndex) + "/" + str(numberOfBeams) + ")")
 
-      beamNode = planNode.GetBeamByName(beam_name)
-      print('current beam: ', beam_name)
+      beamNode = planNode.GetBeamByName(beamName)
+      logging.info(f"Processing beam: {beamName}")
 
       # Prepare the ct
       ct = prepareCt(beamNode)
@@ -134,70 +142,70 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
       cst = prepareCst(beamNode, ct)
 
       # Prepare the plan configuration
-      pln = preparePln(beamNode, ct, dose_grid_from_beamNode=True)
+      pln = preparePln(beamNode, ct, doseGridFromBeamNode=True)
 
       # Generate Steering Geometry ("stf")
       stf = generate_stf(ct, cst, pln)
 
       # Get Dose Influence Matrix (coo_matrix)
-      field_data = beamNode.GetDoseInfluenceMatrixFieldData()
-      data = np.array(field_data.GetArray('Data'), dtype=np.float32)
-      indices = np.array(field_data.GetArray('Indices'), dtype=np.int32)
-      indptr = np.array(field_data.GetArray('Indptr'), dtype=np.int32)
+      fieldData = beamNode.GetDoseInfluenceMatrixFieldData()
+      data = np.array(fieldData.GetArray('Data'), dtype=np.float32)
+      indices = np.array(fieldData.GetArray('Indices'), dtype=np.int32)
+      indptr = np.array(fieldData.GetArray('Indptr'), dtype=np.int32)
 
       # Convert to csc_matrix
-      num_of_cols = len(indptr) - 1
-      number_of_voxels = pln.prop_dose_calc['dose_grid'].num_voxels
-      dose_influence_matrix = csc_matrix((data, indices, indptr), shape=(number_of_voxels, num_of_cols))
+      numOfCols = len(indptr) - 1
+      numberOfVoxels = pln.prop_dose_calc['dose_grid'].num_voxels
+      doseInfluenceMatrix = csc_matrix((data, indices, indptr), shape=(numberOfVoxels, numOfCols))
 
       # Create Dij object
       dij = Dij(
         dose_grid=pln.prop_dose_calc['dose_grid'],
         ct_grid=ct.grid,
-        physical_dose=dose_influence_matrix,
+        physical_dose=doseInfluenceMatrix,
         num_of_beams = 1,
         beam_num=stf.bixel_beam_index_map,
         ray_num=stf.bixel_ray_index_per_beam_map,
         bixel_num=stf.bixel_index_per_beam_map
       )
 
-      dij_list.append(dij)
+      dijList.append(dij)
 
     # Compose dij from all beams
-    if len(dij_list) > 1:
-      dij = compose_beam_dijs(dij_list)
+    if len(dijList) > 1:
+      dij = compose_beam_dijs(dijList)
     else:
-      dij = dij_list[0]
+      dij = dijList[0]
 
 
     ########################### Update overlap priorities & objectives in cst ############################
     for voi in cst.vois:
 
-      if voi.name in objectives_dict:
+      if voi.name in objectivesDict:
         voi.objectives = []
 
         # Set overlap priority for VOI
-        voi.overlap_priority = overlap_priority_dict[voi.name]
+        voi.overlap_priority = overlapPriorityDict[voi.name]
 
-        for i in range(len(objectives_dict[voi.name])):
-          objective_name = objectives_dict[voi.name][i]['objectiveName']
-          objective_parameters = objectives_dict[voi.name][i]['parameters']
+        for i in range(len(objectivesDict[voi.name])):
+          objectiveName = objectivesDict[voi.name][i]['objectiveName']
+          objectiveParameters = objectivesDict[voi.name][i]['parameters']
 
           # Get instance of objective function from pyRadPlan
-          objective_instance = get_objective(objective_name)
+          objectiveInstance = get_objective(objectiveName)
 
           # Set penalty (called "priority" in pyRadPlan) for objective function
-          objective_instance.priority = objectives_dict[voi.name][i]['penalty']
+          objectiveInstance.priority = objectivesDict[voi.name][i]['penalty']
 
           # Set parameters for objective function
-          for parameter in objective_instance.parameter_names:
-            if parameter in objective_parameters:
+          for parameter in objectiveInstance.parameter_names:
+            if parameter in objectiveParameters:
               # TODO: type check
-              setattr(objective_instance, parameter, objective_parameters[parameter])
+              setattr(objectiveInstance, parameter, objectiveParameters[parameter])
             else:
-              print(f"Parameter {parameter} not found in objectives table.")
-              print(f"Using default value: {getattr(objective_instance, parameter)}")
-          voi.objectives.append(objective_instance)
+              logging.warning(f"Parameter {parameter} not found in objectives table. "
+                              f"Using default value: {getattr(objectiveInstance, parameter)}")
+          voi.objectives.append(objectiveInstance)
 
 
     ########################################## Optimize dose #############################################
@@ -212,41 +220,44 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
     ##################################### Visualize dose in Slicer #######################################
     self.scriptedPlanOptimizer.progressInfoUpdated("visualize dose")
 
-    total_dose = result["physical_dose"]
+    # Get global variables for dose volume node naming and hierarchy placement
+    shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
+    planItemID = shNode.GetItemByDataNode(planNode)
+    rxDose = planNode.GetRxDose()
 
-    # TODO: directly get dose per beam from overlay=result.beam_quantities["physical_dose"][0].distribution (once result_gui is merged)
-    # Now: manually get dose per beam and create a new volume node for each beam
-    for i in range(planNode.GetNumberOfBeams()):
-      mask = (dij.beam_num == i)
-      fluence_for_beam = np.zeros_like(fluence)
-      fluence_for_beam[mask] = fluence[mask]
-      result_for_beam = dij.compute_result_ct_grid(fluence_for_beam)
-      dose_per_beam = result_for_beam["physical_dose"]
+    # Get dose for each and beam
+    if (planNode.GetNumberOfBeams() > 1):
+      for i, beamName in enumerate(beamNames):
+        # Create a new volume node for each beam
+        beamDoseVolumeNodeName = f'{planNode.GetName()}_pyRadPlanOptimized_physicalDose_{beamName}'
+        beamDoseVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", beamDoseVolumeNodeName)
+        displayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeDisplayNode")
+        beamDoseVolumeNode.SetAndObserveDisplayNodeID(displayNode.GetID())
+        sitkUtils.PushVolumeToSlicer(result['physical_dose_beam'][i], beamDoseVolumeNode)
 
-      # Create a new volume node for each beam
-      beamDoseVolumeNodeName = f'{planNode.GetName()}_pyRadOptimizedDose_Beam_{i+1}'
-      beamDoseVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", beamDoseVolumeNodeName)
-      displayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeDisplayNode")
-      beamDoseVolumeNode.SetAndObserveDisplayNodeID(displayNode.GetID())
+        # Place under the plan in the hierarchy
+        itemID = shNode.GetItemByDataNode(beamDoseVolumeNode)
+        shNode.SetItemParent(itemID, planItemID)
 
-      sitkUtils.PushVolumeToSlicer(dose_per_beam, beamDoseVolumeNode)
+        # Tag & trigger re-evaluation as dose volume
+        shNode.SetItemAttribute(itemID, 'DoseUnitName', "Gy")
+        shNode.SetItemAttribute(itemID, 'DoseUnitValue', "1.0")
+        beamDoseVolumeNode.SetAttribute("DicomRtImport.DoseVolume", "1")
+        shNode.RequestOwnerPluginSearch(itemID)
+        shNode.ItemModified(itemID)
 
-      # Set colormap
-      rxDose = planNode.GetRxDose()
-      displayNode = beamDoseVolumeNode.GetDisplayNode()
-      displayNode.SetAndObserveColorNodeID("vtkMRMLColorTableNodeDose_ColorTable_Relative")
-      displayNode.AutoWindowLevelOn()
-      displayNode.SetLowerThreshold(0.05*rxDose)
-      displayNode.ApplyThresholdOn()
+        # Set colormap
+        displayNode.SetAndObserveColorNodeID("vtkMRMLColorTableNodeDose_ColorTable_Relative")
+        displayNode.AutoWindowLevelOn()
+        displayNode.SetLowerThreshold(0.05*rxDose)
+        displayNode.ApplyThresholdOn()
 
-    # Push total dose to volumeNode in Slicer
-    sitkUtils.PushVolumeToSlicer(total_dose, targetNode = resultOptimizationVolumeNode)
-
-    # Set name of result volume node
+    # Push total dose to volumeNode in Slicer, set name & overlay on CT
+    sitkUtils.PushVolumeToSlicer(result["physical_dose"], targetNode = resultOptimizationVolumeNode)
     try:
       resultOptimizationVolumeNodeName = planNode.GetOutputTotalDoseVolumeNode().GetName()
     except AttributeError:
-      resultOptimizationVolumeNodeName = str(planNode.GetName())+"_pyRadOptimizedDose"
+      resultOptimizationVolumeNodeName = str(planNode.GetName())+"_pyRadPlanOptimized_physicalDose"
     resultOptimizationVolumeNode.SetName(resultOptimizationVolumeNodeName)
 
     return str()

--- a/ExternalBeamPlanning/Widgets/Python/PlanOptimizers/pyRadPlanPlanOptimizer.py
+++ b/ExternalBeamPlanning/Widgets/Python/PlanOptimizers/pyRadPlanPlanOptimizer.py
@@ -84,6 +84,15 @@ class pyRadPlanPlanOptimizer(AbstractScriptedPlanOptimizer):
       else:
         objectives_dict[segmentName].append(objective_info)
 
+    print("Objectives extracted from Slicer objectives table:\n")
+    for segmentName, objectives_list in objectives_dict.items():
+      print(f"Segment: {segmentName}")
+      for objective_info in objectives_list:
+        print(f"  Objective: {objective_info['objectiveName']}")
+        print(f"    Overlap Priority: {objective_info['overlapPriority']}")
+        print(f"    Penalty: {objective_info['penalty']}")
+        print(f"    Parameters: {objective_info['parameters']}\n")
+
 
     ###################################### Get overlap priorites #########################################
     overlap_priority_dict = {}

--- a/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
+++ b/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
@@ -2,11 +2,12 @@ import numpy as np
 import logging
 import slicer
 import sitkUtils
+import SimpleITK as sitk
+import vtkSegmentationCorePython as vtkSegmentationCore
 
 #------------------------------------------------------------------------------
 def prepareCt(beamNode):
   from pyRadPlan.ct import create_ct
-  logging.basicConfig(level=logging.INFO)
 
   # Get sitk image from Slicer
   planNode = beamNode.GetParentPlanNode()
@@ -17,9 +18,8 @@ def prepareCt(beamNode):
   return create_ct(cube_hu=image)
 
 #------------------------------------------------------------------------------
-def prepareCst(beamNode, ct):
-  from pyRadPlan.cst import StructureSet, create_voi
-  logging.basicConfig(level=logging.INFO)
+def prepareCst(beamNode, ct, needBody=False):
+  from pyRadPlan.cst import StructureSet, create_voi, validate_cst
 
   # Get segmentations from Slicer
   planNode = beamNode.GetParentPlanNode()
@@ -27,25 +27,38 @@ def prepareCst(beamNode, ct):
   segmentationNode = planNode.GetSegmentationNode()
   segmentation = segmentationNode.GetSegmentation()
 
+  if planNode.GetTargetSegmentID() == "":
+    raise ValueError("No target segment selected in plan node. Please select a target segment and try again.")
+  if planNode.GetTargetSegmentID() == planNode.GetBodySegmentID():
+    raise ValueError("Target segment and body segment are the same. Please select a different target segment or body segment and try again.")
+
+  # Get arrays for all segments in segmentation node (convert to binary labelmap if necessary)
+  segmentArrays = getSegmentArrays(segmentationNode, referenceVolumeNode)
+
   # Create VOI objects from segments
   vois = []
   for id in segmentation.GetSegmentIDs():
-    segmentArray = slicer.util.arrayFromSegmentBinaryLabelmap(segmentationNode, id, referenceVolumeNode)
-    segmentArray = np.uint8(segmentArray)
-    segmentName = segmentation.GetSegment(id).GetName()
-    # Set VOI type as 'TARGET' if segment is selected as target, otherwise 'OAR'
-    voi_type = 'TARGET' if id==planNode.GetTargetSegmentID() else 'OAR'
-    voi = create_voi(voi_type=voi_type, name=segmentName, ct_image=ct, mask=segmentArray)
+    segmentArray = segmentArrays[id]['array']
+    segmentName = segmentArrays[id]['name']
+    voiType = 'OAR'
+    if id == planNode.GetBodySegmentID():
+      voiType = 'EXTERNAL'
+    if id == planNode.GetTargetSegmentID(): # overwrite if also selected as body
+      voiType = 'TARGET'
+    voi = create_voi(voi_type=voiType, name=segmentName, ct_image=ct, mask=segmentArray)
     vois.append(voi)
 
   # Create cst object from VOIs and ct
   cst = StructureSet(vois=vois, ct_image=ct)
-  return cst
+
+  if needBody:
+    createAndLoadBodySegment(planNode, cst)
+    
+  return validate_cst(cst)
 
 #------------------------------------------------------------------------------
-def preparePln(beamNode, ct, dose_grid_from_beamNode=False):
+def preparePln(beamNode, ct, doseGridFromBeamNode=False):
   from pyRadPlan.plan import create_pln
-  logging.basicConfig(level=logging.INFO)
   
   # Get isocenter position in RAS coordinates from Slicer
   planNode = beamNode.GetParentPlanNode()
@@ -57,39 +70,39 @@ def preparePln(beamNode, ct, dose_grid_from_beamNode=False):
   isocenter = ijkToRASDirections @ np.array(isocenter)
 
   # Get dose grid by resampling ct grid to resolution defined in beamNode or planNode
-  if dose_grid_from_beamNode:
+  if doseGridFromBeamNode:
     # Get dose grid specs saved in beamNode (corresponding to saved dose influence matrix)
     doseGridSpacing = beamNode.GetDoseGridSpacing()
     doseGridDimensions = beamNode.GetDoseGridDim()
     # Check if dose influence matrix is available in beamNode
     if beamNode.GetDoseInfluenceMatrixFieldData() is None:
-      print("Warning: No dose influence matrix found in beamNode. Using planNode's dose grid spacing.")
+      logging.warning("No dose influence matrix found in beamNode. Using planNode's dose grid spacing.")
       doseGridSpacing = planNode.GetDoseGridSpacing()
     # Check if dose grid spacing was set in beamNode (default: {-1, -1, -1})
     if doseGridSpacing[0] < 0 or doseGridSpacing[1] < 0 or doseGridSpacing[2] < 0 :
-      print("Warning: Dose grid spacing in beamNode is invalid. Using planNode's dose grid spacing.")
+      logging.warning("Dose grid spacing in beamNode is invalid. Using planNode's dose grid spacing.")
       doseGridSpacing = planNode.GetDoseGridSpacing()
-    dose_grid = ct.grid.copy().resample(target_resolution=doseGridSpacing)
+    doseGrid = ct.grid.model_copy().resample(target_resolution=doseGridSpacing)
     # Set new dose grid spacing in planNode if necessary
     if doseGridSpacing != planNode.GetDoseGridSpacing():
       planNode.SetDoseGridSpacing(doseGridSpacing)
     # Check if dose grid dimensions match for doseGrid dimensions in beamNode
-    if (dose_grid.dimensions != doseGridDimensions):
-      print("Warning: Dose grid dimensions in beamNode do not match the calculated dose grid dimensions.")
+    if (doseGrid.dimensions != doseGridDimensions):
+      logging.warning("Dose grid dimensions in beamNode do not match the calculated dose grid dimensions.")
   else:
-    dose_grid = ct.grid.copy().resample(target_resolution=planNode.GetDoseGridSpacing())
+    doseGrid = ct.grid.copy().resample(target_resolution=planNode.GetDoseGridSpacing())
 
   # Get radiation mode from beamNode
   if planNode.GetIonPlanFlag():
-    available_radiation_modes = ['protons', 'carbon']
+    availableRadiationModes = ['protons', 'carbon']
   else:
-    available_radiation_modes = ['photons', 'protons', 'carbon']
-  radiation_mode = slicer.pyRadPlanEngine.scriptedEngine.integerParameter(beamNode, 'radiationMode')
+    availableRadiationModes = ['photons', 'protons', 'carbon']
+  radiationMode = slicer.pyRadPlanEngine.scriptedEngine.integerParameter(beamNode, 'radiationMode')
 
 
   # Create plan object from dictionary
   pln = {
-    "radiation_mode": available_radiation_modes[radiation_mode],
+    "radiation_mode": availableRadiationModes[radiationMode],
     "machine": ['Generic'][slicer.pyRadPlanEngine.scriptedEngine.integerParameter(beamNode, 'machine')],
     "num_of_fractions": slicer.pyRadPlanEngine.scriptedEngine.doubleParameter(beamNode, 'numOfFractions'),
     "prop_stf": {
@@ -101,7 +114,7 @@ def preparePln(beamNode, ct, dose_grid_from_beamNode=False):
     },
 
     # Dose calculation settings
-    "prop_dose_calc": {"dose_grid": dose_grid},
+    "prop_dose_calc": {"dose_grid": doseGrid},
 
     # Optimization settings
     "prop_opt": {},
@@ -112,3 +125,115 @@ def preparePln(beamNode, ct, dose_grid_from_beamNode=False):
     pln["prop_opt"] = {"solver": "scipy"}
 
   return create_pln(pln)
+
+
+#------------------------------------------------------------------------------
+# HELPERS
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+def getSegmentArrays(segmentationNode, referenceVolumeNode):
+  """
+  Extract binary labelmap arrays from all segments in a segmentation node.
+  Converts segments to binary labelmap representation if necessary.
+  
+  Args:
+    segmentationNode: Slicer segmentation node containing segments
+    referenceVolumeNode: Reference volume node for array orientation
+    
+  Returns:
+    Dictionary mapping segment IDs to their arrays and names
+  """
+  segmentation = segmentationNode.GetSegmentation()
+  
+  PLANAR_CONTOUR = vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationPlanarContourRepresentationName()
+  RIBBON_MODEL   = "Ribbon model"
+  LABELMAP       = vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()
+
+  firstSegment = segmentation.GetSegment(segmentation.GetSegmentIDs()[0])
+  if firstSegment.GetRepresentation(LABELMAP) is None:
+    logging.info(f"\nBinary labelmap not found for segmentation {segmentationNode.GetName()}, converting...")
+
+    converter = vtkSegmentationCore.vtkSegmentationConverter()
+    sourceRep = segmentation.GetSourceRepresentationName()
+
+    if sourceRep == PLANAR_CONTOUR:
+      paths = vtkSegmentationCore.vtkSegmentationConversionPaths()
+      converter.GetPossibleConversions(PLANAR_CONTOUR, RIBBON_MODEL, paths)
+      cheapestPath = vtkSegmentationCore.vtkSegmentationConverter.GetCheapestPath(paths)
+      success = segmentation.CreateRepresentation(RIBBON_MODEL, cheapestPath)
+      logging.info(f"Planar contour source detected. Conversion to Ribbon model {'succeeded' if success else 'FAILED'}")
+      segmentation.SetSourceRepresentationName(RIBBON_MODEL)
+
+    paths = vtkSegmentationCore.vtkSegmentationConversionPaths()
+    converter.GetPossibleConversions(segmentation.GetSourceRepresentationName(), LABELMAP, paths)
+    cheapestPath = vtkSegmentationCore.vtkSegmentationConverter.GetCheapestPath(paths)
+    success = segmentation.CreateRepresentation(LABELMAP, cheapestPath)
+    logging.info(f"Conversion from {segmentation.GetSourceRepresentationName()} source to binary labelmap {'succeeded' if success else 'FAILED'}")
+    segmentation.SetSourceRepresentationName(LABELMAP)
+    logging.info("Setting source representation to binary labelmap for future conversions\n")
+
+  segmentArrays = {}
+  for id in segmentation.GetSegmentIDs():
+    segmentArray = slicer.util.arrayFromSegmentBinaryLabelmap(segmentationNode, id, referenceVolumeNode)
+    segmentName = segmentation.GetSegment(id).GetName()
+    segmentArrays[id] = {
+        'array': np.uint8(segmentArray),
+        'name': segmentName
+    }
+  return segmentArrays
+
+
+#------------------------------------------------------------------------------
+def createAndLoadBodySegment(planNode, cst):
+  """
+  If body segment is not selected, create body segment from cst and load into segmentation node in Slicer.
+  
+  Args:
+    planNode: Slicer plan node to access body segment ID and segmentation node
+    cst: StructureSet object containing VOIs, used to create new body segment
+  """
+  referenceVolumeNode = planNode.GetReferenceVolumeNode()
+  segmentationNode = planNode.GetSegmentationNode()
+  segmentation = segmentationNode.GetSegmentation()
+
+  # Check if body segment selected and create from cst if not
+  bodySegmentID = planNode.GetBodySegmentID()
+  if bodySegmentID == "" or bodySegmentID is None:
+    # ensure no segment is named "BODY" to avoid confusion
+    segmentNames = [segmentation.GetSegment(id).GetName() for id in segmentation.GetSegmentIDs()]
+    bodySegmentName = 'BODY'
+    i = 1
+    while bodySegmentName in segmentNames:
+      bodySegmentName += str(i)
+      i += 1
+
+    # Create body segment from cst (ask user to confirm)
+    msg = ("No body segment selected in plan node.\n\n"
+      "Create a body segment named '{}' from the current structure set?").format(bodySegmentName)
+    if not slicer.util.confirmOkCancelDisplay(msg):
+      logging.info("Body segment creation canceled by user.")
+      return cst
+    
+    cst.create_body_seg(voi_type="EXTERNAL", name=bodySegmentName)
+
+    # Find body mask in cst to add to segmentation
+    for voi in cst.vois:
+      if voi.name == bodySegmentName:
+        bodyMask = voi.mask
+        break
+    
+    # Add new segment directly as binary labelmap
+    logging.info("Adding body segment to segmentation in Slicer.")
+    LABELMAP = vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()
+    maskArray = sitk.GetArrayFromImage(bodyMask)
+    newSegmentID = segmentation.AddEmptySegment("", bodySegmentName)
+    slicer.util.updateSegmentBinaryLabelmapFromArray(
+        maskArray, segmentationNode, newSegmentID, referenceVolumeNode
+    )
+    segmentation.SetSourceRepresentationName(LABELMAP)
+
+    # Set body segment ID in plan node
+    planNode.SetBodySegmentID(newSegmentID)
+    segmentationNode.GetDisplayNode().SetSegmentOpacity3D(newSegmentID, 0.2)
+    logging.info(f"Body segment '{bodySegmentName}' (ID: {newSegmentID}) added successfully as binary labelmap.\n")

--- a/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
+++ b/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
@@ -69,7 +69,7 @@ def preparePln(beamNode, ct, dose_grid_from_beamNode=False):
     if doseGridSpacing[0] < 0 or doseGridSpacing[1] < 0 or doseGridSpacing[2] < 0 :
       print("Warning: Dose grid spacing in beamNode is invalid. Using planNode's dose grid spacing.")
       doseGridSpacing = planNode.GetDoseGridSpacing()
-    dose_grid = ct.grid.copy().resample(target_resolution=doseGridSpacing)
+    dose_grid = ct.grid.model_copy().resample(target_resolution=doseGridSpacing)
     # Set new dose grid spacing in planNode if necessary
     if doseGridSpacing != planNode.GetDoseGridSpacing():
       planNode.SetDoseGridSpacing(doseGridSpacing)

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
@@ -131,7 +131,7 @@ bool qSlicerAbstractDoseEngine::isInverse() const
 void qSlicerAbstractDoseEngine::setIsInverse(bool isInverse)
 {
   // TODO: is this correct to avoid setting the value except for Python engines?
-  qCritical() << Q_FUNC_INFO << ": Cannot set dose engine name by method, only in constructor";
+  qCritical() << Q_FUNC_INFO << ": Cannot set isInverse by method, only in constructor";
 }
 
 //----------------------------------------------------------------------------
@@ -143,7 +143,19 @@ bool qSlicerAbstractDoseEngine::canDoIonPlan() const
 //-----------------------------------------------------------------------------
 void qSlicerAbstractDoseEngine::setCanDoIonPlan(bool canDoIonPlan)
 {
-  qCritical() << Q_FUNC_INFO << ": Cannot set dose engine name by method, only in constructor";
+  qCritical() << Q_FUNC_INFO << ": Cannot set canDoIonPlan by method, only in constructor";
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerAbstractDoseEngine::supportsBodySegment() const
+{
+  return this->m_SupportsBodySegment;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerAbstractDoseEngine::setSupportsBodySegment(bool supportsBodySegment)
+{
+  qCritical() << Q_FUNC_INFO << ": Cannot set supportsBodySegment by method, only in constructor";
 }
 
 //----------------------------------------------------------------------------

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.h
@@ -48,6 +48,7 @@ class Q_SLICER_MODULE_EXTERNALBEAMPLANNING_WIDGETS_EXPORT qSlicerAbstractDoseEng
   Q_PROPERTY(QString name READ name WRITE setName)
   Q_PROPERTY(bool isInverse READ isInverse WRITE setIsInverse)
   Q_PROPERTY(bool canDoIonPlan READ canDoIonPlan WRITE setCanDoIonPlan)
+  Q_PROPERTY(bool supportsBodySegment READ supportsBodySegment WRITE setSupportsBodySegment)
 
 public:
   /// Maximum Gray value for visualization window/level of the newly created per-beam dose volumes
@@ -78,6 +79,12 @@ public:
 
   /// Set ion planing capabilities
   virtual void setCanDoIonPlan(bool canDoIonPlan);
+
+  /// Body segment support
+  bool supportsBodySegment()const;
+
+  /// Set body segment support
+  virtual void setSupportsBodySegment(bool supportsBodySegment);
 
 // Dose calculation related functions
 public:
@@ -289,6 +296,10 @@ protected:
   /// Can the dose engine do ion plan? (i.e. it is able to calculate a dose for ion beams)
   /// Is false by default, but can be set in the dose engine constructor
   bool m_CanDoIonPlan = false;
+
+  /// Does the dose engine support body segment? (i.e. uses specified body segment for dose calculation)
+  /// Is false by default, but can be set in the dose engine constructor
+  bool m_SupportsBodySegment = false;
 
   /// List of registered tab widgets. Static so that it is common to all engines.
   static QSet<qMRMLBeamParametersTabWidget*> m_BeamParametersTabWidgets;

--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.cxx
@@ -211,6 +211,12 @@ void qSlicerScriptedDoseEngine::setCanDoIonPlan(bool canDoIonPlan)
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerScriptedDoseEngine::setSupportsBodySegment(bool supportsBodySegment)
+{
+  this->m_SupportsBodySegment = supportsBodySegment;
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerScriptedDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamNode, vtkMRMLScalarVolumeNode* resultDoseVolumeNode)
 {
   Q_D(const qSlicerScriptedDoseEngine);

--- a/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.h
+++ b/ExternalBeamPlanning/Widgets/qSlicerScriptedDoseEngine.h
@@ -73,6 +73,10 @@ public:
   /// \sa canDoIonPlan
   void setCanDoIonPlan(bool isInverse) override;
 
+  /// Set the body segment support bool
+  /// \sa supportsBodySegment
+  void setSupportsBodySegment(bool supportsBodySegment);
+
 // Dose calculation related functions (API functions to call from the subclass)
 protected:
   /// Calculate dose for a single beam. Called by \sa CalculateDose that performs actions generic

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -294,12 +294,12 @@ void qSlicerExternalBeamPlanningModuleWidget::onEnter()
   context.evalScript(QString(
     "try:\n"
     " import pyRadPlan\n"
-    " assert pyRadPlan.__version__ == '0.2.8'\n"
+    " assert pyRadPlan.__version__ == '0.3.1'\n"
     "except (ImportError, AttributeError, AssertionError):\n"
     " if slicer.util.confirmOkCancelDisplay("
-    "   'This module requires pyRadPlan.\\nClick OK to install it now. Slicer will automatically restart.'\n"
+    "   'This module requires pyRadPlan (version 0.3.1).\\nClick OK to install it now. Slicer will automatically restart.'\n"
     " ):\n"
-    "   slicer.util.pip_install('pyRadPlan==0.2.8')\n"
+    "   slicer.util.pip_install('pyRadPlan==0.3.1')\n"
     "   slicer.app.restart()\n"));
 }
 
@@ -341,6 +341,8 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
 
   connect( d->MRMLSegmentSelectorWidget_TargetStructure, SIGNAL(currentSegmentChanged(QString)), this, SLOT(targetSegmentChanged(const QString&)) );
   connect( d->checkBox_IsocenterAtTargetCenter, SIGNAL(stateChanged(int)), this, SLOT(isocenterAtTargetCenterCheckboxStateChanged(int)));
+
+  connect(d->MRMLSegmentSelectorWidget_BodyStructure, SIGNAL(currentSegmentChanged(QString)), this, SLOT(bodySegmentChanged(const QString&)));
 
   connect( d->checkBox_InversePlanning, SIGNAL(stateChanged(int)), this, SLOT(inversePlanningCheckboxStateChanged(int)));
 
@@ -429,6 +431,10 @@ void qSlicerExternalBeamPlanningModuleWidget::updateWidgetFromMRML()
   // Set target segment
   d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentNode(planNode->GetSegmentationNode());
   d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentSegmentID(planNode->GetTargetSegmentID());
+
+  // Set body segment
+  d->MRMLSegmentSelectorWidget_BodyStructure->setCurrentNode(planNode->GetSegmentationNode());
+  d->MRMLSegmentSelectorWidget_BodyStructure->setCurrentSegmentID(planNode->GetBodySegmentID());
 
   // Update isocenter specification
   d->checkBox_IsocenterAtTargetCenter->setChecked(planNode->GetIsocenterSpecification() == vtkMRMLRTPlanNode::CenterOfTarget);
@@ -624,8 +630,9 @@ void qSlicerExternalBeamPlanningModuleWidget::segmentationNodeChanged(vtkMRMLNod
   planNode->SetAndObserveSegmentationNode(vtkMRMLSegmentationNode::SafeDownCast(node));
   planNode->DisableModifiedEventOff();
 
-  // Set segmentation node to target selector
+  // Set segmentation node to target and body selector
   d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentNode(node);
+  d->MRMLSegmentSelectorWidget_BodyStructure->setCurrentNode(node);
 }
 
 //-----------------------------------------------------------------------------
@@ -854,6 +861,30 @@ void qSlicerExternalBeamPlanningModuleWidget::targetSegmentChanged(const QString
       firstBeamNode->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamTransformModified);
     }
   }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExternalBeamPlanningModuleWidget::bodySegmentChanged(const QString& segment)
+{
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+
+  if (!this->mrmlScene())
+  {
+    qCritical() << Q_FUNC_INFO << ": Invalid scene";
+    return;
+  }
+
+  vtkMRMLRTPlanNode* planNode = vtkMRMLRTPlanNode::SafeDownCast(d->MRMLNodeComboBox_RtPlan->currentNode());
+  if (!planNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": Invalid RT plan node";
+    return;
+  }
+
+  // Set body segment ID
+  planNode->DisableModifiedEventOn();
+  planNode->SetBodySegmentID(segment.toUtf8().constData());
+  planNode->DisableModifiedEventOff();
 }
 
 //-----------------------------------------------------------------------------
@@ -1187,6 +1218,8 @@ void qSlicerExternalBeamPlanningModuleWidget::doseEngineChanged(const QString &t
   planNode->DisableModifiedEventOn();
   planNode->SetDoseEngineName(selectedEngine->name().toUtf8().constData());
   planNode->DisableModifiedEventOff();
+
+  d->MRMLSegmentSelectorWidget_BodyStructure->setEnabled(selectedEngine->supportsBodySegment());
 }
 
 //-----------------------------------------------------------------------------

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
@@ -73,6 +73,7 @@ protected slots:
   void poisMarkupsNodeChanged(vtkMRMLNode*);
 
   void targetSegmentChanged(const QString& segment);
+  void bodySegmentChanged(const QString& segment);
   void isocenterAtTargetCenterCheckboxStateChanged(int state);
   void isocenterCoordinatesChanged(double* isocenterCoordinates);
   void centerViewToIsocenterClicked();


### PR DESCRIPTION
This PR adds two methods for the pyRadPlan dose and optimizer engines:

1. **Automatic body segment creation**: Without selected body segment, the user is prompted to create one from the current structure set. The new "BODY" segment is added directly as a binary labelmap to the segmentation.
(A body segment is required for pyRadPlan's optimizer for proper dose distribution, as dose is only placed in segments on which objectives were defined.)
2.  **Automatic segmentation representation conversion**: If the segmentation is not already in binary labelmap representation, it is automatically converted.
(Required for loading segments into python arrays via  `slicer.util.arrayFromSegmentBinaryLabelmap`.)
 (Adresses issue #316)


_Additional changes:_
- Per-beam dose  in pyRadPlanOptimizer is now loaded directly from pyRadPlan's optimized `result`
- Per-beam dose volume nodes are now directly converted to dose volumes
- Variable naming in pyRadPlan Python scripts corrected to camelCase