### PR TITLE
ENH: Add multi-target segment support for RT plan isocenter and dose calculation

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -42,6 +42,10 @@
 #include <vtkSmartPointer.h>
 #include <vtkVariant.h>
 
+// Qt includes
+#include <QString>
+#include <QStringList>
+
 //------------------------------------------------------------------------------
 const char* vtkMRMLRTPlanNode::ISOCENTER_FIDUCIAL_NAME = "Isocenter";
 const int vtkMRMLRTPlanNode::ISOCENTER_FIDUCIAL_INDEX = 0;
@@ -66,7 +70,7 @@ vtkMRMLRTPlanNode::vtkMRMLRTPlanNode()
 //----------------------------------------------------------------------------
 vtkMRMLRTPlanNode::~vtkMRMLRTPlanNode()
 {
-  this->SetTargetSegmentID(nullptr);
+  this->SetTargetSegmentIDs(nullptr);
   this->SetBodySegmentID(nullptr);
   this->SetDoseEngineName(nullptr);
   this->SetPlanOptimizerName(nullptr);
@@ -80,7 +84,7 @@ void vtkMRMLRTPlanNode::WriteXML(ostream& of, int nIndent)
   // Write all MRML node attributes into output stream
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLIntMacro(NextBeamNumber, NextBeamNumber);
-  vtkMRMLWriteXMLStringMacro(TargetSegmentID, TargetSegmentID);
+  vtkMRMLWriteXMLStringMacro(TargetSegmentIDs, TargetSegmentIDs);
   vtkMRMLWriteXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLWriteXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLWriteXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
@@ -99,7 +103,7 @@ void vtkMRMLRTPlanNode::ReadXMLAttributes(const char** atts)
   // Read all MRML node attributes from two arrays of names and values
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLIntMacro(NextBeamNumber, NextBeamNumber);
-  vtkMRMLReadXMLStringMacro(TargetSegmentID, TargetSegmentID);
+  vtkMRMLReadXMLStringMacro(TargetSegmentIDs, TargetSegmentIDs);
   vtkMRMLReadXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLReadXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLReadXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
@@ -126,7 +130,7 @@ void vtkMRMLRTPlanNode::Copy(vtkMRMLNode *anode)
   this->DisableModifiedEventOn();
 
   vtkMRMLCopyBeginMacro(node);
-  vtkMRMLCopyStringMacro(TargetSegmentID);
+  vtkMRMLCopyStringMacro(TargetSegmentIDs);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
@@ -167,7 +171,7 @@ void vtkMRMLRTPlanNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
 
   vtkMRMLCopyBeginMacro(node);
   vtkMRMLCopyFloatMacro(RxDose);
-  vtkMRMLCopyStringMacro(TargetSegmentID);
+  vtkMRMLCopyStringMacro(TargetSegmentIDs);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
@@ -185,7 +189,7 @@ void vtkMRMLRTPlanNode::PrintSelf(ostream& os, vtkIndent indent)
 
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintIntMacro(NextBeamNumber);
-  vtkMRMLPrintStringMacro(TargetSegmentID);
+  vtkMRMLPrintStringMacro(TargetSegmentIDs);
   vtkMRMLPrintStringMacro(BodySegmentID);
   vtkMRMLPrintStringMacro(DoseEngineName);
   vtkMRMLPrintStringMacro(PlanOptimizerName);
@@ -814,7 +818,7 @@ void vtkMRMLRTPlanNode::SetIsocenterSpecification(int isocenterSpec)
 //----------------------------------------------------------------------------
 void vtkMRMLRTPlanNode::SetIsocenterToTargetCenter()
 {
-  if (!this->TargetSegmentID)
+  if (!this->TargetSegmentIDs)
   {
     vtkErrorMacro("SetIsocenterToTargetCenter: Unable to set isocenter to target segment as no target segment defined in beam " << this->Name);
     return;
@@ -837,7 +841,88 @@ void vtkMRMLRTPlanNode::SetIsocenterToTargetCenter()
 }
 
 //----------------------------------------------------------------------------
+vtkSmartPointer<vtkPolyData> vtkMRMLRTPlanNode::GetTargetClosedSurface()
+{
+  vtkMRMLSegmentationNode* segmentationNode = this->GetSegmentationNode();
+  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
+
+  // Return closed surface of the single target segment if only one segment specified
+  if (targetSegmentIDs.size() == 1)
+  {
+    return segmentationNode->GetClosedSurfaceInternalRepresentation(
+      targetSegmentIDs[0].toStdString());
+  }
+
+  // Get merged labelmap
+  vtkSmartPointer<vtkOrientedImageData> mergedLabelmap = this->GetTargetOrientedImageData();
+
+  // Import as temporary segment
+  std::string tempSegmentID = "TempMergedTarget";
+  vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
+    mergedLabelmap, segmentationNode, tempSegmentID.c_str());
+
+  // Get closed surface
+  vtkPolyData* surface = segmentationNode->GetClosedSurfaceInternalRepresentation(tempSegmentID);
+
+  // Clean up
+  segmentationNode->GetSegmentation()->RemoveSegment(tempSegmentID);
+
+  return surface;
+}
+
+//----------------------------------------------------------------------------
 vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageData()
+{
+  vtkMRMLSegmentationNode* segmentationNode = this->GetSegmentationNode();
+  if (!segmentationNode)
+  {
+    vtkErrorMacro("GetMergedTargetOrientedImageData: Failed to get segmentation node");
+    return nullptr;
+  }
+
+  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
+
+  if (targetSegmentIDs.empty())
+  {
+    vtkErrorMacro("GetMergedTargetOrientedImageData: No target segments specified");
+    return nullptr;
+  }
+
+  // Return labelmap of the single target segment if only one segment specified (no need to merge)
+  if (targetSegmentIDs.size() == 1)
+  {
+    return this->GetSingleTargetOrientedImageData(targetSegmentIDs[0]);
+  }
+
+  // Get segment IDs as string array
+  vtkSmartPointer<vtkStringArray> segmentIDs = vtkSmartPointer<vtkStringArray>::New();
+  for (const QString& id : targetSegmentIDs)
+  {
+    segmentIDs->InsertNextValue(id.toUtf8().constData());
+  }
+
+  // Make sure binary labelmap representation exists
+  if (!segmentationNode->GetSegmentation()->ContainsRepresentation(
+    vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
+  {
+    segmentationNode->GetSegmentation()->CreateRepresentation(
+      vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName());
+  }
+
+  // Merge segments into one labelmap
+  vtkSmartPointer<vtkOrientedImageData> mergedLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
+  vtkSlicerSegmentationsModuleLogic::GenerateMergedLabelmapInReferenceGeometry(
+    segmentationNode,
+    this->GetReferenceVolumeNode(),
+    segmentIDs,
+    vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS,
+    mergedLabelmap);
+
+  return mergedLabelmap;
+}
+
+//----------------------------------------------------------------------------
+vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetSingleTargetOrientedImageData(QString segmentID)
 {
   vtkSmartPointer<vtkOrientedImageData> targetOrientedImageData;
   vtkMRMLSegmentationNode* segmentationNode = this->GetSegmentationNode();
@@ -854,12 +939,12 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
     return targetOrientedImageData;
   }
 
-  if (!this->TargetSegmentID)
+  if (!this->TargetSegmentIDs)
   {
     vtkErrorMacro("GetTargetOrientedImageData: No target segment specified");
     return targetOrientedImageData;
   }
-  vtkSegment* segment = segmentation->GetSegment(this->TargetSegmentID);
+  vtkSegment* segment = segmentation->GetSegment(segmentID.toStdString());
   if (!segment)
   {
     vtkErrorMacro("GetTargetOrientedImageData: Failed to get segment");
@@ -881,7 +966,7 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
     // Need to convert
     targetOrientedImageData = vtkSmartPointer<vtkOrientedImageData>::Take(vtkOrientedImageData::SafeDownCast(
       vtkSlicerSegmentationsModuleLogic::CreateRepresentationForOneSegment(
-        segmentation, this->GetTargetSegmentID(), vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName())));
+        segmentation, segmentID.toStdString(), vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName())));
     if (!targetOrientedImageData.GetPointer())
     {
       std::string errorMessage("Failed to convert target segment into binary labelmap");
@@ -903,6 +988,8 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
 //----------------------------------------------------------------------------
 bool vtkMRMLRTPlanNode::ComputeTargetVolumeCenter(double center[3])
 {
+  //TODO: currently only mean of segment centers is computed,
+  //but it would be more accurate to compute center of mass of the combined target volume.
   center[0] = center[1] = center[2] = 0.0;
 
   if (!this->Scene)
@@ -916,23 +1003,35 @@ bool vtkMRMLRTPlanNode::ComputeTargetVolumeCenter(double center[3])
     vtkErrorMacro("ComputeTargetVolumeCenter: Failed to get target segmentation node");
     return false;
   }
-  if (!this->TargetSegmentID)
+  if (!this->TargetSegmentIDs)
   {
-    vtkErrorMacro("ComputeTargetVolumeCenter: No target segment specified");
+    vtkErrorMacro("ComputeTargetVolumeCenter: No target segments specified");
     return false;
   }
 
-  double* centerRas = segmentationNode->GetSegmentCenterRAS(this->TargetSegmentID);
-  if (!centerRas)
-  {
-    vtkErrorMacro("ComputeTargetVolumeCenter: No target segment center");
-    return false;
-  }
-  center[0] = centerRas[0];
-  center[1] = centerRas[1];
-  center[2] = centerRas[2];
+  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
 
-  return true;
+  int count = 0;
+  for (const QString& segmentID : targetSegmentIDs)
+  {
+    double* centerRas = segmentationNode->GetSegmentCenterRAS(segmentID.toUtf8().constData());
+    if (!centerRas)
+    {
+      vtkErrorMacro("ComputeTargetVolumeCenter: Failed to get center of segment with ID " << segmentID.toUtf8().constData());
+      return false;
+    }
+    center[0] += centerRas[0];
+    center[1] += centerRas[1];
+    center[2] += centerRas[2];
+    count++;
+  }
+  if (count > 0)
+  {
+    center[0] /= count;
+    center[1] /= count;
+    center[2] /= count;
+    return true;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -70,7 +70,7 @@ vtkMRMLRTPlanNode::vtkMRMLRTPlanNode()
 //----------------------------------------------------------------------------
 vtkMRMLRTPlanNode::~vtkMRMLRTPlanNode()
 {
-  this->SetTargetSegmentIDs(nullptr);
+  this->TargetSegmentIDs.clear();
   this->SetBodySegmentID(nullptr);
   this->SetDoseEngineName(nullptr);
   this->SetPlanOptimizerName(nullptr);
@@ -84,7 +84,7 @@ void vtkMRMLRTPlanNode::WriteXML(ostream& of, int nIndent)
   // Write all MRML node attributes into output stream
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLIntMacro(NextBeamNumber, NextBeamNumber);
-  vtkMRMLWriteXMLStringMacro(TargetSegmentIDs, TargetSegmentIDs);
+  vtkMRMLWriteXMLStdStringVectorMacro(TargetSegmentIDs, TargetSegmentIDs, std::vector);
   vtkMRMLWriteXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLWriteXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLWriteXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
@@ -103,7 +103,7 @@ void vtkMRMLRTPlanNode::ReadXMLAttributes(const char** atts)
   // Read all MRML node attributes from two arrays of names and values
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLIntMacro(NextBeamNumber, NextBeamNumber);
-  vtkMRMLReadXMLStringMacro(TargetSegmentIDs, TargetSegmentIDs);
+  vtkMRMLReadXMLStdStringVectorMacro(TargetSegmentIDs, TargetSegmentIDs, std::vector);
   vtkMRMLReadXMLStringMacro(BodySegmentID, BodySegmentID);
   vtkMRMLReadXMLStringMacro(DoseEngineName, DoseEngineName);
   vtkMRMLReadXMLStringMacro(PlanOptimizerName, PlanOptimizerName);
@@ -130,7 +130,7 @@ void vtkMRMLRTPlanNode::Copy(vtkMRMLNode *anode)
   this->DisableModifiedEventOn();
 
   vtkMRMLCopyBeginMacro(node);
-  vtkMRMLCopyStringMacro(TargetSegmentIDs);
+  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs, std::vector);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
@@ -171,7 +171,7 @@ void vtkMRMLRTPlanNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
 
   vtkMRMLCopyBeginMacro(node);
   vtkMRMLCopyFloatMacro(RxDose);
-  vtkMRMLCopyStringMacro(TargetSegmentIDs);
+  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs, std::vector);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
@@ -189,7 +189,7 @@ void vtkMRMLRTPlanNode::PrintSelf(ostream& os, vtkIndent indent)
 
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintIntMacro(NextBeamNumber);
-  vtkMRMLPrintStringMacro(TargetSegmentIDs);
+  vtkMRMLPrintStdStringVectorMacro(TargetSegmentIDs, std::vector);
   vtkMRMLPrintStringMacro(BodySegmentID);
   vtkMRMLPrintStringMacro(DoseEngineName);
   vtkMRMLPrintStringMacro(PlanOptimizerName);
@@ -459,6 +459,18 @@ bool vtkMRMLRTPlanNode::SetIsocenterPosition(double isocenter[3])
   fiducialNode->SetNthControlPointPosition(ISOCENTER_FIDUCIAL_INDEX, isocenter);
 
   return true;
+}
+
+//----------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLRTPlanNode::GetTargetSegmentIDs()
+{
+  return this->TargetSegmentIDs;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLRTPlanNode::SetTargetSegmentIDs(std::vector<std::string> targetSegmentIDs)
+{
+  this->TargetSegmentIDs = targetSegmentIDs;
 }
 
 //----------------------------------------------------------------------------
@@ -818,7 +830,7 @@ void vtkMRMLRTPlanNode::SetIsocenterSpecification(int isocenterSpec)
 //----------------------------------------------------------------------------
 void vtkMRMLRTPlanNode::SetIsocenterToTargetCenter()
 {
-  if (!this->TargetSegmentIDs)
+  if (this->TargetSegmentIDs.empty())
   {
     vtkErrorMacro("SetIsocenterToTargetCenter: Unable to set isocenter to target segment as no target segment defined in beam " << this->Name);
     return;
@@ -844,13 +856,13 @@ void vtkMRMLRTPlanNode::SetIsocenterToTargetCenter()
 vtkSmartPointer<vtkPolyData> vtkMRMLRTPlanNode::GetTargetClosedSurface()
 {
   vtkMRMLSegmentationNode* segmentationNode = this->GetSegmentationNode();
-  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
+  std::vector<std::string> targetSegmentIDs = this->TargetSegmentIDs;
 
   // Return closed surface of the single target segment if only one segment specified
   if (targetSegmentIDs.size() == 1)
   {
     return segmentationNode->GetClosedSurfaceInternalRepresentation(
-      targetSegmentIDs[0].toStdString());
+      targetSegmentIDs[0]);
   }
 
   // Get merged labelmap
@@ -880,7 +892,7 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
     return nullptr;
   }
 
-  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
+  std::vector<std::string> targetSegmentIDs = this->TargetSegmentIDs;
 
   if (targetSegmentIDs.empty())
   {
@@ -891,16 +903,18 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetTargetOrientedImageD
   // Return labelmap of the single target segment if only one segment specified (no need to merge)
   if (targetSegmentIDs.size() == 1)
   {
-    return this->GetSingleTargetOrientedImageData(targetSegmentIDs[0]);
+    return this->GetSingleTargetOrientedImageData(QString::fromStdString(targetSegmentIDs[0]));
   }
 
   // Get segment IDs as string array
   vtkSmartPointer<vtkStringArray> segmentIDs = vtkSmartPointer<vtkStringArray>::New();
-  for (const QString& id : targetSegmentIDs)
+  for (const std::string id : targetSegmentIDs)
   {
-    segmentIDs->InsertNextValue(id.toUtf8().constData());
+    if (!id.empty())
+    {
+      segmentIDs->InsertNextValue(id);
+    }
   }
-
   // Make sure binary labelmap representation exists
   if (!segmentationNode->GetSegmentation()->ContainsRepresentation(
     vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
@@ -939,7 +953,7 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetSingleTargetOriented
     return targetOrientedImageData;
   }
 
-  if (!this->TargetSegmentIDs)
+  if (this->TargetSegmentIDs.empty())
   {
     vtkErrorMacro("GetTargetOrientedImageData: No target segment specified");
     return targetOrientedImageData;
@@ -954,7 +968,7 @@ vtkSmartPointer<vtkOrientedImageData> vtkMRMLRTPlanNode::GetSingleTargetOriented
   if (segmentation->ContainsRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
   {
 #if Slicer_VERSION_MAJOR >= 5 || (Slicer_VERSION_MAJOR >= 4 && Slicer_VERSION_MINOR >= 11)
-    segmentationNode->GetBinaryLabelmapRepresentation(this->TargetSegmentID, targetOrientedImageData);
+    segmentationNode->GetBinaryLabelmapRepresentation(segmentID.toStdString(), targetOrientedImageData);
 #else
     targetOrientedImageData = vtkSmartPointer<vtkOrientedImageData>::New();
     targetOrientedImageData->DeepCopy(vtkOrientedImageData::SafeDownCast(
@@ -1003,21 +1017,21 @@ bool vtkMRMLRTPlanNode::ComputeTargetVolumeCenter(double center[3])
     vtkErrorMacro("ComputeTargetVolumeCenter: Failed to get target segmentation node");
     return false;
   }
-  if (!this->TargetSegmentIDs)
+  if (this->TargetSegmentIDs.empty())
   {
     vtkErrorMacro("ComputeTargetVolumeCenter: No target segments specified");
     return false;
   }
 
-  QStringList targetSegmentIDs = QString(this->TargetSegmentIDs).split("|", Qt::SkipEmptyParts);
+  std::vector<std::string> targetSegmentIDs = this->TargetSegmentIDs;
 
   int count = 0;
-  for (const QString& segmentID : targetSegmentIDs)
+  for (std::string segmentID : targetSegmentIDs)
   {
-    double* centerRas = segmentationNode->GetSegmentCenterRAS(segmentID.toUtf8().constData());
+    double* centerRas = segmentationNode->GetSegmentCenterRAS(segmentID);
     if (!centerRas)
     {
-      vtkErrorMacro("ComputeTargetVolumeCenter: Failed to get center of segment with ID " << segmentID.toUtf8().constData());
+      vtkErrorMacro("ComputeTargetVolumeCenter: Failed to get center of segment with ID " << segmentID);
       return false;
     }
     center[0] += centerRas[0];

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -187,9 +187,9 @@ public:
   void SetAndObserveSegmentationNode(vtkMRMLSegmentationNode* node);
 
   /// Get target segment ID
-  vtkGetStringMacro(TargetSegmentIDs);
+  std::vector<std::string> GetTargetSegmentIDs();
   /// Set target segment ID
-  vtkSetStringMacro(TargetSegmentIDs);
+  void SetTargetSegmentIDs(std::vector<std::string> targetSegmentIDs);
 
   /// Get body segment ID
   vtkGetStringMacro(BodySegmentID);
@@ -267,8 +267,8 @@ protected:
   /// Prescription dose (Gy)
   double RxDose{ 1.0 };
 
-  /// Target segment IDs in target segmentation node as pipe-separated list (e.g., "segment1|segment2|segment3")
-  char* TargetSegmentIDs{ nullptr };
+  /// Target segment IDs in target segmentation node
+  std::vector<std::string> TargetSegmentIDs;
 
   /// Body segment ID in segmentation node
   char* BodySegmentID{ nullptr };

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -33,6 +33,9 @@
 #include "vtkOrientedImageData.h"
 #include <vtkSmartPointer.h>
 
+// Qt includes
+#include <QString>
+
 class vtkCollection;
 class vtkMRMLMarkupsFiducialNode;
 class vtkMRMLRTBeamNode;
@@ -100,8 +103,16 @@ public:
   /// Get subject hierarchy item associated with this node. Create if missing
   vtkIdType GetPlanSubjectHierarchyItemID();
 
-  /// Get target segment as a labelmap oriented image data
+
+  /// Get target segment as a closed surface poly data.
+  /// If multiple target segments are specified, then they are merged and returned as a single surface.
+  vtkSmartPointer<vtkPolyData> GetTargetClosedSurface();
+
+  /// Get merged target segment as a labelmap oriented image data
   vtkSmartPointer<vtkOrientedImageData> GetTargetOrientedImageData();
+
+  /// Get target segment as a labelmap oriented image data
+  vtkSmartPointer<vtkOrientedImageData> GetSingleTargetOrientedImageData(QString segmentID);
 
   /// Add given beam node to plan
   void AddBeam(vtkMRMLRTBeamNode* beam);
@@ -176,9 +187,9 @@ public:
   void SetAndObserveSegmentationNode(vtkMRMLSegmentationNode* node);
 
   /// Get target segment ID
-  vtkGetStringMacro(TargetSegmentID);
+  vtkGetStringMacro(TargetSegmentIDs);
   /// Set target segment ID
-  vtkSetStringMacro(TargetSegmentID);
+  vtkSetStringMacro(TargetSegmentIDs);
 
   /// Get body segment ID
   vtkGetStringMacro(BodySegmentID);
@@ -256,8 +267,8 @@ protected:
   /// Prescription dose (Gy)
   double RxDose{ 1.0 };
 
-  /// Target segment ID in target segmentation node
-  char* TargetSegmentID{ nullptr };
+  /// Target segment IDs in target segmentation node as pipe-separated list (e.g., "segment1|segment2|segment3")
+  char* TargetSegmentIDs{ nullptr };
 
   /// Body segment ID in segmentation node
   char* BodySegmentID{ nullptr };

--- a/Beams/Widgets/Resources/UI/qMRMLBeamsTableView.ui
+++ b/Beams/Widgets/Resources/UI/qMRMLBeamsTableView.ui
@@ -78,7 +78,7 @@
       <bool>true</bool>
      </property>
      <property name="columnCount">
-      <number>7</number>
+      <number>8</number>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
       <number>64</number>
@@ -113,6 +113,11 @@
      <column>
       <property name="text">
        <string>Weight</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string/>
       </property>
      </column>
      <column>

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -1042,15 +1042,14 @@ void qMRMLBeamParametersTabWidget::calculateMLCPositionClicked()
   }
   vtkMRMLSegmentationNode* segmentationNode = planNode->GetSegmentationNode();
   vtkMRMLScalarVolumeNode* volumeNode = planNode->GetReferenceVolumeNode();
-  const char* targetID = planNode->GetTargetSegmentID();
 
-  if (!segmentationNode || !volumeNode || !targetID)
+  if (!segmentationNode || !volumeNode)
   {
     qCritical() << Q_FUNC_INFO << ": No segmentation, reference volume or target id data!";
     return;
   }
 
-  vtkPolyData* targetPoly = segmentationNode->GetClosedSurfaceInternalRepresentation(std::string(targetID));
+  vtkPolyData* targetPoly = planNode->GetTargetClosedSurface();
   if (targetPoly)
   {
     vtkMRMLMarkupsCurveNode* convexHullCurve = d->MLCPositionLogic->CalculatePositionConvexHullCurve( d->BeamNode, targetPoly);

--- a/Beams/Widgets/qMRMLBeamsTableView.cxx
+++ b/Beams/Widgets/qMRMLBeamsTableView.cxx
@@ -37,6 +37,17 @@
 // SlicerQt includes
 #include "qSlicerApplication.h"
 
+#include "qMRMLThreeDView.h"
+#include "qMRMLThreeDWidget.h"
+#include "qSlicerLayoutManager.h"
+#include <vtkMRMLCameraNode.h>
+#include <vtkTransform.h>
+#include <vtkMatrix4x4.h>
+#include "vtkMRMLCameraNode.h"
+#include "vtkMRMLViewNode.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkCamera.h"
+
 #define ID_PROPERTY "ID"
 
 //-----------------------------------------------------------------------------
@@ -83,7 +94,7 @@ void qMRMLBeamsTableViewPrivate::init()
   this->setMessage(QString());
 
   // Set table header properties
-  this->ColumnLabels << "Number" << "Name" << "Gantry" << "Weight" << "Edit" << "Clone";
+  this->ColumnLabels << "Number" << "Name" << "Gantry" << "Weight" << "Edit" << "Clone" << "BEV";
   this->BeamsTable->setHorizontalHeaderLabels(
     QStringList() << "#" << "Name" << "Gantry" << "Weight" << "" );
   this->BeamsTable->setColumnCount(this->ColumnLabels.size());
@@ -282,6 +293,14 @@ void qMRMLBeamsTableView::updateBeamTable()
     cloneButton->setProperty(ID_PROPERTY, beamNode->GetID());
     connect(cloneButton, SIGNAL(clicked()), this, SLOT(onCloneButtonClicked()));
     d->BeamsTable->setCellWidget(row, d->columnIndex("Clone"), cloneButton);
+
+    // BEV button
+    QPushButton* bevButton = new QPushButton("BEV");
+    bevButton->setMaximumWidth(52);
+    bevButton->setToolTip("Show Beam's Eye View");
+    bevButton->setProperty(ID_PROPERTY, beamNode->GetID());
+    connect(bevButton, SIGNAL(clicked()), this, SLOT(onBEVButtonClicked()));
+    d->BeamsTable->setCellWidget(row, d->columnIndex("BEV"), bevButton);
 }
 
   // Unblock signals
@@ -403,6 +422,91 @@ void qMRMLBeamsTableView::onCloneButtonClicked()
 
   // Clone beam node in its parent plan
   beamNode->RequestCloning();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLBeamsTableView::onBEVButtonClicked()
+{
+  Q_D(qMRMLBeamsTableView);
+  QPushButton* senderButton = qobject_cast<QPushButton*>(sender());
+  if (!senderButton || !d->PlanNode || !d->PlanNode->GetScene())
+  {
+    return;
+  }
+
+  QString beamNodeID = senderButton->property(ID_PROPERTY).toString();
+  vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(
+    d->PlanNode->GetScene()->GetNodeByID(beamNodeID.toUtf8().constData()));
+  if (!beamNode)
+  {
+    return;
+  }
+
+  // Get 3D view node camera
+  vtkMRMLCameraNode* cameraNode = this->get3DViewCameraNode();
+  if (!cameraNode)
+  {
+    return;
+  }
+
+  double sourcePosition[3] = { 0.0, 0.0, 0.0 };
+  double isocenter[3] = { 0.0, 0.0, 0.0 };
+
+  if (beamNode->GetSourcePosition(sourcePosition))
+  {
+    vtkMRMLTransformNode* beamTransformNode = beamNode->GetParentTransformNode();
+    vtkTransform* beamTransform = nullptr;
+    vtkNew<vtkMatrix4x4> mat;
+    mat->Identity();
+
+    if (beamTransformNode)
+    {
+      beamTransform = vtkTransform::SafeDownCast(beamTransformNode->GetTransformToParent());
+      beamTransform->GetMatrix(mat);
+    }
+    else
+    {
+      qCritical() << Q_FUNC_INFO << "Beam transform node is invalid";
+      return;
+    }
+
+    double viewUpVector[4] = { -1., 0., 0., 0. }; // beam negative X-axis
+    double vup[4];
+
+    mat->MultiplyPoint(viewUpVector, vup);
+
+    cameraNode->GetCamera()->SetPosition(sourcePosition);
+    if (beamNode->GetPlanIsocenterPosition(isocenter))
+    {
+      cameraNode->GetCamera()->SetFocalPoint(isocenter);
+    }
+    cameraNode->SetViewUp(vup);
+  }
+
+  //this->setMachinePartsOpacityForBeamsEyeView(0.1);
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLCameraNode* qMRMLBeamsTableView::get3DViewCameraNode()
+{
+  Q_D(qMRMLBeamsTableView);
+
+  // Get 3D view node
+  qSlicerApplication* slicerApplication = qSlicerApplication::application();
+  qSlicerLayoutManager* layoutManager = slicerApplication->layoutManager();
+  if (!layoutManager->threeDViewCount())
+  {
+    return nullptr;
+  }
+
+  qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
+  vtkMRMLCameraNode* cameraNode = threeDView->cameraNode();
+  if (!cameraNode)
+  {
+    qCritical() << Q_FUNC_INFO << "Failed to find camera for view "
+      << (threeDView->mrmlViewNode() ? threeDView->mrmlViewNode()->GetID() : "(null)");
+  }
+  return cameraNode;
 }
 
 //-----------------------------------------------------------------------------

--- a/Beams/Widgets/qMRMLBeamsTableView.h
+++ b/Beams/Widgets/qMRMLBeamsTableView.h
@@ -37,6 +37,7 @@ class qMRMLBeamsTableViewPrivate;
 class vtkMRMLNode;
 class QTableWidgetItem;
 class QItemSelection;
+class vtkMRMLCameraNode;
 
 /// \ingroup SlicerRt_QtModules_Beams_Widgets
 class Q_SLICER_MODULE_BEAMS_WIDGETS_EXPORT qMRMLBeamsTableView : public qMRMLWidget
@@ -92,6 +93,12 @@ protected slots:
 
   /// Handle clone button click. Creates clone of the beam for which the button was clicked
   void onCloneButtonClicked();
+
+  /// Handle BEV button click. Shows beam's eye view for the beam for which the button was clicked
+  void onBEVButtonClicked();
+
+  /// Get camera node for the 3D view
+  vtkMRMLCameraNode* get3DViewCameraNode();
 
   /// Update beam table according to the plan node
   void updateBeamTable();

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -327,6 +327,13 @@
             </item>
            </layout>
           </item>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -200,7 +200,7 @@
             <item>
              <widget class="QLabel" name="label_TargetVolume">
               <property name="text">
-               <string>Target volume:</string>
+               <string>Target volumes:</string>
               </property>
              </widget>
             </item>
@@ -235,6 +235,9 @@
               </property>
               <property name="segmentationNodeSelectorVisible" stdset="0">
                <bool>false</bool>
+              </property>
+              <property name="multiSelection" stdset="0">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
+++ b/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
@@ -27,10 +27,10 @@ def prepareCst(beamNode, ct, needBody=False):
   segmentationNode = planNode.GetSegmentationNode()
   segmentation = segmentationNode.GetSegmentation()
 
-  if planNode.GetTargetSegmentID() == "":
-    raise ValueError("No target segment selected in plan node. Please select a target segment and try again.")
-  if planNode.GetTargetSegmentID() == planNode.GetBodySegmentID():
-    raise ValueError("Target segment and body segment are the same. Please select a different target segment or body segment and try again.")
+  if planNode.GetTargetSegmentIDs() == "":
+    raise ValueError("No target segments selected in plan node. Please select target segments and try again.")
+  if planNode.GetBodySegmentID() in planNode.GetTargetSegmentIDs().split('|'):
+    raise ValueError("Body segment is also a target segment. Please select a different target segment or body segment and try again.")
 
   # Get arrays for all segments in segmentation node (convert to binary labelmap if necessary)
   segmentArrays = getSegmentArrays(segmentationNode, referenceVolumeNode)
@@ -43,7 +43,7 @@ def prepareCst(beamNode, ct, needBody=False):
     voiType = 'OAR'
     if id == planNode.GetBodySegmentID():
       voiType = 'EXTERNAL'
-    if id == planNode.GetTargetSegmentID(): # overwrite if also selected as body
+    if id in planNode.GetTargetSegmentIDs().split('|'):
       voiType = 'TARGET'
     voi = create_voi(voi_type=voiType, name=segmentName, ct_image=ct, mask=segmentArray)
     vois.append(voi)

--- a/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
+++ b/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
@@ -29,7 +29,7 @@ def prepareCst(beamNode, ct, needBody=False):
 
   if planNode.GetTargetSegmentIDs() == "":
     raise ValueError("No target segments selected in plan node. Please select target segments and try again.")
-  if planNode.GetBodySegmentID() in planNode.GetTargetSegmentIDs().split('|'):
+  if planNode.GetBodySegmentID() in planNode.GetTargetSegmentIDs():
     raise ValueError("Body segment is also a target segment. Please select a different target segment or body segment and try again.")
 
   # Get arrays for all segments in segmentation node (convert to binary labelmap if necessary)
@@ -43,7 +43,7 @@ def prepareCst(beamNode, ct, needBody=False):
     voiType = 'OAR'
     if id == planNode.GetBodySegmentID():
       voiType = 'EXTERNAL'
-    if id in planNode.GetTargetSegmentIDs().split('|'):
+    if id in planNode.GetTargetSegmentIDs():
       voiType = 'TARGET'
     voi = create_voi(voi_type=voiType, name=segmentName, ct_image=ct, mask=segmentArray)
     vois.append(voi)

--- a/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
+++ b/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
@@ -893,7 +893,9 @@ int qMRMLObjectivesTableWidget::findOverlapPriorityValueOfSegment(int row)
 
   int newValue;
 
-  if (segmentID == planNode->GetTargetSegmentID())
+  QStringList targetSegmentIDs = QString(planNode->GetTargetSegmentIDs()).split("|", Qt::SkipEmptyParts);
+
+  if (targetSegmentIDs.contains(segmentID))
   {
     newValue = 0;
   }

--- a/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
+++ b/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
@@ -893,9 +893,9 @@ int qMRMLObjectivesTableWidget::findOverlapPriorityValueOfSegment(int row)
 
   int newValue;
 
-  QStringList targetSegmentIDs = QString(planNode->GetTargetSegmentIDs()).split("|", Qt::SkipEmptyParts);
+  std::vector<std::string> targetSegmentIDs = planNode->GetTargetSegmentIDs();
 
-  if (targetSegmentIDs.contains(segmentID))
+  if (std::find(targetSegmentIDs.begin(), targetSegmentIDs.end(), segmentID.toStdString()) != targetSegmentIDs.end())
   {
     newValue = 0;
   }

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -430,8 +430,12 @@ void qSlicerExternalBeamPlanningModuleWidget::updateWidgetFromMRML()
 
   // Set target segments
   d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentNode(planNode->GetSegmentationNode());
-  QString ids(planNode->GetTargetSegmentIDs());
-  d->MRMLSegmentSelectorWidget_TargetStructure->setSelectedSegmentIDs(ids.split("|", Qt::SkipEmptyParts));
+  QStringList targetSegmentIDs;
+  for (const std::string& id : planNode->GetTargetSegmentIDs())
+  {
+    targetSegmentIDs << QString::fromStdString(id);
+  }
+  d->MRMLSegmentSelectorWidget_TargetStructure->setSelectedSegmentIDs(targetSegmentIDs);
 
 
   // Set body segment
@@ -826,7 +830,7 @@ void qSlicerExternalBeamPlanningModuleWidget::useCTGridForDoseGridSpacingClicked
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerExternalBeamPlanningModuleWidget::targetSegmentsChanged(const QStringList& targetSegmentIDs)
+void qSlicerExternalBeamPlanningModuleWidget::targetSegmentsChanged(QStringList targetSegmentIDs)
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
@@ -845,7 +849,12 @@ void qSlicerExternalBeamPlanningModuleWidget::targetSegmentsChanged(const QStrin
 
   // Set target segment ID
   planNode->DisableModifiedEventOn();
-  planNode->SetTargetSegmentIDs(targetSegmentIDs.join("|").toUtf8().constData());
+  std::vector<std::string> ids;
+  for (const QString& id : targetSegmentIDs)
+  {
+    ids.push_back(id.toStdString());
+  }
+  planNode->SetTargetSegmentIDs(ids);
   planNode->DisableModifiedEventOff();
 
   if (planNode->GetIsocenterSpecification() == vtkMRMLRTPlanNode::CenterOfTarget)

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -339,7 +339,7 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
   connect( d->MRMLCoordinatesWidget_IsocenterCoordinates, SIGNAL(coordinatesChanged(double*)), this, SLOT(isocenterCoordinatesChanged(double *)));
   connect( d->pushButton_CenterViewToIsocenter, SIGNAL(clicked()), this, SLOT(centerViewToIsocenterClicked()) );
 
-  connect( d->MRMLSegmentSelectorWidget_TargetStructure, SIGNAL(currentSegmentChanged(QString)), this, SLOT(targetSegmentChanged(const QString&)) );
+  connect( d->MRMLSegmentSelectorWidget_TargetStructure, SIGNAL(segmentSelectionChanged(QStringList)), this, SLOT(targetSegmentsChanged(QStringList)) );
   connect( d->checkBox_IsocenterAtTargetCenter, SIGNAL(stateChanged(int)), this, SLOT(isocenterAtTargetCenterCheckboxStateChanged(int)));
 
   connect(d->MRMLSegmentSelectorWidget_BodyStructure, SIGNAL(currentSegmentChanged(QString)), this, SLOT(bodySegmentChanged(const QString&)));
@@ -428,9 +428,11 @@ void qSlicerExternalBeamPlanningModuleWidget::updateWidgetFromMRML()
     d->MRMLNodeComboBox_DoseVolume->setCurrentNode(planNode->GetOutputTotalDoseVolumeNode());
   }
 
-  // Set target segment
+  // Set target segments
   d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentNode(planNode->GetSegmentationNode());
-  d->MRMLSegmentSelectorWidget_TargetStructure->setCurrentSegmentID(planNode->GetTargetSegmentID());
+  QString ids(planNode->GetTargetSegmentIDs());
+  d->MRMLSegmentSelectorWidget_TargetStructure->setSelectedSegmentIDs(ids.split("|", Qt::SkipEmptyParts));
+
 
   // Set body segment
   d->MRMLSegmentSelectorWidget_BodyStructure->setCurrentNode(planNode->GetSegmentationNode());
@@ -824,7 +826,7 @@ void qSlicerExternalBeamPlanningModuleWidget::useCTGridForDoseGridSpacingClicked
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerExternalBeamPlanningModuleWidget::targetSegmentChanged(const QString& segment)
+void qSlicerExternalBeamPlanningModuleWidget::targetSegmentsChanged(const QStringList& targetSegmentIDs)
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
@@ -843,7 +845,7 @@ void qSlicerExternalBeamPlanningModuleWidget::targetSegmentChanged(const QString
 
   // Set target segment ID
   planNode->DisableModifiedEventOn();
-  planNode->SetTargetSegmentID(segment.toUtf8().constData());
+  planNode->SetTargetSegmentIDs(targetSegmentIDs.join("|").toUtf8().constData());
   planNode->DisableModifiedEventOff();
 
   if (planNode->GetIsocenterSpecification() == vtkMRMLRTPlanNode::CenterOfTarget)

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
@@ -72,7 +72,7 @@ protected slots:
   void segmentationNodeChanged(vtkMRMLNode*);
   void poisMarkupsNodeChanged(vtkMRMLNode*);
 
-  void targetSegmentsChanged(const QStringList& targetSegmentIDs);
+  void targetSegmentsChanged(QStringList targetSegmentIDs);
   void bodySegmentChanged(const QString& segment);
   void isocenterAtTargetCenterCheckboxStateChanged(int state);
   void isocenterCoordinatesChanged(double* isocenterCoordinates);

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
@@ -72,7 +72,7 @@ protected slots:
   void segmentationNodeChanged(vtkMRMLNode*);
   void poisMarkupsNodeChanged(vtkMRMLNode*);
 
-  void targetSegmentChanged(const QString& segment);
+  void targetSegmentsChanged(const QStringList& targetSegmentIDs);
   void bodySegmentChanged(const QString& segment);
   void isocenterAtTargetCenterCheckboxStateChanged(int state);
   void isocenterCoordinatesChanged(double* isocenterCoordinates);


### PR DESCRIPTION
Addresses issue #318.

_Open questions:_

- Saving multiple targets in one string (seperated by `|` ) acceptable?
(`planNode->SetTargetSegmentIDs(targetSegmentIDs.join("|").toUtf8().constData());`)

- How to handle isocenter from multiple targets?
Currently calculating mean of isocenters in `vtkMRMLRTPlanNode::ComputeTargetVolumeCenter` (`Beams/MRML/vtkMRMLRTPlanNode.cxx` lines 989-1035)

- How to remove shift between target segment & body segment selection widgets introduced by target multiSelection box? (see image)
<img width="600" height="70" alt="image" src="https://github.com/user-attachments/assets/67b91e93-ed76-4422-baf5-dffdf6905a61" />
