### PR TITLE
COMP: Fix IPOPT packaging in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,18 +152,11 @@ endif()
 set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
 list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkIECTransformLogic_DIR};vtkIECTransformLogic;RuntimeLibraries;/")
 
-# Add optimization runtime libraries if enabled
-if(EXTENSION_BUILDS_IPOPT)
-  if(DEFINED Mumps_DIR AND UNIX)
-    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Mumps_DIR};Mumps;RuntimeLibraries;/")
-  endif()
-  if(DEFINED HSL_DIR AND UNIX)
-    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${HSL_DIR};HSL;RuntimeLibraries;/")
-  endif()
-  if(DEFINED Ipopt_DIR)
-    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Ipopt_DIR};Ipopt;RuntimeLibraries;/")
-  endif()
-endif()
+# Note: Mumps/HSL/Ipopt are built via autotools (Unix) or downloaded as a prebuilt zip
+# (Windows), so none of them are CMake build trees with a cmake_install.cmake script.
+# They cannot be registered via CPACK_INSTALL_CMAKE_PROJECTS (CPack fails trying to run
+# a nonexistent install script for them); their runtime files are installed directly by
+# the modules that consume them instead (see ExternalBeamPlanning/Widgets/CMakeLists.txt).
 
 if((LINUX OR APPLE) AND EXTENSION_BUILDS_ADAPTIVE_CPP)
   list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${AdaptiveCpp_DIR};AdaptiveCpp;RuntimeLibraries;/")

--- a/ExternalBeamPlanning/Widgets/CMakeLists.txt
+++ b/ExternalBeamPlanning/Widgets/CMakeLists.txt
@@ -281,6 +281,14 @@ if(EXTENSION_BUILDS_IPOPT AND WIN32 AND DEFINED Ipopt_DLL_DIR)
         "$<TARGET_FILE_DIR:${KIT}>"
     )
   endforeach()
+
+  # Also install the DLLs for packaging. Ipopt is a prebuilt zip on Windows (not a CMake
+  # build tree), so it cannot be registered via CPACK_INSTALL_CMAKE_PROJECTS; install it
+  # as part of this module instead.
+  install(DIRECTORY "${Ipopt_DLL_DIR}/"
+    DESTINATION ${Slicer_INSTALL_QTLOADABLEMODULES_BIN_DIR}
+    COMPONENT RuntimeLibraries
+    FILES_MATCHING PATTERN "*.dll")
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
`CPACK_INSTALL_CMAKE_PROJECTS` requires every listed directory to be a CMake build tree with a generated `cmake_install.cmake`. The Mumps/HSL/Ipopt entries pointed at autotools install prefixes (Unix) or a prebuilt binaries zip extraction (Windows), none of which are CMake projects, so package failed with a generic "Error when generating package: SlicerRT" whenever EXTENSION_BUILDS_IPOPT=ON.

Removed those three entries from `CPACK_INSTALL_CMAKE_PROJECTS` in the top-level CMakeLists.txt.
Added a proper `install()` rule in `ExternalBeamPlanning/Widgets/CMakeLists.txt` so the IPOPT DLLs are installed as part of that module (which is a real CMake target with a valid install script) instead.

With this fix, both build and package work on Windows and Linux.

Re #298