### PR TITLE
ENH: Restore machine parts opacity in Rooms Eye View when the viewpoint changes

### DIFF
--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -77,6 +77,7 @@
 #include <vtkPolyData.h>
 #include <vtkMatrix4x4.h>
 #include <vtkTransform.h>
+#include <vtkWeakPointer.h>
 
 //-----------------------------------------------------------------------------
 /// \ingroup SlicerRt_QtModules_RoomsEyeView
@@ -95,6 +96,10 @@ public:
   vtkMRMLRTPlanNode* currentPlanNode(vtkMRMLRoomsEyeViewNode* paramNode);
 
   bool ModuleWindowInitialized;
+
+  // 3D view camera that the Beam's Eye View button positioned and is being watched
+  // for user interaction (moving the camera away cancels the Beam's Eye View)
+  vtkWeakPointer<vtkMRMLCameraNode> BeamsEyeViewCameraNode;
 };
 
 //-----------------------------------------------------------------------------
@@ -844,6 +849,7 @@ void qSlicerRoomsEyeViewModuleWidget::onCollimatorRotationSliderValueChanged(dou
     beamNode->SetCollimatorAngle(value);
   }
 
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
   d->getLayoutManager()->resumeRender();
@@ -940,6 +946,7 @@ void qSlicerRoomsEyeViewModuleWidget::onPatientSupportRotationSliderValueChanged
     }
   }
 
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
   this->checkForCollisions();
   this->updateTreatmentOrientationMarker();
   d->getLayoutManager()->resumeRender();
@@ -1163,12 +1170,33 @@ void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewButtonClicked()
 
   this->setMachinePartsOpacityForBeamsEyeView(0.1);
 
+  // Watch the positioned camera; if the user moves it away (rotates, pans, zooms the
+  // 3D view), the current viewpoint is no longer the beam's eye view, so restore the
+  // machine parts opacity
+  qvtkReconnect(d->BeamsEyeViewCameraNode.GetPointer(), cameraNode, vtkMRMLCameraNode::CameraInteractionEvent,
+    this, SLOT(onBeamsEyeViewCameraInteraction()));
+  d->BeamsEyeViewCameraNode = cameraNode;
+
   //TODO: Oblique slice updating real-time based on beam geometry
   //vtkMRMLSliceNode* redSliceNode = redSliceWidget->mrmlSliceNode();
   //redSliceNode->SetSliceVisible(1);
 
   //TODO: Camera roll also needs to be set to keep the field of view aligned with the beam's field
   //redSliceNode->SetWidgetNormalLockedToCamera(cameraNode->GetCamera()->GetID);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerRoomsEyeViewModuleWidget::onBeamsEyeViewCameraInteraction()
+{
+  Q_D(qSlicerRoomsEyeViewModuleWidget);
+
+  // The user moved the camera away from the positioned beam's eye viewpoint,
+  // so the lowered machine parts opacity no longer applies
+  this->setMachinePartsOpacityForBeamsEyeView(1.0);
+
+  qvtkDisconnect(d->BeamsEyeViewCameraNode.GetPointer(), vtkMRMLCameraNode::CameraInteractionEvent,
+    this, SLOT(onBeamsEyeViewCameraInteraction()));
+  d->BeamsEyeViewCameraNode = nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.h
@@ -84,6 +84,7 @@ protected slots:
   void onMovePatientWithTableTopCheckBoxToggled(bool);
 
   void onBeamsEyeViewButtonClicked();
+  void onBeamsEyeViewCameraInteraction();
 
   void onBeamNodeChanged(vtkMRMLNode*);
   void onPatientBodySegmentationNodeChanged(vtkMRMLNode*);


### PR DESCRIPTION
Opacity is lowered when entering the beam's eye viewpoint so the beam path can be seen through the machine. It was only restored again when the beam selection or the gantry angle changed.

Now it is also restored when the collimator or patient support angle changes, the other two angle-type controls.

It also restores the opacity as soon as the user manually moves the view away from the positioned viewpoint, by rotating, panning, or zooming, since the lowered opacity no longer makes sense once the beam's eye view is no longer being shown. This is detected through the signal the 3D view sends specifically for direct user interaction with the camera, which is not raised when the viewpoint is set up by the button itself, so positioning the view does not immediately undo its own opacity change.