### PR TITLE
BUG: Fix beam parameter changes becoming progressively slower

### DIFF
--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -507,6 +507,10 @@ void vtkMRMLRTBeamNode::SetCouchAngle(double angle)
 //----------------------------------------------------------------------------
 void vtkMRMLRTBeamNode::SetSAD(double sad)
 {
+  if (this->SAD == sad)
+  {
+    return;
+  }
   this->SAD = sad;
   this->Modified();
   this->InvokeCustomModifiedEvent(vtkMRMLRTBeamNode::BeamGeometryModified);

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -324,7 +324,7 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
   vtkMRMLRTIonBeamNode* ionBeamNode = vtkMRMLRTIonBeamNode::SafeDownCast(d->BeamNode);
   if (d->BeamNode && !ionBeamNode)
   {
-    connect( d->doubleSpinBox_SAD, SIGNAL(valueChanged(double)), this, SLOT(sourceDistanceChanged(double)) );
+    connect( d->doubleSpinBox_SAD, SIGNAL(valueChanged(double)), this, SLOT(sourceDistanceChanged(double)), Qt::UniqueConnection );
     disconnect( d->doubleSpinBox_VSADx, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisXDistanceChanged(double)) );
     disconnect( d->doubleSpinBox_VSADy, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisYDistanceChanged(double)) );
     // rename some labels
@@ -354,8 +354,8 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
   else if (ionBeamNode)
   {
     disconnect( d->doubleSpinBox_SAD, SIGNAL(valueChanged(double)), this, SLOT(sourceDistanceChanged(double)) );
-    connect( d->doubleSpinBox_VSADx, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisXDistanceChanged(double)) );
-    connect( d->doubleSpinBox_VSADy, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisYDistanceChanged(double)) );
+    connect( d->doubleSpinBox_VSADx, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisXDistanceChanged(double)), Qt::UniqueConnection );
+    connect( d->doubleSpinBox_VSADy, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisYDistanceChanged(double)), Qt::UniqueConnection );
 
     // Check for ScanSpot table and enable combo box
     if (vtkMRMLTableNode* scanspotTable = ionBeamNode->GetScanSpotTableNode())


### PR DESCRIPTION
Each time the beam parameters panel refreshed, a new duplicate listener was added to the source distance spinbox without removing the previous one. Because every value change triggers a refresh, the number of listeners, and also the number of geometry rebuilds, doubled with each edit, making subsequent changes exponentially slower.

Also added a guard so that setting the source distance to its current value is a no-op, as a double measure to help mitigate this issue.