### PR TITLE
BUG: Fix wrong camera in Rooms Eye View due to tag name mismatch

### DIFF
--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -172,25 +172,12 @@ vtkMRMLCameraNode* qSlicerRoomsEyeViewModuleWidgetPrivate::get3DViewCameraNode()
   }
 
   qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
-  vtkMRMLViewNode* viewNode = threeDView->mrmlViewNode();
-
-  // Get camera node for view
-  vtkCollection* cameras = q->mrmlScene()->GetNodesByClass("vtkMRMLCameraNode");
-  vtkMRMLCameraNode* cameraNode = nullptr;
-  for (int i = 0; i < cameras->GetNumberOfItems(); i++)
-  {
-    cameraNode = vtkMRMLCameraNode::SafeDownCast(cameras->GetItemAsObject(i));
-    std::string viewUniqueName = std::string(viewNode->GetNodeTagName()) + cameraNode->GetLayoutName();
-    if (viewUniqueName == viewNode->GetID())
-    {
-      break;
-    }
-  }
+  vtkMRMLCameraNode* cameraNode = threeDView->cameraNode();
   if (!cameraNode)
   {
-    qCritical() << Q_FUNC_INFO << "Failed to find camera for view " << (viewNode ? viewNode->GetID() : "(null)");
+    qCritical() << Q_FUNC_INFO << "Failed to find camera for view "
+                << (threeDView->mrmlViewNode() ? threeDView->mrmlViewNode()->GetID() : "(null)");
   }
-  cameras->Delete();
   return cameraNode;
 }
 


### PR DESCRIPTION
The Beam's Eye View feature in the Rooms Eye View module was broken when multiple camera nodes were present in the scene.

The root cause was in `get3DViewCameraNode()`, which tried to find the correct camera by constructing a string from the view node's tag name and the camera's layout name, then comparing it against the view node's ID. The problem is that `GetNodeTagName()` returns the XML tag "View", not the class name prefix "vtkMRMLViewNode", so the constructed string "View1" never matched the view ID "vtkMRMLViewNode1". 

The loop always fell through without finding a match, leaving the camera pointer on the last node iterated — whichever camera happened to be last in the scene.

This accidentally works when only one camera existed in the scene, because the last camera was also the correct one.

The fix replaces the scene search entirely with a direct call to `threeDView->cameraNode()`. 