### PR TITLE
BUG: Fix 3D view centering breaking when range shifter is present

### DIFF
--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -1490,6 +1490,10 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequen
     {
       proxyIonBeamNode->SetAndObserveRangeShifterNode(proxyRangeShifterNode);
       proxyRangeShifterNode->SetAndObserveParentBeamNode(proxyIonBeamNode);
+      // Rebuild geometry now that the parent beam is known; the first build (triggered when the
+      // proxy was synchronized to the sequence browser above) ran before the parent was set and
+      // silently produced empty polydata.
+      proxyRangeShifterNode->UpdateGeometry();
       rsShId = shNode->GetItemByDataNode(proxyRangeShifterNode);
     }
 


### PR DESCRIPTION
The range shifter model shown for a scanned beam sequence was never rebuilt after its parent beam reference was established, leaving it permanently empty and throwing off the 3D view's automatic centering.

Re #330