### PR TITLE
BUG:  Use AddRepresentation to import body segment independent of source representation

### DIFF
--- a/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
+++ b/ExternalBeamPlanning/Widgets/Python/PyRadPlanUtils.py
@@ -224,12 +224,14 @@ def createAndLoadBodySegment(planNode, cst):
     # Add new segment directly as binary labelmap
     logging.info("Adding body segment to segmentation in Slicer.")
     LABELMAP = vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()
-    maskArray = sitk.GetArrayFromImage(bodyMask)
+    tempVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", "__tempBody__")
+    sitkUtils.PushVolumeToSlicer(bodyMask, tempVolumeNode)
+    orientedImageData = slicer.vtkSlicerSegmentationsModuleLogic.CreateOrientedImageDataFromVolumeNode(tempVolumeNode)
+    slicer.mrmlScene.RemoveNode(tempVolumeNode)
     newSegmentID = segmentation.AddEmptySegment("", bodySegmentName)
-    slicer.util.updateSegmentBinaryLabelmapFromArray(
-        maskArray, segmentationNode, newSegmentID, referenceVolumeNode
-    )
-    segmentation.SetSourceRepresentationName(LABELMAP)
+    newSegment = segmentation.GetSegment(newSegmentID)
+    newSegment.AddRepresentation(LABELMAP, orientedImageData)
+    segmentationNode.Modified()
 
     # Set body segment ID in plan node
     planNode.SetBodySegmentID(newSegmentID)


### PR DESCRIPTION
### Problem:
`updateSegmentBinaryLabelmapFromArray` internally calls `ImportLabelmapToSegmentationNode` which requires the segmentation's source representation to be binary labelmap. When the source representation is anything other than binary labelmap (e.g. planar contour), the import fails.

### Fix:
Replace `updateSegmentBinaryLabelmapFromArray` with direct `AddRepresentation` on the new segment via `vtkOrientedImageData`.