### PR TITLE
BUG: Fix camera and view detection for Beam's Eye View on External Beam Planning Module

### DIFF
--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -130,7 +130,7 @@ void vtkMRMLRTPlanNode::Copy(vtkMRMLNode *anode)
   this->DisableModifiedEventOn();
 
   vtkMRMLCopyBeginMacro(node);
-  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs, std::vector);
+  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);
@@ -171,7 +171,7 @@ void vtkMRMLRTPlanNode::CopyContent(vtkMRMLNode *anode, bool deepCopy/*=true*/)
 
   vtkMRMLCopyBeginMacro(node);
   vtkMRMLCopyFloatMacro(RxDose);
-  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs, std::vector);
+  vtkMRMLCopyStdStringVectorMacro(TargetSegmentIDs);
   vtkMRMLCopyStringMacro(BodySegmentID);
   vtkMRMLCopyIntMacro(IsocenterSpecification);
   vtkMRMLCopyIntMacro(NextBeamNumber);

--- a/Beams/Widgets/qMRMLBeamsTableView.cxx
+++ b/Beams/Widgets/qMRMLBeamsTableView.cxx
@@ -487,11 +487,8 @@ void qMRMLBeamsTableView::onBEVButtonClicked()
 }
 
 //-----------------------------------------------------------------------------
-vtkMRMLCameraNode* qMRMLBeamsTableView::get3DViewCameraNode()
+qMRMLThreeDView* qMRMLBeamsTableView::get3DView()
 {
-  Q_D(qMRMLBeamsTableView);
-
-  // Get 3D view node
   qSlicerApplication* slicerApplication = qSlicerApplication::application();
   qSlicerLayoutManager* layoutManager = slicerApplication->layoutManager();
   if (!layoutManager->threeDViewCount())
@@ -499,7 +496,38 @@ vtkMRMLCameraNode* qMRMLBeamsTableView::get3DViewCameraNode()
     return nullptr;
   }
 
-  qMRMLThreeDView* threeDView = layoutManager->threeDWidget(0)->threeDView();
+  // Prefer the active 3D view, hidden views added by other extensions never
+  // go through the normal layout setup, so the active view is more reliable
+  // than index 0.
+  vtkMRMLViewNode* activeViewNode = layoutManager->activeMRMLThreeDViewNode();
+  if (activeViewNode)
+  {
+    qMRMLThreeDWidget* widget = layoutManager->threeDWidget(QString(activeViewNode->GetLayoutName()));
+    if (widget)
+    {
+      return widget->threeDView();
+    }
+  }
+  for (int i = 0; i < layoutManager->threeDViewCount(); ++i)
+  {
+    qMRMLThreeDWidget* widget = layoutManager->threeDWidget(i);
+    if (widget && widget->threeDView()->mrmlViewNode() && widget->threeDView()->mrmlViewNode()->IsMappedInLayout())
+    {
+      return widget->threeDView();
+    }
+  }
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLCameraNode* qMRMLBeamsTableView::get3DViewCameraNode()
+{
+  qMRMLThreeDView* threeDView = this->get3DView();
+  if (!threeDView)
+  {
+    return nullptr;
+  }
+
   vtkMRMLCameraNode* cameraNode = threeDView->cameraNode();
   if (!cameraNode)
   {

--- a/Beams/Widgets/qMRMLBeamsTableView.h
+++ b/Beams/Widgets/qMRMLBeamsTableView.h
@@ -34,6 +34,7 @@
 #include <ctkVTKObject.h>
 
 class qMRMLBeamsTableViewPrivate;
+class qMRMLThreeDView;
 class vtkMRMLNode;
 class QTableWidgetItem;
 class QItemSelection;
@@ -96,6 +97,9 @@ protected slots:
 
   /// Handle BEV button click. Shows beam's eye view for the beam for which the button was clicked
   void onBEVButtonClicked();
+
+  /// Get the active (or first mapped) 3D view
+  qMRMLThreeDView* get3DView();
 
   /// Get camera node for the 3D view
   vtkMRMLCameraNode* get3DViewCameraNode();


### PR DESCRIPTION
This fixes the same bug that happened on Room's Eye View that was fixed on commit https://github.com/SlicerRt/SlicerRT/commit/80487992f155544e5b0730d1519ecb174ddc9f01 (merged on https://github.com/SlicerRt/SlicerRT/pull/323).

When there were multiple views added by different extensions, the Beam's Eye View in the External Beam Planning module would pick up those views instead of main active, making it seem as if clicking the button did nothing.

Also: fixed a bug in which a macro being called with too many arguments caused a crash when building with GCC. With MSVC it only showed a warning (which is probably why this error went undetected at first):

```
C4002: too many arguments for function-like macro invocation
```

However, with GCC it straight up crashed, making it impossible to build.