### PR TITLE
BUG: Fix duplicate dose-engine-specific beam parameters added on each EBP module entry

### DIFF
--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
@@ -149,8 +149,13 @@ void qSlicerAbstractDoseEngine::setCanDoIonPlan(bool canDoIonPlan)
 //----------------------------------------------------------------------------
 void qSlicerAbstractDoseEngine::registerBeamParametersTabWidget(qMRMLBeamParametersTabWidget* tabWidget)
 {
-  qSlicerAbstractDoseEngine::m_BeamParametersTabWidgets.insert(tabWidget);
+  // Check if this tab widget has already been registered
+  if (qSlicerAbstractDoseEngine::m_BeamParametersTabWidgets.contains(tabWidget))
+  {
+    return;
+  }
 
+  qSlicerAbstractDoseEngine::m_BeamParametersTabWidgets.insert(tabWidget);
   // Make sure beam parameters specified by engines are defined in the tab widget
   qSlicerDoseEnginePluginHandler::DoseEngineListType engines =
     qSlicerDoseEnginePluginHandler::instance()->registeredDoseEngines();


### PR DESCRIPTION
This PR addresses Issue #313

`registerBeamParametersTabWidget()` is being called every time the External Beam Planning module is entered and re-adds the dose-engine-specific beam parameters to the tab widget, causing duplicate rows. Fixed by skipping registration if tab widget is already registered.