### PR TITLE
BUG: Fix Rooms Eye View picking the wrong 3D view when other extensions add their own views

### DIFF
--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -1174,7 +1174,10 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateGantryToFixedReferenceTransform(vtk
 
   this->IECLogic->UpdateGantryToFixedReferenceTransform(parameterNode->GetGantryRotationAngle());
   vtkMRMLLinearTransformNode* gantryToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkIECTransformLogic::Gantry, vtkIECTransformLogic::FixedReference);
-  gantryToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  if (gantryToFixedReferenceTransformNode)
+  {
+    gantryToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -1188,7 +1191,10 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateCollimatorToGantryTransform(vtkMRML
 
   this->IECLogic->UpdateCollimatorToGantryTransform(parameterNode->GetCollimatorRotationAngle());
   vtkMRMLLinearTransformNode* collimatorToGantryTransformNode = this->GetTransformNodeBetween(vtkIECTransformLogic::Collimator, vtkIECTransformLogic::Gantry);
-  collimatorToGantryTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  if (collimatorToGantryTransformNode)
+  {
+    collimatorToGantryTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1361,7 +1367,10 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportRotationToFixedRefere
 
   this->IECLogic->UpdatePatientSupportRotationToFixedReferenceTransform(parameterNode->GetPatientSupportRotationAngle());
   vtkMRMLLinearTransformNode* patientSupportRotationToFixedReferenceTransformNode = this->GetTransformNodeBetween(vtkIECTransformLogic::PatientSupportRotation, vtkIECTransformLogic::FixedReference);
-  patientSupportRotationToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  if (patientSupportRotationToFixedReferenceTransformNode)
+  {
+    patientSupportRotationToFixedReferenceTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1407,8 +1416,11 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdatePatientSupportToPatientSupportRotat
 
   vtkMRMLLinearTransformNode* patientSupportToPatientSupportRotationTransformNode =
     this->GetTransformNodeBetween(vtkIECTransformLogic::PatientSupport, vtkIECTransformLogic::PatientSupportRotation);
-  patientSupportToPatientSupportRotationTransformNode->SetAndObserveTransformToParent(patientSupportScalingTransform);
-  patientSupportToPatientSupportRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  if (patientSupportToPatientSupportRotationTransformNode)
+  {
+    patientSupportToPatientSupportRotationTransformNode->SetAndObserveTransformToParent(patientSupportScalingTransform);
+    patientSupportToPatientSupportRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1433,7 +1445,10 @@ void vtkSlicerRoomsEyeViewModuleLogic::UpdateTableTopToTableTopEccentricRotation
     0.0, 0.0); // pitch and roll not yet exposed in parameter node
   vtkMRMLLinearTransformNode* tableTopToTableTopEccentricRotationTransformNode =
     this->GetTransformNodeBetween(vtkIECTransformLogic::TableTop, vtkIECTransformLogic::TableTopEccentricRotation);
-  tableTopToTableTopEccentricRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  if (tableTopToTableTopEccentricRotationTransformNode)
+  {
+    tableTopToTableTopEccentricRotationTransformNode->Modified(); // Modified call is needed because it does not update display in app
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -89,6 +89,7 @@ public:
   qSlicerRoomsEyeViewModuleWidgetPrivate(qSlicerRoomsEyeViewModuleWidget& object);
   ~qSlicerRoomsEyeViewModuleWidgetPrivate()  = default;
   vtkSmartPointer<vtkSlicerRoomsEyeViewModuleLogic> logic() const;
+  qMRMLThreeDView* get3DView() const;
   vtkMRMLCameraNode* get3DViewCameraNode() const;
   qMRMLLayoutManager* getLayoutManager() const;
 
@@ -159,11 +160,8 @@ vtkMRMLRTPlanNode* qSlicerRoomsEyeViewModuleWidgetPrivate::currentPlanNode(vtkMR
 }
 
 //-----------------------------------------------------------------------------
-vtkMRMLCameraNode* qSlicerRoomsEyeViewModuleWidgetPrivate::get3DViewCameraNode() const
+qMRMLThreeDView* qSlicerRoomsEyeViewModuleWidgetPrivate::get3DView() const
 {
-  Q_Q(const qSlicerRoomsEyeViewModuleWidget);
-
-  // Get 3D view node
   qSlicerApplication* slicerApplication = qSlicerApplication::application();
   qSlicerLayoutManager* layoutManager = slicerApplication->layoutManager();
   if (!layoutManager->threeDViewCount())
@@ -171,7 +169,44 @@ vtkMRMLCameraNode* qSlicerRoomsEyeViewModuleWidgetPrivate::get3DViewCameraNode()
     return nullptr;
   }
 
-  qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
+  // Some extensions (for example ones adding virtual reality or hologram
+  // display support) introduce their own kind of 3D-like view; Slicer's standard 3D
+  // view recognizes those as views of its own type as well, and quietly creates an
+  // additional, normally hidden, view for them.
+  // To make sure the correct view is the one selected, this first asks the layout
+  // manager which 3D view is currently active, and if that is not available, falls
+  // back to the first view that went through the normal layout setup - the hidden
+  // views added by other extensions never go through that setup, so this reliably
+  // picks the right one.
+  vtkMRMLViewNode* activeViewNode = layoutManager->activeMRMLThreeDViewNode();
+  if (activeViewNode)
+  {
+    qMRMLThreeDWidget* widget = layoutManager->threeDWidget(QString(activeViewNode->GetLayoutName()));
+    if (widget)
+    {
+      return widget->threeDView();
+    }
+  }
+  for (int i = 0; i < layoutManager->threeDViewCount(); ++i)
+  {
+    qMRMLThreeDWidget* widget = layoutManager->threeDWidget(i);
+    if (widget && widget->threeDView()->mrmlViewNode() && widget->threeDView()->mrmlViewNode()->IsMappedInLayout())
+    {
+      return widget->threeDView();
+    }
+  }
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLCameraNode* qSlicerRoomsEyeViewModuleWidgetPrivate::get3DViewCameraNode() const
+{
+  qMRMLThreeDView* threeDView = this->get3DView();
+  if (!threeDView)
+  {
+    return nullptr;
+  }
+
   vtkMRMLCameraNode* cameraNode = threeDView->cameraNode();
   if (!cameraNode)
   {
@@ -1159,6 +1194,7 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewButtonClicked()
       cameraNode->GetCamera()->SetFocalPoint(isocenter);
     }
     cameraNode->SetViewUp(vup);
+    cameraNode->ResetClippingRange();
   }
 
   this->setMachinePartsOpacityForBeamsEyeView(0.1);
@@ -1214,9 +1250,11 @@ void qSlicerRoomsEyeViewModuleWidget::updateTreatmentOrientationMarker()
   vtkMRMLRoomsEyeViewNode* paramNode = vtkMRMLRoomsEyeViewNode::SafeDownCast(d->MRMLNodeComboBox_ParameterSet->currentNode());
 
   // Get 3D view node
-  qSlicerApplication* slicerApplication = qSlicerApplication::application();
-  qSlicerLayoutManager* layoutManager = slicerApplication->layoutManager();
-  qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
+  qMRMLThreeDView* threeDView = d->get3DView();
+  if (!threeDView)
+  {
+    return;
+  }
   vtkMRMLViewNode* viewNode = threeDView->mrmlViewNode();
 
   // Update orientation marker if shown


### PR DESCRIPTION
The rooms eye view module found the 3D view by taking the first one in the layout manager's internal list, which is ordered by internal pointer value rather than anything meaningful. Extensions such as the virtual reality and Looking Glass add their own view types that are still recognized as regular 3D views by Slicer's view-matching logic, so they get registered as extra, normally hidden views that can end up first in that list - causing the wrong view, and therefore the wrong camera, to be used.

This adds a small helper that instead asks the layout manager for the 3D view the user is actually working with, falling back to the first view that went through normal layout setup (which the hidden views added by other extensions never do). The camera and orientation marker lookups now both go through this helper instead of repeating their own, less reliable, search.

Also reset the camera's clipping range after moving it to the beam's viewpoint, since the old near/far planes no longer make sense once the camera has jumped to a very different position.

Additionally, fix crash when selecting a beam is Room's Eye View before loading the machine.