### PR TITLE
ENH: Wrap user-facing strings in translation functions across all SlicerRT modules

### DIFF
--- a/BatchProcessing/BatchStructureSetConversion.py
+++ b/BatchProcessing/BatchStructureSetConversion.py
@@ -8,6 +8,8 @@ import sys
 import logging
 from DICOMLib import DICOMUtils
 
+from slicer.i18n import tr as _
+
 slicer.exit_when_finished = True
 
 # ------------------------------------------------------------------------------
@@ -17,14 +19,14 @@ slicer.exit_when_finished = True
 class BatchStructureSetConversion(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "Batch Structure Set Conversion"
-        parent.categories = ["Testing.SlicerRT Tests"]
+        parent.title = _("Batch Structure Set Conversion")
+        parent.categories = [_("Testing.SlicerRT Tests")]
         parent.dependencies = ["DicomRtImportExport", "Segmentations"]
         parent.contributors = ["Csaba Pinter (Queen's)"]
-        parent.helpText = """
+        parent.helpText = _("""
     This is a module for converting DICOM structure set to labelmaps and saving them to disk.
-    """
-        parent.acknowledgementText = """This file was originally developed by Csaba Pinter, PerkLab, Queen's University and was supported through the Applied Cancer Research Unit program of Cancer Care Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care"""  # replace with organization, grant and thanks.
+    """)
+        parent.acknowledgementText = _("""This file was originally developed by Csaba Pinter, PerkLab, Queen's University and was supported through the Applied Cancer Research Unit program of Cancer Care Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care""")  # replace with organization, grant and thanks.
         self.parent = parent
 
         # Add this test to the SelfTest module's list for discovery when the module

--- a/Beams/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRTBeamPlugin.cxx
+++ b/Beams/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRTBeamPlugin.cxx
@@ -135,7 +135,7 @@ double qSlicerSubjectHierarchyRTBeamPlugin::canOwnSubjectHierarchyItem(vtkIdType
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyRTBeamPlugin::roleForPlugin()const
 {
-  return "RT beam";
+  return /*no tr*/ "RT beam";
 }
 
 //---------------------------------------------------------------------------

--- a/Beams/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRTPlanPlugin.cxx
+++ b/Beams/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRTPlanPlugin.cxx
@@ -147,7 +147,7 @@ double qSlicerSubjectHierarchyRTPlanPlugin::canOwnSubjectHierarchyItem(vtkIdType
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyRTPlanPlugin::roleForPlugin()const
 {
-  return "RT plan";
+  return /*no tr*/ "RT plan";
 }
 
 //---------------------------------------------------------------------------

--- a/Beams/Widgets/qMRMLBeamsTableView.cxx
+++ b/Beams/Widgets/qMRMLBeamsTableView.cxx
@@ -29,6 +29,7 @@
 #include <vtkWeakPointer.h>
 
 // Qt includes
+#include <QCoreApplication>
 #include <QDebug>
 #include <QKeyEvent>
 #include <QStringList>
@@ -96,7 +97,8 @@ void qMRMLBeamsTableViewPrivate::init()
   // Set table header properties
   this->ColumnLabels << "Number" << "Name" << "Gantry" << "Weight" << "Edit" << "Clone" << "BEV";
   this->BeamsTable->setHorizontalHeaderLabels(
-    QStringList() << "#" << "Name" << "Gantry" << "Weight" << "" );
+    QStringList() << qMRMLBeamsTableView::tr("#") << qMRMLBeamsTableView::tr("Name")
+      << qMRMLBeamsTableView::tr("Gantry") << qMRMLBeamsTableView::tr("Weight") << "" );
   this->BeamsTable->setColumnCount(this->ColumnLabels.size());
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
@@ -279,25 +281,25 @@ void qMRMLBeamsTableView::updateBeamTable()
     d->BeamsTable->setItem(row, d->columnIndex("Weight"), beamWeightItem);
 
     // Edit button
-    QPushButton* editButton = new QPushButton("Edit");
+    QPushButton* editButton = new QPushButton(tr("Edit"));
     editButton->setMaximumWidth(52);
-    editButton->setToolTip("Show beam details in Beams module");
+    editButton->setToolTip(tr("Show beam details in Beams module"));
     editButton->setProperty(ID_PROPERTY, beamNode->GetID());
     connect(editButton, SIGNAL(clicked()), this, SLOT(onEditButtonClicked()));
     d->BeamsTable->setCellWidget(row, d->columnIndex("Edit"), editButton);
 
     // Clone button
-    QPushButton* cloneButton = new QPushButton("Clone");
+    QPushButton* cloneButton = new QPushButton(tr("Clone"));
     cloneButton->setMaximumWidth(52);
-    cloneButton->setToolTip("Create a copy of this beam");
+    cloneButton->setToolTip(tr("Create a copy of this beam"));
     cloneButton->setProperty(ID_PROPERTY, beamNode->GetID());
     connect(cloneButton, SIGNAL(clicked()), this, SLOT(onCloneButtonClicked()));
     d->BeamsTable->setCellWidget(row, d->columnIndex("Clone"), cloneButton);
 
     // BEV button
-    QPushButton* bevButton = new QPushButton("BEV");
+    QPushButton* bevButton = new QPushButton(tr("BEV"));
     bevButton->setMaximumWidth(52);
-    bevButton->setToolTip("Show Beam's Eye View");
+    bevButton->setToolTip(tr("Show Beam's Eye View"));
     bevButton->setProperty(ID_PROPERTY, beamNode->GetID());
     connect(bevButton, SIGNAL(clicked()), this, SLOT(onBEVButtonClicked()));
     d->BeamsTable->setCellWidget(row, d->columnIndex("BEV"), bevButton);

--- a/Beams/qSlicerBeamsModule.cxx
+++ b/Beams/qSlicerBeamsModule.cxx
@@ -19,7 +19,6 @@
 ==============================================================================*/
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // SubjectHierarchy Plugins includes
@@ -67,7 +66,7 @@ qSlicerBeamsModule::qSlicerBeamsModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 QStringList qSlicerBeamsModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------
@@ -82,15 +81,13 @@ QStringList qSlicerBeamsModule::dependencies()const
 //-----------------------------------------------------------------------------
 QString qSlicerBeamsModule::helpText()const
 {
-  return QString("This module displays and handles beam geometry models created from the loaded isocenter and source fiducials. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Beams\">%1/Documentation/%2.%3/Modules/Beams</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module displays and handles beam geometry models created from the loaded isocenter and source fiducials.");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerBeamsModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------

--- a/Beams/qSlicerBeamsModuleWidget.cxx
+++ b/Beams/qSlicerBeamsModuleWidget.cxx
@@ -160,7 +160,7 @@ void qSlicerBeamsModuleWidget::updateButtonsState()
   Q_D(qSlicerBeamsModuleWidget);
 
   vtkMRMLRTBeamNode* beamNode = vtkMRMLRTBeamNode::SafeDownCast(d->MRMLNodeComboBox_RtBeam->currentNode());
-  d->pushButton_SwitchToParentPlan->setText(beamNode ? "Switch to parent plan" : "Go to External Beam Planning");
+  d->pushButton_SwitchToParentPlan->setText(beamNode ? tr("Switch to parent plan") : tr("Go to External Beam Planning"));
 }
 
 //-----------------------------------------------------------------------------

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.cxx
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.cxx
@@ -82,6 +82,7 @@ vtkPlanarContourToClosedSurfaceConversionRule::vtkPlanarContourToClosedSurfaceCo
   this->ImagePadding[1] = 4;
   this->ImagePadding[2] = 0;
 
+  // no tr (this description is written into the .seg.nrrd segmentation file)
   this->ConversionParameters->SetParameter(this->GetDefaultSliceThicknessParameterName(), "0.0",
     "Default thickness for contours if slice spacing cannot be calculated.");
   this->ConversionParameters->SetParameter(this->GetEndCappingParameterName(), "1",

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.h
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToClosedSurfaceConversionRule.h
@@ -86,7 +86,7 @@ public:
   unsigned int GetConversionCost(vtkDataObject* sourceRepresentation = nullptr, vtkDataObject* targetRepresentation = nullptr) override;
 
   /// Human-readable name of the converter rule
-  const char* GetName() override { return "Planar contour to closed surface"; };
+  const char* GetName() override { return /*no tr*/ "Planar contour to closed surface"; };
 
   /// Human-readable name of the source representation
   const char* GetSourceRepresentationName() override { return vtkSegmentationConverter::GetSegmentationPlanarContourRepresentationName(); };

--- a/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.h
+++ b/DicomRtImportExport/ConversionRules/vtkPlanarContourToRibbonModelConversionRule.h
@@ -71,7 +71,7 @@ public:
   unsigned int GetConversionCost(vtkDataObject* sourceRepresentation=nullptr, vtkDataObject* targetRepresentation=nullptr) override;
 
   /// Human-readable name of the converter rule
-  const char* GetName() override { return "Planar contour to ribbon model"; };
+  const char* GetName() override { return /*no tr*/ "Planar contour to ribbon model"; };
   
   /// Human-readable name of the source representation
   const char* GetSourceRepresentationName() override { return vtkSegmentationConverter::GetSegmentationPlanarContourRepresentationName(); };

--- a/DicomRtImportExport/ConversionRules/vtkRibbonModelToBinaryLabelmapConversionRule.h
+++ b/DicomRtImportExport/ConversionRules/vtkRibbonModelToBinaryLabelmapConversionRule.h
@@ -43,7 +43,7 @@ public:
   vtkSegmentationConverterRule* CreateRuleInstance() override;
 
   /// Human-readable name of the converter rule
-  const char* GetName() override { return "Ribbon model to binary labelmap"; };
+  const char* GetName() override { return /*no tr*/ "Ribbon model to binary labelmap"; };
   
   /// Human-readable name of the source representation
   const char* GetSourceRepresentationName() override { return vtkSlicerRtCommon::SEGMENTATION_RIBBON_MODEL_REPRESENTATION_NAME; };

--- a/DicomRtImportExport/DicomRtImportExportPlugin.py
+++ b/DicomRtImportExport/DicomRtImportExportPlugin.py
@@ -2,6 +2,7 @@ import os
 import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin
 import logging
+from slicer.i18n import tr as _
 
 #
 # This is the plugin to handle translation of DICOM RT objects
@@ -47,7 +48,7 @@ class DicomRtImportExportPluginClass(DICOMPlugin):
           # Convert to Qt loadable to pass it back
           qtLoadable = slicer.qSlicerDICOMLoadable()
           qtLoadable.copyFromVtkLoadable(vtkLoadable)
-          qtLoadable.tooltip = 'Valid RT object in selection'
+          qtLoadable.tooltip = _('Valid RT object in selection')
           qtLoadable.selected = True
           loadables.append(qtLoadable)
 
@@ -103,7 +104,7 @@ class DicomRtImportExportPluginClass(DICOMPlugin):
     if exportable is not None:
       # Set common properties for RT exportable
       exportable.name = self.loadType
-      exportable.tooltip = "Create DICOM files from RT study"
+      exportable.tooltip = _("Create DICOM files from RT study")
       exportable.subjectHierarchyItemID = subjectHierarchyItemID
       exportable.pluginClass = self.__module__
       # Define common required tags and default values
@@ -136,19 +137,19 @@ class DicomRtImportExportPlugin:
   as a loadable scripted module
   """
   def __init__(self, parent):
-    parent.title = "DICOM RT Import-Export Plugin"
-    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.title = _("DICOM RT Import-Export Plugin")
+    parent.categories = [_("Developer Tools.DICOM Plugins")]
     parent.dependencies = []
     parent.contributors = "Csaba Pinter (Queen's), Andras Lasso (Queen's), Kevin Wang (UHN, Toronto)"
-    parent.helpText = """
+    parent.helpText = _("""
     Plugin to the DICOM Module to parse and load RT entities from DICOM files.
     No module interface here, only in the DICOM module
-    """
-    parent.acknowledgementText = """
+    """)
+    parent.acknowledgementText = _("""
     This DICOM Plugin was developed by
     Csaba Pinter, PerkLab, Queen's University, Kingston, ON, CA
     and was funded by OCAIRO, CCO/CINO
-    """
+    """)
 
     # don't show this module - it only appears in the DICOM module
     parent.hidden = True

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -84,6 +84,7 @@
 
 // MRML includes
 #include <vtkMRMLColorTableNode.h>
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLMarkupsCurveNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelHierarchyNode.h>
@@ -790,16 +791,16 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadRtPlan(vtkSlicerD
     scene->AddNode(doseReferencesTableNode);
 
     doseReferencesTableNode->SetUseColumnTitleAsColumnHeader(true);
-    doseReferencesTableNode->SetColumnDescription("Description", "Dose Reference Description");
-    doseReferencesTableNode->SetColumnDescription("Structure Type", "Dose Reference Structure Type");
-    doseReferencesTableNode->SetColumnDescription("Reference Type", "Dose Reference Type");
-    doseReferencesTableNode->SetColumnDescription("Target Min. Dose", "Target/Organ Minimum Dose (in Gy)");
-    doseReferencesTableNode->SetColumnDescription("Target Prescription Dose", "Target Prescription Dose (in Gy)");
-    doseReferencesTableNode->SetColumnDescription("Target Max. Dose", "Target/Organ Maximum Dose (in Gy)");
-    doseReferencesTableNode->SetColumnDescription("Target Underdose Frac.", "Target Underdose Volume Fraction (in %)");
-    doseReferencesTableNode->SetColumnDescription("Weight", "Constraint Weight");
-    doseReferencesTableNode->SetColumnDescription("Organ Max. Dose", "Organ at Risk Maximum Dose (in Gy)");
-    doseReferencesTableNode->SetColumnDescription("Organ Overdose Frac.", "Organ at Risk Overdose Volume Fraction (in %)");
+    doseReferencesTableNode->SetColumnDescription("Description", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Dose Reference Description").c_str());
+    doseReferencesTableNode->SetColumnDescription("Structure Type", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Dose Reference Structure Type").c_str());
+    doseReferencesTableNode->SetColumnDescription("Reference Type", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Dose Reference Type").c_str());
+    doseReferencesTableNode->SetColumnDescription("Target Min. Dose", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Target/Organ Minimum Dose (in Gy)").c_str());
+    doseReferencesTableNode->SetColumnDescription("Target Prescription Dose", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Target Prescription Dose (in Gy)").c_str());
+    doseReferencesTableNode->SetColumnDescription("Target Max. Dose", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Target/Organ Maximum Dose (in Gy)").c_str());
+    doseReferencesTableNode->SetColumnDescription("Target Underdose Frac.", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Target Underdose Volume Fraction (in %)").c_str());
+    doseReferencesTableNode->SetColumnDescription("Weight", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Constraint Weight").c_str());
+    doseReferencesTableNode->SetColumnDescription("Organ Max. Dose", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Organ at Risk Maximum Dose (in Gy)").c_str());
+    doseReferencesTableNode->SetColumnDescription("Organ Overdose Frac.", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Organ at Risk Overdose Volume Fraction (in %)").c_str());
 
     vtkSmartPointer< vtkTable > doseTable = vtkSmartPointer< vtkTable >::Take(table);
     doseReferencesTableNode->SetAndObserveTable(doseTable);
@@ -2026,9 +2027,9 @@ vtkMRMLTableNode* vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::CreateMu
     table->SetValue(size, 2, 0.); // side "2" set last unused value to zero
 
     tableNode->SetUseColumnTitleAsColumnHeader(true);
-    tableNode->SetColumnDescription("Boundary", "Leaf pair boundary");
-    tableNode->SetColumnDescription("1", "Leaf position on the side \"1\"");
-    tableNode->SetColumnDescription("2", "Leaf position on the side \"2\"");
+    tableNode->SetColumnDescription("Boundary", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Leaf pair boundary").c_str());
+    tableNode->SetColumnDescription("1", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Leaf position on the side \"1\"").c_str());
+    tableNode->SetColumnDescription("2", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Leaf position on the side \"2\"").c_str());
     return tableNode;
   }
   else
@@ -2081,9 +2082,9 @@ vtkMRMLTableNode* vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::CreateSc
       table->SetValue(row, 2, weights[row]);
     }
     tableNode->SetUseColumnTitleAsColumnHeader(true);
-    tableNode->SetColumnDescription("X", "Scan spot positions X");
-    tableNode->SetColumnDescription("Y", "Scan spot positions Y");
-    tableNode->SetColumnDescription("Weight", "Scan spot meterset weights");
+    tableNode->SetColumnDescription("X", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Scan spot positions X").c_str());
+    tableNode->SetColumnDescription("Y", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Scan spot positions Y").c_str());
+    tableNode->SetColumnDescription("Weight", vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Scan spot meterset weights").c_str());
     return tableNode;
   }
   else
@@ -2617,21 +2618,21 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
   vtkMRMLScene* mrmlScene = this->GetMRMLScene();
   if (!mrmlScene)
   {
-    error = "MRML scene not valid";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "MRML scene not valid");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(this->GetMRMLScene());
   if (!shNode)
   {
-    error = "Failed to access subject hierarchy node";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to access subject hierarchy node");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
 
   if (exportables->GetNumberOfItems() < 1)
   {
-    error = "Exportable list contains no exportables";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Exportable list contains no exportables");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
@@ -2759,7 +2760,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
   // Make sure there is an image node.  Don't check for struct / dose, as those are optional
   if (!imageNode)
   {
-    error = "Must export the primary anatomical (CT/MR) image";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Must export the primary anatomical (CT/MR) image");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
@@ -2790,7 +2791,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
   vtkSmartPointer<vtkOrientedImageData> imageOrientedImageData = vtkSmartPointer<vtkOrientedImageData>::New();
   if (!vtkSlicerRtCommon::ConvertVolumeNodeToVtkOrientedImageData(imageNode, imageOrientedImageData))
   {
-    error = "Failed to convert anatomical image " + std::string(imageNode->GetName()) + " to oriented image data";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to convert anatomical image ") + std::string(imageNode->GetName()) + vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", " to oriented image data");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
@@ -2811,7 +2812,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
   Plm_image::Pointer plm_img = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(imageOrientedImageData);
   if (plm_img->dim(0) * plm_img->dim(1) * plm_img->dim(2) == 0)
   {
-    error = "Failed to convert anatomical (CT/MR) image to Plastimatch format";
+    error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to convert anatomical (CT/MR) image to Plastimatch format");
     vtkErrorMacro("ExportDicomRTStudy: " + error);
     return error;
   }
@@ -2823,7 +2824,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
     vtkSmartPointer<vtkOrientedImageData> doseOrientedImageData = vtkSmartPointer<vtkOrientedImageData>::New();
     if (!vtkSlicerRtCommon::ConvertVolumeNodeToVtkOrientedImageData(doseNode, doseOrientedImageData))
     {
-      error = "Failed to convert dose volume " + std::string(doseNode->GetName()) + " to oriented image data";
+      error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to convert dose volume ") + std::string(doseNode->GetName()) + vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", " to oriented image data");
       vtkErrorMacro("ExportDicomRTStudy: " + error);
       return error;
     }
@@ -2844,7 +2845,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
     Plm_image::Pointer dose_img = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(doseOrientedImageData);
     if (dose_img->dim(0) * dose_img->dim(1) * dose_img->dim(2) == 0)
     {
-      error = "Failed to convert dose volume to Plastimatch format";
+      error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to convert dose volume to Plastimatch format");
       vtkErrorMacro("ExportDicomRTStudy: " + error);
       return error;
     }
@@ -2862,7 +2863,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
       if ( !segmentationNode->GetSegmentation()->CreateRepresentation(
         vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() ) )
       {
-        error = "Failed to get binary labelmap representation from segmentation " + std::string(segmentationNode->GetName());
+        error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to get binary labelmap representation from segmentation ") + std::string(segmentationNode->GetName());
         vtkErrorMacro("ExportDicomRTStudy: " + error);
         return error;
       }
@@ -2885,7 +2886,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
 #endif
         if (!binaryLabelmap)
         {
-          error = "Failed to get binary labelmap representation from segment " + segmentID;
+          error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to get binary labelmap representation from segment ") + segmentID;
           vtkErrorMacro("ExportDicomRTStudy: " + error);
           return error;
         }
@@ -2898,7 +2899,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
         {
           if (!vtkSlicerSegmentationsModuleLogic::ApplyParentTransformToOrientedImageData(segmentationNode, binaryLabelmapCopy))
           {
-            std::string errorMessage("Failed to apply parent transformation to exported segment");
+            std::string errorMessage(vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to apply parent transformation to exported segment"));
             vtkErrorMacro("ExportDicomRTStudy: " << errorMessage);
             return errorMessage;
           }
@@ -2909,7 +2910,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
         {
           if (!vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(binaryLabelmapCopy, imageOrientedImageData, binaryLabelmapCopy))
           {
-            error = "Failed to resample segment " + segmentID + " to match anatomical image geometry";
+            error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to resample segment ") + segmentID + vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", " to match anatomical image geometry");
             vtkErrorMacro("ExportDicomRTStudy: " + error);
             return error;
           }
@@ -2919,7 +2920,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
         Plm_image::Pointer plmStructure = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(binaryLabelmapCopy);
         if (!plmStructure)
         {
-          error = "Failed to convert segment labelmap " + segmentID + " to Plastimatch image";
+          error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to convert segment labelmap ") + segmentID + vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", " to Plastimatch image");
           vtkErrorMacro("ExportDicomRTStudy: " + error);
           return error;
         }
@@ -2938,7 +2939,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
       if ( !segmentationNode->GetSegmentation()->CreateRepresentation(
         vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName() ) )
       {
-        error = "Failed to get closed surface representation from segmentation " + std::string(segmentationNode->GetName());
+        error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to get closed surface representation from segmentation ") + std::string(segmentationNode->GetName());
         vtkErrorMacro("ExportDicomRTStudy: " + error);
         return error;
       }
@@ -2974,7 +2975,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
           segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName()) );
         if (!closedSurfacePolyData)
         {
-          error = "Failed to get closed surface representation from segment " + segmentID;
+          error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Failed to get closed surface representation from segment ") + segmentID;
           vtkErrorMacro("ExportDicomRTStudy: " + error);
           return error;
         }
@@ -3046,7 +3047,7 @@ std::string vtkSlicerDicomRtImportExportModuleLogic::ExportDicomRTStudy(vtkColle
     }
     else
     {
-      error = "Structure set contains unsupported master representation";
+      error = vtkMRMLTr("vtkSlicerDicomRtImportExportModuleLogic", "Structure set contains unsupported master representation");
       vtkErrorMacro("ExportDicomRTStudy: " + error);
       return error;
     }

--- a/DicomRtImportExport/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRtDoseVolumePlugin.cxx
+++ b/DicomRtImportExport/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRtDoseVolumePlugin.cxx
@@ -94,11 +94,11 @@ void qSlicerSubjectHierarchyRtDoseVolumePluginPrivate::init()
 {
   Q_Q(qSlicerSubjectHierarchyRtDoseVolumePlugin);
 
-  this->ConvertToRtDoseVolumeAction = new QAction("Convert to RT dose volume...",q);
+  this->ConvertToRtDoseVolumeAction = new QAction(qSlicerSubjectHierarchyRtDoseVolumePlugin::tr("Convert to RT dose volume..."),q);
   QObject::connect(this->ConvertToRtDoseVolumeAction, SIGNAL(triggered()), q, SLOT(convertCurrentNodeToRtDoseVolume()));
-  this->CreateIsodoseAction = new QAction("Create isodose surfaces...",q);
+  this->CreateIsodoseAction = new QAction(qSlicerSubjectHierarchyRtDoseVolumePlugin::tr("Create isodose surfaces..."),q);
   QObject::connect(this->CreateIsodoseAction, SIGNAL(triggered()), q, SLOT(createIsodoseForCurrentItem()));
-  this->CalculateDvhAction = new QAction("Calculate DVH...",q);
+  this->CalculateDvhAction = new QAction(qSlicerSubjectHierarchyRtDoseVolumePlugin::tr("Calculate DVH..."),q);
   QObject::connect(this->CalculateDvhAction, SIGNAL(triggered()), q, SLOT(calculateDvhForCurrentItem()));
 }
 
@@ -167,7 +167,7 @@ double qSlicerSubjectHierarchyRtDoseVolumePlugin::canOwnSubjectHierarchyItem(vtk
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyRtDoseVolumePlugin::roleForPlugin()const
 {
-  return "RT dose volume";
+  return /*no tr*/ "RT dose volume";
 }
 
 //-----------------------------------------------------------------------------
@@ -324,7 +324,7 @@ void qSlicerSubjectHierarchyRtDoseVolumePlugin::convertCurrentNodeToRtDoseVolume
   vtkIdType studyItemID = shNode->GetItemAncestorAtLevel(currentItemID, vtkMRMLSubjectHierarchyConstants::GetDICOMLevelStudy());
   if (!studyItemID)
   {
-    QString message("The volume must be under a study in order to be converted to dose. Please drag&drop the volume under a study. If there is no study, it can be created under a subject. Consult the help window for more details.");
+    QString message(tr("The volume must be under a study in order to be converted to dose. Please drag&drop the volume under a study. If there is no study, it can be created under a subject. Consult the help window for more details."));
     qCritical() << Q_FUNC_INFO << ": Failed to find study item among the ancestors of current item '" << shNode->GetItemName(currentItemID).c_str() << "'! " << message;
     QMessageBox::warning(nullptr, tr("Failed to convert volume to dose"), message);
     return;

--- a/DicomRtImportExport/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRtImagePlugin.cxx
+++ b/DicomRtImportExport/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRtImagePlugin.cxx
@@ -125,7 +125,7 @@ double qSlicerSubjectHierarchyRtImagePlugin::canOwnSubjectHierarchyItem(vtkIdTyp
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyRtImagePlugin::roleForPlugin()const
 {
-  return "RT image";
+  return /*no tr*/ "RT image";
 }
 
 //---------------------------------------------------------------------------

--- a/DicomRtImportExport/qSlicerDicomRtImportExportModule.cxx
+++ b/DicomRtImportExport/qSlicerDicomRtImportExportModule.cxx
@@ -28,7 +28,6 @@
 #include <QDebug> 
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // SubjectHierarchy Plugins includes
@@ -77,15 +76,15 @@ qSlicerDicomRtImportExportModule::~qSlicerDicomRtImportExportModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerDicomRtImportExportModule::helpText()const
 {
-  return QString("The DicomRtImportExport module enables importing and loading DICOM RT files into the Slicer DICOM database and the Slicer scene, and exporting MRML nodes into DICOM-RT files"
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/DicomRtImportExport\">%1/Documentation/%2.%3/Modules/Models</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("The DicomRtImportExport module enables importing and loading DICOM RT files into the Slicer DICOM database and the Slicer scene, and exporting MRML nodes into DICOM-RT files"
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/DicomRtImport.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDicomRtImportExportModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------
@@ -101,7 +100,7 @@ QStringList qSlicerDicomRtImportExportModule::contributors()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerDicomRtImportExportModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/DicomSroImportExport/DicomSroImportExportPlugin.py
+++ b/DicomSroImportExport/DicomSroImportExportPlugin.py
@@ -2,6 +2,7 @@ import os
 import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin
 import logging
+from slicer.i18n import tr as _
 
 #
 # This is the plugin to handle translation of spatial registration object
@@ -46,7 +47,7 @@ class DicomSroImportExportPluginClass(DICOMPlugin):
           # Convert to Qt loadable to pass it back
           qtLoadable = slicer.qSlicerDICOMLoadable()
           qtLoadable.copyFromVtkLoadable(vtkLoadable)
-          qtLoadable.tooltip = 'Valid REG object in selection'
+          qtLoadable.tooltip = _('Valid REG object in selection')
           qtLoadable.selected = True
           loadables.append(qtLoadable)
 
@@ -90,7 +91,7 @@ class DicomSroImportExportPluginClass(DICOMPlugin):
     # Define type-specific required tags and default values
     exportable.setTag('Modality', 'REG')
     exportable.name = self.loadType
-    exportable.tooltip = "Create DICOM file from registration result"
+    exportable.tooltip = _("Create DICOM file from registration result")
     exportable.subjectHierarchyItemID = subjectHierarchyItemID
     exportable.pluginClass = self.__module__
     # Define common required tags and default values
@@ -105,13 +106,13 @@ class DicomSroImportExportPluginClass(DICOMPlugin):
       shn = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
       transformNode = shn.GetItemDataNode(exportable.subjectHierarchyItemID)
       if transformNode is None or not transformNode.IsA('vtkMRMLTransformNode'):
-        return 'Invalid transform node in exportable (ItemID:' + str(exportable.subjectHierarchyItemID)
+        return _('Invalid transform node in exportable (ItemID:') + str(exportable.subjectHierarchyItemID)
 
       # Get moving and fixed volumes involved in the registration
       movingVolumeNode = transformNode.GetNodeReference(slicer.vtkMRMLTransformNode.GetMovingNodeReferenceRole())
       fixedVolumeNode = transformNode.GetNodeReference(slicer.vtkMRMLTransformNode.GetFixedNodeReferenceRole())
       if movingVolumeNode is None or fixedVolumeNode is None:
-        currentError = 'Failed to find moving and/or fixed image for transform ' + transformNode.GetName()
+        currentError = _('Failed to find moving and/or fixed image for transform ') + transformNode.GetName()
         logging.error(currentError + '. These references are needed in order to export the transform into DICOM SRO. Please make sure the transform is created by a registration module.')
         errorMessage += currentError + '\n'
         continue
@@ -129,7 +130,7 @@ class DicomSroImportExportPluginClass(DICOMPlugin):
       sroExporter.SetOutputDirectory(exportable.directory)
       success = sroExporter.DoExport()
       if success != 0:
-        currentError = 'Failed to export transform node to DICOM SRO: ' + transformNode.GetName()
+        currentError = _('Failed to export transform node to DICOM SRO: ') + transformNode.GetName()
         logging.error(currentError)
         errorMessage += currentError + '\n'
         continue
@@ -146,20 +147,20 @@ class DicomSroImportExportPlugin:
   as a loadable scripted module
   """
   def __init__(self, parent):
-    parent.title = "DICOM Spatial Registration Object Plugin"
-    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.title = _("DICOM Spatial Registration Object Plugin")
+    parent.categories = [_("Developer Tools.DICOM Plugins")]
     parent.contributors = ["Kevin Wang (RMP, PMH), Csaba Pinter (Queen's)"]
-    parent.helpText = """
+    parent.helpText = _("""
     Plugin to the DICOM Module to parse and load spatial registration
     from DICOM files.
     No module interface here, only in the DICOM module
-    """
-    parent.acknowledgementText = """
+    """)
+    parent.acknowledgementText = _("""
     This DICOM Plugin was developed by
     Kevin Wang, RMP, PMH and
     Csaba Pinter, PerkLab, Queen's University, Kingston, ON, CA
     and was funded by OCAIRO, CCO's ACCU program, and CANARIE
-    """
+    """)
 
     # don't show this module - it only appears in the DICOM module
     parent.hidden = True

--- a/DicomSroImportExport/qSlicerDicomSroImportExportModule.cxx
+++ b/DicomSroImportExport/qSlicerDicomSroImportExportModule.cxx
@@ -23,7 +23,6 @@
 #include <QDebug> 
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // ExtensionTemplate Logic includes
@@ -69,15 +68,15 @@ qSlicerDicomSroImportExportModule::~qSlicerDicomSroImportExportModule() = defaul
 //-----------------------------------------------------------------------------
 QString qSlicerDicomSroImportExportModule::helpText()const
 {
-  return QString("The DicomSroImportExport module enables importing and loading DICOM Spatial Registration Objects into the Slicer DICOM database and the Slicer scene, and exporting transformations as DICOM SROs. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/DicomSroImport\">%1/Documentation/%2.%3/Modules/Models</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("The DicomSroImportExport module enables importing and loading DICOM Spatial Registration Objects into the Slicer DICOM database and the Slicer scene, and exporting transformations as DICOM SROs. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/DicomSroImportExport.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDicomSroImportExportModule::acknowledgementText()const
 {
-  return "This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.";
+  return tr("This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.");
 }
 
 //-----------------------------------------------------------------------------
@@ -97,7 +96,7 @@ QIcon qSlicerDicomSroImportExportModule::icon()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerDicomSroImportExportModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/DoseAccumulation/Logic/vtkSlicerDoseAccumulationModuleLogic.cxx
+++ b/DoseAccumulation/Logic/vtkSlicerDoseAccumulationModuleLogic.cxx
@@ -33,6 +33,7 @@
 #include "vtkSlicerIsodoseModuleLogic.h"
 
 // MRML includes
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScalarVolumeDisplayNode.h>
 #include <vtkMRMLTransformNode.h>
@@ -172,7 +173,7 @@ std::string vtkSlicerDoseAccumulationModuleLogic::AccumulateDoseVolumes(vtkMRMLD
 {
   if (!parameterNode)
   {
-    std::string errorMessage("No parameter set currentNode");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "No parameter set currentNode");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -181,7 +182,7 @@ std::string vtkSlicerDoseAccumulationModuleLogic::AccumulateDoseVolumes(vtkMRMLD
   int numberOfInputDoseVolumes = parameterNode->GetNumberOfSelectedInputVolumeNodes();
   if (numberOfInputDoseVolumes == 0)
   {
-    std::string errorMessage("No dose volume selected");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "No dose volume selected");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -191,13 +192,13 @@ std::string vtkSlicerDoseAccumulationModuleLogic::AccumulateDoseVolumes(vtkMRMLD
   vtkMRMLScalarVolumeNode* referenceDoseVolumeNode = parameterNode->GetReferenceDoseVolumeNode();
   if (referenceDoseVolumeNode == nullptr)
   {
-    std::string errorMessage("Reference volume not specified");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "Reference volume not specified");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
   if (outputAccumulatedDoseVolumeNode == nullptr)
   {
-    std::string errorMessage("Output volume not specified");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "Output volume not specified");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -214,7 +215,7 @@ std::string vtkSlicerDoseAccumulationModuleLogic::AccumulateDoseVolumes(vtkMRMLD
     if (!currentInputDoseVolumeNode->GetImageData())
     {
       std::stringstream errorMessage;
-      errorMessage << "No image data in input volume #" << inputVolumeIndex;
+      errorMessage << vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "No image data in input volume #") << inputVolumeIndex;
       vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage.str());
       return errorMessage.str().c_str();
     }
@@ -289,21 +290,21 @@ std::string vtkSlicerDoseAccumulationModuleLogic::AccumulateDoseVolumes(vtkMRMLD
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(this->GetMRMLScene());
   if (!shNode)
   {
-    std::string errorMessage("Failed to access subject hierarchy node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "Failed to access subject hierarchy node");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
   vtkIdType referenceDoseVolumeShItemID = shNode->GetItemByDataNode(referenceDoseVolumeNode);
   if (referenceDoseVolumeShItemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
   {
-    std::string errorMessage("No subject hierarchy currentNode found for reference dose");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "No subject hierarchy currentNode found for reference dose");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }
   vtkIdType studyItemID = shNode->GetItemAncestorAtLevel(referenceDoseVolumeShItemID, vtkMRMLSubjectHierarchyConstants::GetDICOMLevelStudy());
   if (studyItemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
   {
-    std::string errorMessage("No study currentNode found for reference dose");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseAccumulationModuleLogic", "No study currentNode found for reference dose");
     vtkErrorMacro("AccumulateDoseVolumes: " << errorMessage);
     return errorMessage;
   }

--- a/DoseAccumulation/qSlicerDoseAccumulationModule.cxx
+++ b/DoseAccumulation/qSlicerDoseAccumulationModule.cxx
@@ -18,9 +18,6 @@
 
 ==============================================================================*/
 
-// Slicer includes
-#include <qSlicerCoreApplication.h>
-
 // DoseAccumulation Logic includes
 #include <vtkSlicerDoseAccumulationModuleLogic.h>
 
@@ -61,7 +58,7 @@ qSlicerDoseAccumulationModule::qSlicerDoseAccumulationModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 QStringList qSlicerDoseAccumulationModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------
@@ -70,15 +67,15 @@ qSlicerDoseAccumulationModule::~qSlicerDoseAccumulationModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerDoseAccumulationModule::helpText()const
 {
-  return QString("This module accumulates the multiple dose distribution maps into one dose map. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/DoseAccumulation\">%1/Documentation/%2.%3/Modules/DoseAccumulation</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module accumulates the multiple dose distribution maps into one dose map. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/DoseAccumulation.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDoseAccumulationModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------

--- a/DoseAccumulation/qSlicerDoseAccumulationModuleWidget.cxx
+++ b/DoseAccumulation/qSlicerDoseAccumulationModuleWidget.cxx
@@ -279,7 +279,7 @@ void qSlicerDoseAccumulationModuleWidget::referenceDoseVolumeNodeChanged(vtkMRML
   this->updateButtonsState();
 
   d->label_Warning->setVisible(!paramNode->GetReferenceDoseVolumeNode() || !vtkSlicerRtCommon::IsDoseVolumeNode(paramNode->GetReferenceDoseVolumeNode()));
-  d->label_Warning->setText(QString("Volume is not a dose volume!"));
+  d->label_Warning->setText(tr("Volume is not a dose volume!"));
 }
 
 //-----------------------------------------------------------------------------
@@ -584,7 +584,7 @@ void qSlicerDoseAccumulationModuleWidget::checkDoseUnitsInSelectedVolumes()
   }
 
   d->label_Warning->setVisible( doseUnits.count() > 1 );
-  d->label_Warning->setText(QString("Dose units do not match!"));
+  d->label_Warning->setText(tr("Dose units do not match!"));
 }
 
 //-----------------------------------------------------------------------------

--- a/DoseComparison/Logic/vtkSlicerDoseComparisonModuleLogic.cxx
+++ b/DoseComparison/Logic/vtkSlicerDoseComparisonModuleLogic.cxx
@@ -36,6 +36,7 @@
 #include "vtkClosedSurfaceToBinaryLabelmapConversionRule.h"
 
 // MRML includes
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScalarVolumeDisplayNode.h>
 #include <vtkMRMLTransformNode.h>
@@ -218,7 +219,7 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
     vtkSegment* maskSegment = maskSegmentation->GetSegment(maskSegmentID);
     if (!maskSegment)
     {
-      std::string errorMessage("Failed to get mask segment");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Failed to get mask segment");
       vtkErrorMacro("ComputeGammaDoseDifference: " << errorMessage);
       return errorMessage;
     }
@@ -235,7 +236,7 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
     segmentationCopy->CopySegmentFromSegmentation(maskSegmentation, maskSegmentID);
     if (!segmentationCopy->CreateRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
     {
-      std::string errorMessage("Failed to create binary labelmap representation for mask segment");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Failed to create binary labelmap representation for mask segment");
       vtkErrorMacro("ComputeGammaDoseDifference: " << errorMessage);
       return errorMessage;
     }
@@ -252,7 +253,7 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
     if ( maskSegmentationNode->GetParentTransformNode()
       && (!vtkSlicerSegmentationsModuleLogic::ApplyParentTransformToOrientedImageData(maskSegmentationNode, maskSegmentLabelmap)) )
     {
-      std::string errorMessage("Failed to apply parent transform on mask segment");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Failed to apply parent transform on mask segment");
       vtkErrorMacro("ComputeGammaDoseDifference: " << errorMessage);
       return errorMessage;
     }
@@ -261,7 +262,7 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
     maskVolume = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(maskSegmentLabelmap);
     if (!maskVolume)
     {
-      std::string errorMessage("Failed to convert mask segment labelmap into Plm_image");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Failed to convert mask segment labelmap into Plm_image");
       vtkErrorMacro("ComputeGammaDoseDifference: " << errorMessage);
       return errorMessage;
     }
@@ -302,7 +303,7 @@ std::string vtkSlicerDoseComparisonModuleLogic::ComputeGammaDoseDifference(vtkMR
   vtkMRMLScalarVolumeNode* gammaVolumeNode = parameterNode->GetGammaVolumeNode();
   if (gammaVolumeNode == nullptr)
   {
-    std::string errorMessage("Invalid gamma volume node in parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Invalid gamma volume node in parameter set node");
     vtkErrorMacro("ComputeGammaDoseDifference: " << errorMessage);
     return errorMessage;
   }
@@ -409,7 +410,7 @@ void vtkSlicerDoseComparisonModuleLogic::CreateDefaultGammaColorTable()
   gammaColorTable->GetLookupTable()->ForceBuild();
   gammaColorTable->SetNamesFromColors();
   gammaColorTable->SaveWithSceneOff();
-  gammaColorTable->SetDescription("Goes from green to red, passing through the colors of the rainbow in between in reverse. Useful for a colorful display of a difference volume");
+  gammaColorTable->SetDescription(vtkMRMLTr("vtkSlicerDoseComparisonModuleLogic", "Goes from green to red, passing through the colors of the rainbow in between in reverse. Useful for a colorful display of a difference volume").c_str());
 
   this->GetMRMLScene()->AddNode(gammaColorTable);
   this->SetDefaultGammaColorTableNodeId(gammaColorTable->GetID());

--- a/DoseComparison/SubjectHierarchyPlugins/qSlicerSubjectHierarchyGammaPlugin.cxx
+++ b/DoseComparison/SubjectHierarchyPlugins/qSlicerSubjectHierarchyGammaPlugin.cxx
@@ -121,7 +121,7 @@ double qSlicerSubjectHierarchyGammaPlugin::canOwnSubjectHierarchyItem(vtkIdType 
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyGammaPlugin::roleForPlugin()const
 {
-  return "Gamma dose comparison volume";
+  return /*no tr*/ "Gamma dose comparison volume";
 }
 
 //---------------------------------------------------------------------------

--- a/DoseComparison/qSlicerDoseComparisonModule.cxx
+++ b/DoseComparison/qSlicerDoseComparisonModule.cxx
@@ -18,9 +18,6 @@
 
 ==============================================================================*/
 
-// Slicer includes
-#include <qSlicerCoreApplication.h>
-
 // SubjectHierarchy Plugins includes
 #include "qSlicerSubjectHierarchyPluginHandler.h"
 #include "qSlicerSubjectHierarchyGammaPlugin.h"
@@ -68,21 +65,21 @@ qSlicerDoseComparisonModule::~qSlicerDoseComparisonModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerDoseComparisonModule::helpText()const
 {
-  return QString("This module computes and displays dose comparison metrics. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/DoseComparison\">%1/Documentation/%2.%3/Modules/DoseComparison</a><br>").arg(
-    qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module computes and displays dose comparison metrics. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/DoseComparison.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDoseComparisonModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------
 QStringList qSlicerDoseComparisonModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/DoseComparison/qSlicerDoseComparisonModuleWidget.cxx
+++ b/DoseComparison/qSlicerDoseComparisonModuleWidget.cxx
@@ -280,7 +280,7 @@ void qSlicerDoseComparisonModuleWidget::setup()
   d->setupUi(this);
   this->Superclass::setup();
 
-  d->label_Warning->setText("");
+  d->label_Warning->setText(QString());
 
   d->SegmentSelectorWidget_Mask->setNoneEnabled(true);
 
@@ -691,7 +691,7 @@ void qSlicerDoseComparisonModuleWidget::applyClicked()
     return;
   }
 
-  d->label_Warning->setText("");
+  d->label_Warning->setText(QString());
 
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
@@ -700,7 +700,7 @@ void qSlicerDoseComparisonModuleWidget::applyClicked()
   d->GammaProgressDialog = new QProgressDialog((QWidget*)qSlicerApplication::application()->mainWindow());
   d->GammaProgressDialog->setModal(true);
   d->GammaProgressDialog->setMinimumDuration(150);
-  d->GammaProgressDialog->setLabelText("Computing gamma dose difference...");
+  d->GammaProgressDialog->setLabelText(tr("Computing gamma dose difference..."));
   d->GammaProgressDialog->show();
   QApplication::processEvents();
 
@@ -713,7 +713,7 @@ void qSlicerDoseComparisonModuleWidget::applyClicked()
   if (paramNode->GetResultsValid())
   {
     d->lineEdit_PassFraction->setText(
-      QString("%1 %").arg(paramNode->GetPassFractionPercent(),0,'f',2) );
+      tr("%1 %").arg(paramNode->GetPassFractionPercent(),0,'f',2) );
   }
 
   qvtkDisconnect( d->logic(), vtkSlicerRtCommon::ProgressUpdated, this, SLOT( onProgressUpdated(vtkObject*,void*,unsigned long,void*) ) );
@@ -762,7 +762,7 @@ void qSlicerDoseComparisonModuleWidget::checkDoseVolumeAttributes()
   }
   else
   {
-    d->label_Warning->setText("");
+    d->label_Warning->setText(QString());
   }
 }
 

--- a/DoseVolumeHistogram/Logic/vtkSlicerDoseVolumeHistogramModuleLogic.cxx
+++ b/DoseVolumeHistogram/Logic/vtkSlicerDoseVolumeHistogramModuleLogic.cxx
@@ -41,6 +41,7 @@
 #include "vtkMRMLSubjectHierarchyConstants.h"
 
 // MRML includes
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLLayoutNode.h>
 #include <vtkMRMLPlotSeriesNode.h>
 #include <vtkMRMLPlotChartNode.h>
@@ -176,7 +177,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
 {
   if (!this->GetMRMLScene() || !parameterNode)
   {
-    std::string errorMessage("Invalid MRML scene or parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Invalid MRML scene or parameter set node");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -186,7 +187,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   vtkMRMLScalarVolumeNode* doseVolumeNode = parameterNode->GetDoseVolumeNode();
   if ( !segmentationNode || !doseVolumeNode )
   {
-    std::string errorMessage("Both segmentation node and dose volume node need to be set");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Both segmentation node and dose volume node need to be set");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -217,7 +218,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
     vtkSlicerSegmentationsModuleLogic::CreateOrientedImageDataFromVolumeNode(doseVolumeNode) );
   if (!doseImageData.GetPointer())
   {
-    std::string errorMessage("Failed to get image data from dose volume");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to get image data from dose volume");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -266,7 +267,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
     // If conversion failed and there is no binary labelmap in the segmentation, then cannot calculate DVH
     if (!segmentationCopy->ContainsRepresentation(representationName) )
     {
-      std::string errorMessage("Unable to acquire binary labelmap from segmentation");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Unable to acquire binary labelmap from segmentation");
       vtkErrorMacro("ComputeDvh: " << errorMessage);
       return errorMessage;
     }
@@ -294,7 +295,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
         currentSegment->GetRepresentation(representationName) );
       if (!currentLabelmap)
       {
-        std::string errorMessage("Representation missing after converting with automatic oversampling factor");
+        std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Representation missing after converting with automatic oversampling factor");
         vtkErrorMacro("ComputeDvh: " << errorMessage);
         return errorMessage;
       }
@@ -322,7 +323,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
     if ( !vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(
       doseImageData, fixedOversampledDoseVolume, fixedOversampledDoseVolume, true ) )
     {
-      std::string errorMessage("Failed to resample dose volume");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to resample dose volume");
       vtkErrorMacro("ComputeDvh: " << errorMessage);
       return errorMessage;
     }
@@ -363,7 +364,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
 
     if (!segmentLabelmap)
     {
-      std::string errorMessage("Failed to get labelmap for segments");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to get labelmap for segments");
       vtkErrorMacro("ComputeDvh: " << errorMessage);
       return errorMessage;
     }
@@ -382,7 +383,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
       double backgroundValue[4] = {minimumValue, minimumValue, minimumValue, 0.0};
       if (!vtkSlicerSegmentationsModuleLogic::ApplyParentTransformToOrientedImageData(segmentationNode, segmentLabelmap, useFractionalLabelmap, backgroundValue))
       {
-        std::string errorMessage("Failed to apply parent transformation to segment");
+        std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to apply parent transformation to segment");
         vtkErrorMacro("ComputeDvh: " << errorMessage);
         return errorMessage;
       }
@@ -395,7 +396,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
       if ( !vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(
         segmentLabelmap, fixedOversampledDoseVolume, segmentLabelmap, useFractionalLabelmap, false, nullptr, minimumValue ) )
       {
-        std::string errorMessage("Failed to resample segment binary labelmap");
+        std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to resample segment binary labelmap");
         vtkErrorMacro("ComputeDvh: " << errorMessage);
         return errorMessage;
       }
@@ -415,7 +416,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
       if ( !vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(
         doseImageData, segmentLabelmap, oversampledDoseVolume, this->UseLinearInterpolationForDoseVolume ) )
       {
-        std::string errorMessage("Failed to resample dose volume");
+        std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to resample dose volume");
         vtkErrorMacro("ComputeDvh: " << errorMessage);
         return errorMessage;
       }
@@ -462,19 +463,19 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
 {
   if (!this->GetMRMLScene() || !parameterNode)
   {
-    std::string errorMessage("Invalid MRML scene or parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Invalid MRML scene or parameter set node");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
   if (!segmentLabelmap)
   {
-    std::string errorMessage("Invalid segment labelmap");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Invalid segment labelmap");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
   if (!oversampledDoseVolume)
   {
-    std::string errorMessage("Invalid oversampled dose volume");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Invalid oversampled dose volume");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -482,7 +483,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   vtkMRMLScalarVolumeNode* doseVolumeNode = parameterNode->GetDoseVolumeNode();
   if ( !segmentationNode || !doseVolumeNode )
   {
-    std::string errorMessage("Both segmentation node and dose volume node need to be set");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Both segmentation node and dose volume node need to be set");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -498,7 +499,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   {
     if (parameterNode->GetUseFractionalLabelmap())
     {
-      std::string errorMessage("Dose surface histogram is not currently supported for fractional labelmaps");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose surface histogram is not currently supported for fractional labelmaps");
       vtkErrorMacro("ComputeDvh: " << errorMessage);
       return errorMessage;
     }
@@ -574,7 +575,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   structureStencil->GetExtent(stencilExtent);
   if (stencilExtent[1]-stencilExtent[0] <= 0 || stencilExtent[3]-stencilExtent[2] <= 0 || stencilExtent[5]-stencilExtent[4] <= 0)
   {
-    std::string errorMessage("Invalid stenciled dose volume");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Invalid stenciled dose volume");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -600,7 +601,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   // Report error if there are no voxels in the stenciled dose volume (no non-zero voxels in the resampled labelmap)
   if (structureStat->GetVoxelCount() < 1)
   {
-    std::string errorMessage("Dose volume and the structure do not overlap"); // User-friendly error to help troubleshooting
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose volume and the structure do not overlap"); // User-friendly error to help troubleshooting
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -660,7 +661,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   }
   else
   {
-    std::string errorMessage("Failed to find metrics table row for structure " + segmentName);
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to find metrics table row for structure ") + segmentName;
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -717,7 +718,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   {
     if (rangeMin<0)
     {
-      std::string errorMessage("The dose volume contains negative dose values");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "The dose volume contains negative dose values");
       vtkErrorMacro("ComputeDvh: " << errorMessage);
       return errorMessage;
     }
@@ -759,11 +760,13 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   vtkTable* table = tableNode->GetTable();
   int numberOfRows = numSamples + (insertPointAtOrigin?1:0);
   vtkNew<vtkDoubleArray> columnDose;
-  columnDose->SetName(isDoseVolume ? "Dose" : "Intensity");
+  // no tr (column name is used as a lookup key in SetXColumnName/SetYColumnName below;
+  // it must stay stable regardless of UI language)
+  columnDose->SetName(isDoseVolume ? /*no tr*/ "Dose" : /*no tr*/ "Intensity");
   columnDose->SetNumberOfTuples(numberOfRows);
   table->AddColumn(columnDose);
   vtkNew<vtkDoubleArray> columnVolume;
-  columnVolume->SetName("Volume");
+  columnVolume->SetName(/*no tr*/ "Volume");
   columnVolume->SetNumberOfTuples(numberOfRows);
   table->AddColumn(columnVolume);
   table->SetNumberOfRows(numberOfRows);
@@ -817,7 +820,7 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::ComputeDvh(vtkMRMLDoseVolum
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(this->GetMRMLScene());
   if (!shNode)
   {
-    std::string errorMessage("Failed to access subject hierarchy node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Failed to access subject hierarchy node");
     vtkErrorMacro("ComputeDvh: " << errorMessage);
     return errorMessage;
   }
@@ -947,35 +950,37 @@ vtkMRMLPlotSeriesNode* vtkSlicerDoseVolumeHistogramModuleLogic::AddDvhToChart(vt
     {
       std::string doseUnitName = shNode->GetAttributeFromItemAncestor(
         doseShItemID, vtkSlicerRtCommon::DICOMRTIMPORT_DOSE_UNIT_NAME_ATTRIBUTE_NAME, vtkMRMLSubjectHierarchyConstants::GetDICOMLevelStudy());
-      doseAxisName = std::string("Dose [") + (doseUnitName.empty() ? "?" : doseUnitName) + "]";
+      doseAxisName = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose") + std::string(" [") + (doseUnitName.empty() ? "?" : doseUnitName) + "]";
     }
     else
     {
       vtkErrorMacro("AddDvhToChart: Invalid subject hierarchy node for dose volume");
-      doseAxisName = std::string("Dose");
+      doseAxisName = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose");
     }
 
     const char* doseSurfaceHistogramIdentifier = tableNode->GetAttribute(DVH_SURFACE_ATTRIBUTE_NAME.c_str());
     if (doseSurfaceHistogramIdentifier)
     {
-      chartTitle = "Dose Surface Histogram";
+      chartTitle = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose Surface Histogram");
     }
     else
     {
-      chartTitle = "Dose Volume Histogram";
+      chartTitle = vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose Volume Histogram");
     }
   }
   else
   {
-    doseAxisName="Intensity";
-    chartTitle="Intensity Volume Histogram";
+    doseAxisName=vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Intensity");
+    chartTitle=vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Intensity Volume Histogram");
   }
 
   chartNode->SetTitle(chartTitle.c_str());
   chartNode->SetXAxisTitle(doseAxisName.c_str());
-  plotSeriesNode->SetXColumnName(doseIdentifier ? "Dose" : "Intensity");
-  chartNode->SetYAxisTitle("Fractional volume [%]");
-  plotSeriesNode->SetYColumnName("Volume");
+  // no tr (column name is a lookup key into the table, must match the untranslated
+  // name set in ComputeDvh above regardless of UI language)
+  plotSeriesNode->SetXColumnName(doseIdentifier ? /*no tr*/ "Dose" : /*no tr*/ "Intensity");
+  chartNode->SetYAxisTitle(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Fractional volume [%]").c_str());
+  plotSeriesNode->SetYColumnName(/*no tr*/ "Volume");
   plotSeriesNode->SetPlotType(vtkMRMLPlotSeriesNode::PlotTypeScatter);
   plotSeriesNode->SetMarkerStyle(vtkMRMLPlotSeriesNode::MarkerStyleNone);
 
@@ -1841,11 +1846,11 @@ vtkCollection* vtkSlicerDoseVolumeHistogramModuleLogic::ReadCsvToTableNode(std::
   {
     vtkNew<vtkTable> structureDvhTable;
     vtkNew<vtkDoubleArray> columnDose;
-    columnDose->SetName("Dose");
+    columnDose->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Dose").c_str());
     columnDose->SetNumberOfTuples(lineNumber);
     structureDvhTable->AddColumn(columnDose);
     vtkNew<vtkDoubleArray> columnVolume;
-    columnVolume->SetName("Volume");
+    columnVolume->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Volume").c_str());
     columnVolume->SetNumberOfTuples(lineNumber);
     structureDvhTable->AddColumn(columnVolume);
     structureDvhTable->SetNumberOfRows(lineNumber);
@@ -1947,10 +1952,10 @@ std::string vtkSlicerDoseVolumeHistogramModuleLogic::AssembleDoseMetricName(vtkM
 
   // Assemble metric name
   std::string valueType = ( !doseUnitName.empty()
-    ? (DVH_METRIC_DOSE_POSTFIX + " (" + doseUnitName + ")")
-    : (DVH_METRIC_INTENSITY_POSTFIX) );
+    ? (vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", DVH_METRIC_DOSE_POSTFIX.c_str()) + " (" + doseUnitName + ")")
+    : (vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", DVH_METRIC_INTENSITY_POSTFIX.c_str())) );
   std::ostringstream metricNameStream;
-  metricNameStream << doseMetricAttributeNamePrefix << valueType;
+  metricNameStream << vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", doseMetricAttributeNamePrefix.c_str()) << valueType;
 
   return metricNameStream.str();
 }
@@ -1986,7 +1991,7 @@ void vtkSlicerDoseVolumeHistogramModuleLogic::InitializeMetricsTable(vtkMRMLDose
 
   // Add default columns
   vtkSmartPointer<vtkBitArray> visColumn = vtkSmartPointer<vtkBitArray>::New();
-  visColumn->SetName("Show");
+  visColumn->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Show").c_str());
   metricsTableNode->AddColumn(visColumn);
 
   // Observe visualization column changes to show/hide DVH
@@ -1998,13 +2003,13 @@ void vtkSlicerDoseVolumeHistogramModuleLogic::InitializeMetricsTable(vtkMRMLDose
   visColumn->AddObserver(vtkCommand::ModifiedEvent, callbackCommand.GetPointer(), 1.0);
 
   vtkAbstractArray* structureNameColumn = metricsTableNode->AddColumn();
-  structureNameColumn->SetName(DVH_METRIC_STRUCTURE.c_str());
+  structureNameColumn->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", DVH_METRIC_STRUCTURE.c_str()).c_str());
 
   vtkAbstractArray* volumeNameColumn = metricsTableNode->AddColumn();
-  volumeNameColumn->SetName("Volume name");
+  volumeNameColumn->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", "Volume name").c_str());
 
   vtkAbstractArray* volumeCcColumn = metricsTableNode->AddColumn();
-  volumeCcColumn->SetName(DVH_METRIC_TOTAL_VOLUME_CC.c_str());
+  volumeCcColumn->SetName(vtkMRMLTr("vtkSlicerDoseVolumeHistogramModuleLogic", DVH_METRIC_TOTAL_VOLUME_CC.c_str()).c_str());
 
   vtkAbstractArray* meanDoseColumn = metricsTableNode->AddColumn();
   meanDoseColumn->SetName(meanDoseMetricName.c_str());

--- a/DoseVolumeHistogram/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDoseVolumeHistogramPlugin.cxx
+++ b/DoseVolumeHistogram/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDoseVolumeHistogramPlugin.cxx
@@ -134,7 +134,7 @@ double qSlicerSubjectHierarchyDoseVolumeHistogramPlugin::canOwnSubjectHierarchyI
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyDoseVolumeHistogramPlugin::roleForPlugin()const
 {
-  return "Dose volume histogram";
+  return /*no tr*/ "Dose volume histogram";
 }
 
 //---------------------------------------------------------------------------

--- a/DoseVolumeHistogram/qSlicerDoseVolumeHistogramModule.cxx
+++ b/DoseVolumeHistogram/qSlicerDoseVolumeHistogramModule.cxx
@@ -23,7 +23,6 @@
 #include "qSlicerSubjectHierarchyDoseVolumeHistogramPlugin.h"
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // ExtensionTemplate Logic includes
@@ -69,15 +68,15 @@ qSlicerDoseVolumeHistogramModule::~qSlicerDoseVolumeHistogramModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerDoseVolumeHistogramModule::helpText()const
 {
-  return QString("This module computes dose volume histogram (DVH) and metrics from a dose map and segmentation. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/DoseVolumeHistogram\">%1/Documentation/%2.%3/Modules/DoseVolumeHistogram</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module computes dose volume histogram (DVH) and metrics from a dose map and segmentation. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/DoseVolumeHistogram.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDoseVolumeHistogramModule::acknowledgementText()const
 {
-  return "This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.";
+  return tr("This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.");
 }
 
 //-----------------------------------------------------------------------------
@@ -98,7 +97,7 @@ void qSlicerDoseVolumeHistogramModule::setup()
 //-----------------------------------------------------------------------------
 QStringList qSlicerDoseVolumeHistogramModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/DoseVolumeHistogram/qSlicerDoseVolumeHistogramModuleWidget.cxx
+++ b/DoseVolumeHistogram/qSlicerDoseVolumeHistogramModuleWidget.cxx
@@ -252,7 +252,7 @@ void qSlicerDoseVolumeHistogramModuleWidget::updateWidgetFromMRML()
   d->checkBox_DoseSurfaceHistogram->setChecked(paramNode->GetDoseSurfaceHistogram());
   d->pushButton_ShowHideLegend->setChecked(paramNode->GetChartNode()->GetLegendVisibility());
   d->pushButton_ShowHideLegend->setText(
-    paramNode->GetChartNode()->GetLegendVisibility() ? "Hide legend" : "Show legend" );
+    paramNode->GetChartNode()->GetLegendVisibility() ? tr("Hide legend") : tr("Show legend") );
 
   // Set metrics table to table view
   if (d->MRMLTableView->mrmlTableNode() != paramNode->GetMetricsTableNode())
@@ -478,7 +478,7 @@ void qSlicerDoseVolumeHistogramModuleWidget::computeDvhClicked()
   d->ConvertProgressDialog = new QProgressDialog(qSlicerApplication::application()->mainWindow());
   d->ConvertProgressDialog->setModal(true);
   d->ConvertProgressDialog->setMinimumDuration(150);
-  d->ConvertProgressDialog->setLabelText("Computing DVH for all selected segments...");
+  d->ConvertProgressDialog->setLabelText(tr("Computing DVH for all selected segments..."));
   d->ConvertProgressDialog->show();
   QApplication::processEvents();
 
@@ -529,7 +529,7 @@ void qSlicerDoseVolumeHistogramModuleWidget::exportDvhToCsvClicked()
   // User selects file and format
   QString selectedFilter;
 
-  QString fileName = QFileDialog::getSaveFileName( nullptr, QString( tr( "Save DVH values to file" ) ), tr(""), QString( tr( "CSV comma separated values ( *.csv );;TSV tab separated values ( *.tsv )" ) ), &selectedFilter );
+  QString fileName = QFileDialog::getSaveFileName( nullptr, QString( tr( "Save DVH values to file" ) ), QString(), QString( tr( "CSV comma separated values ( *.csv );;TSV tab separated values ( *.tsv )" ) ), &selectedFilter );
   if (fileName.isNull())
   {
     return;
@@ -557,7 +557,7 @@ void qSlicerDoseVolumeHistogramModuleWidget::exportMetricsToCsv()
   // User selects file and format
   QString selectedFilter;
 
-  QString fileName = QFileDialog::getSaveFileName( nullptr, QString( tr( "Save DVH metrics to file" ) ), tr(""), QString( tr( "CSV comma separated values ( *.csv );;TSV tab separated values ( *.tsv )" ) ), &selectedFilter );
+  QString fileName = QFileDialog::getSaveFileName( nullptr, QString( tr( "Save DVH metrics to file" ) ), QString(), QString( tr( "CSV comma separated values ( *.csv );;TSV tab separated values ( *.tsv )" ) ), &selectedFilter );
   if (fileName.isNull())
   {
     return;
@@ -899,5 +899,5 @@ void qSlicerDoseVolumeHistogramModuleWidget::showHideLegendClicked(bool checked)
   }
 
   paramNode->GetChartNode()->SetLegendVisibility(checked);
-  d->pushButton_ShowHideLegend->setText(checked ? "Hide legend" : "Show legend");
+  d->pushButton_ShowHideLegend->setText(checked ? tr("Hide legend") : tr("Show legend"));
 }

--- a/DosxyzNrc3dDoseFileReader/qSlicerDosxyzNrc3dDoseFileReaderModule.cxx
+++ b/DosxyzNrc3dDoseFileReader/qSlicerDosxyzNrc3dDoseFileReaderModule.cxx
@@ -66,7 +66,7 @@ qSlicerDosxyzNrc3dDoseFileReaderModule::~qSlicerDosxyzNrc3dDoseFileReaderModule(
 //-----------------------------------------------------------------------------
 QString qSlicerDosxyzNrc3dDoseFileReaderModule::helpText()const
 {
-  QString help = QString(
+  QString help = tr(
     "The DosxyzNrc3dDoseFileReader module enables importing and loading .3ddose files into Slicer.<br>"
     "The DosxyzNrc3dDoseFileReader module is hidden and therefore does not require an application.<br>");
   return help;
@@ -75,7 +75,7 @@ QString qSlicerDosxyzNrc3dDoseFileReaderModule::helpText()const
 //-----------------------------------------------------------------------------
 QString qSlicerDosxyzNrc3dDoseFileReaderModule::acknowledgementText()const
 {
-  QString acknowledgement = QString(
+  QString acknowledgement = tr(
     "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
   return acknowledgement;
 }

--- a/DosxyzNrc3dDoseFileReader/qSlicerDosxyzNrc3dDoseFileReaderPlugin.cxx
+++ b/DosxyzNrc3dDoseFileReader/qSlicerDosxyzNrc3dDoseFileReaderPlugin.cxx
@@ -73,7 +73,7 @@ vtkSlicerDosxyzNrc3dDoseFileReaderLogic* qSlicerDosxyzNrc3dDoseFileReaderPlugin:
 //-----------------------------------------------------------------------------
 QString qSlicerDosxyzNrc3dDoseFileReaderPlugin::description()const
 {
-  return "DosxyzNrc3dDose";
+  return tr("DosxyzNrc3dDose");
 }
 
 //-----------------------------------------------------------------------------
@@ -85,7 +85,7 @@ qSlicerIO::IOFileType qSlicerDosxyzNrc3dDoseFileReaderPlugin::fileType()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerDosxyzNrc3dDoseFileReaderPlugin::extensions()const
 {
-  return QStringList() << "DosxyzNrc3dDose (*.3ddose)";
+  return QStringList() << tr("DosxyzNrc3dDose (*.3ddose)");
 }
 
 //-----------------------------------------------------------------------------

--- a/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
+++ b/DrrImageComputation/Logic/vtkSlicerDrrImageComputationLogic.cxx
@@ -43,6 +43,9 @@
 // SlicerRT DrrImageComputation MRML includes
 #include <vtkMRMLDrrImageComputationNode.h>
 
+// MRML includes
+#include <vtkMRMLI18N.h>
+
 // SlicerRT Beams Logic includes
 #include <vtkSlicerBeamsModuleLogic.h>
 
@@ -933,10 +936,10 @@ vtkMRMLMarkupsFiducialNode* vtkSlicerDrrImageComputationLogic::CreateFiducials(v
     vtkVector3d p2( -1. * y + offset[0], -1. * x + offset[1], -distance); // (0,0)
     vtkVector3d p3( -1. * y + offset[0], 0.0, -distance); // vup
 
-    pointsMarkupsNode->AddControlPoint( p0, "Imager center");
-    pointsMarkupsNode->AddControlPoint( p1, "n");
-    pointsMarkupsNode->AddControlPoint( p2, "(0,0)");
-    pointsMarkupsNode->AddControlPoint( p3, "VUP");
+    pointsMarkupsNode->AddControlPoint( p0, /*no tr*/ "Imager center");
+    pointsMarkupsNode->AddControlPoint( p1, /*no tr*/ "n"); // point along the imaging plane normal direction
+    pointsMarkupsNode->AddControlPoint( p2, /*no tr*/ "(0,0)"); // origin of the 2D pixel coordinate system
+    pointsMarkupsNode->AddControlPoint( p3, /*no tr*/ "VUP"); // view-up vector reference point
 
     if (vtkMRMLRTBeamNode* beamNode = parameterNode->GetBeamNode())
     {
@@ -1113,7 +1116,7 @@ vtkMRMLScalarVolumeNode* vtkSlicerDrrImageComputationLogic::ComputePlastimatchDR
   if (drrVolumeNode->GetImageData() && drrVolumeNode->GetSpacing())
   {
     // Set more user friendly DRR image name
-    std::string drrName = scene->GenerateUniqueName(std::string("DRR : ") + std::string(beamNode->GetName()));
+    std::string drrName = scene->GenerateUniqueName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "DRR: ") + std::string(beamNode->GetName()));
     drrVolumeNode->SetName(drrName.c_str());
 
     // Create parameter node name, and observe calculated drr volume
@@ -2037,7 +2040,7 @@ vtkMRMLTableNode* vtkSlicerDrrImageComputationLogic::CreateProjectionsTableNode(
     return nullptr;
   }
 
-  std::string name = std::string("DRR : ") + ctInputVolume->GetName() + "_MarkupsProjectionData";
+  std::string name = vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "DRR: ") + ctInputVolume->GetName() + "_MarkupsProjectionData";
   vtkMRMLTableNode* tableNode = vtkMRMLTableNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLTableNode", name.c_str()));
 
   vtkTable* table = tableNode->GetTable();
@@ -2049,47 +2052,50 @@ vtkMRMLTableNode* vtkSlicerDrrImageComputationLogic::CreateProjectionsTableNode(
 
   // Column 0; Original label name
   vtkNew<vtkStringArray> originLabelString;
-  originLabelString->SetName("Original label");
+  originLabelString->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Original label").c_str());
   table->AddColumn(originLabelString);
 
   // Column 1; R
   vtkNew<vtkDoubleArray> rPosition;
-  rPosition->SetName("R");
+  //: right
+  rPosition->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "R").c_str());
   table->AddColumn(rPosition);
 
   // Column 2; A
   vtkNew<vtkDoubleArray> aPosition;
-  aPosition->SetName("A");
+  //: anterior
+  aPosition->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "A").c_str());
   table->AddColumn(aPosition);
 
   // Column 3; S
   vtkNew<vtkDoubleArray> sPosition;
-  sPosition->SetName("S");
+  //: superior
+  sPosition->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "S").c_str());
   table->AddColumn(sPosition);
 
   // Column 4; Width
   vtkNew<vtkDoubleArray> widthOffset;
-  widthOffset->SetName("Width");
+  widthOffset->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Width").c_str());
   table->AddColumn(widthOffset);
 
   // Column 5; Height
   vtkNew<vtkDoubleArray> heigthOffset;
-  heigthOffset->SetName("Height");
+  heigthOffset->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Height").c_str());
   table->AddColumn(heigthOffset);
 
   // Column 6; Column
   vtkNew<vtkIntArray> columnOffset;
-  columnOffset->SetName("Column");
+  columnOffset->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Column").c_str());
   table->AddColumn(columnOffset);
 
   // Column 7; Row
   vtkNew<vtkIntArray> rowOffset;
-  rowOffset->SetName("Row");
+  rowOffset->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Row").c_str());
   table->AddColumn(rowOffset);
 
   // Column 8; Status string
   vtkNew<vtkStringArray> statusString;
-  statusString->SetName("Status");
+  statusString->SetName(vtkMRMLTr("vtkSlicerDrrImageComputationLogic", "Status").c_str());
   table->AddColumn(statusString);
 
   return tableNode;

--- a/DrrImageComputation/qSlicerDrrImageComputationModule.cxx
+++ b/DrrImageComputation/qSlicerDrrImageComputationModule.cxx
@@ -70,14 +70,14 @@ qSlicerDrrImageComputationModule::~qSlicerDrrImageComputationModule()
 //-----------------------------------------------------------------------------
 QString qSlicerDrrImageComputationModule::helpText() const
 {
-  return "This is a loadable module that calculates a digitally " \
-  "reconstructed radiograph (DRR) using the plastimatch reconstruct library.";
+  return tr("This is a loadable module that calculates a digitally " \
+  "reconstructed radiograph (DRR) using the plastimatch reconstruct library.");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerDrrImageComputationModule::acknowledgementText() const
 {
-  return "This work was supported by Slicer Community.";
+  return tr("This work was supported by Slicer Community.");
 }
 
 //-----------------------------------------------------------------------------
@@ -97,7 +97,7 @@ QIcon qSlicerDrrImageComputationModule::icon() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerDrrImageComputationModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
+++ b/DrrImageComputation/qSlicerDrrImageComputationModuleWidget.cxx
@@ -164,7 +164,14 @@ void qSlicerDrrImageComputationModuleWidget::setup()
   this->Superclass::setup();
 
   d->TableWidget_ProjectedPointsCoordinates->setColumnCount( PROJECTED_POINT_COLUMNS );
-  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList() << tr("Original label") << tr("R") << tr("A") << tr("S") \
+  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList()
+    << tr("Original label")
+    //: right
+    << tr("R")
+    //: anterior
+    << tr("A")
+    //: superior
+    << tr("S")
     << tr("Width") << tr("Height") << tr("Column") << tr("Row") << tr("Status") );
   d->TableWidget_ProjectedPointsCoordinates->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
   d->TableWidget_ProjectedPointsCoordinates->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
@@ -782,7 +789,14 @@ void qSlicerDrrImageComputationModuleWidget::onMarkupsNodeChanged()
   vtkMRMLMarkupsFiducialNode* markupsNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(d->SimpleMarkupsWidget_PointCoordinates->currentNode());
 
   d->TableWidget_ProjectedPointsCoordinates->clear();
-  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList() << tr("Original label") << tr("R") << tr("A") << tr("S") \
+  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList()
+    << tr("Original label")
+    //: right
+    << tr("R")
+    //: anterior
+    << tr("A")
+    //: superior
+    << tr("S")
     << tr("Width") << tr("Height") << tr("Column") << tr("Row") << tr("Status") );
 
   d->PushButton_ClearProjectedTableWidget->setEnabled(false);
@@ -862,7 +876,14 @@ void qSlicerDrrImageComputationModuleWidget::onProjectMarkupsControlPointsClicke
 
   d->TableWidget_ProjectedPointsCoordinates->setColumnCount(PROJECTED_POINT_COLUMNS);
   d->TableWidget_ProjectedPointsCoordinates->setRowCount(list.size());
-  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList() << tr("Original label") << tr("R") << tr("A") << tr("S") \
+  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList()
+    << tr("Original label")
+    //: right
+    << tr("R")
+    //: anterior
+    << tr("A")
+    //: superior
+    << tr("S")
     << tr("Width") << tr("Height") << tr("Column") << tr("Row") << tr("Status") );
   d->TableWidget_ProjectedPointsCoordinates->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
   d->TableWidget_ProjectedPointsCoordinates->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
@@ -883,10 +904,12 @@ void qSlicerDrrImageComputationModuleWidget::onProjectMarkupsControlPointsClicke
 
     if (!d->CheckPointWithinVolumeBounds(ctVolumeNode, pointPos))
     {
-      d->TableWidget_ProjectedPointsCoordinates->setItem(projectedRowCount, PROJECTED_POINT_STATUS_COLUMN, new QTableWidgetItem(tr("Point is out of volume bounds!")));
+      QString outOfBoundsMsg = tr("Point is out of volume bounds!");
+      d->TableWidget_ProjectedPointsCoordinates->setItem(projectedRowCount, PROJECTED_POINT_STATUS_COLUMN, new QTableWidgetItem(outOfBoundsMsg));
       if (projectionTable)
       {
-        projectionTable->SetValue(projectedRowCount, PROJECTED_POINT_STATUS_COLUMN, "Point is out of volume bounds!");
+        std::string strMsg = outOfBoundsMsg.toStdString();
+        projectionTable->SetValue(projectedRowCount, PROJECTED_POINT_STATUS_COLUMN, strMsg.c_str());
       }
       projectedRowCount++;
       continue;
@@ -970,7 +993,14 @@ void qSlicerDrrImageComputationModuleWidget::onClearProjectedTableClicked()
   }
   d->TableWidget_ProjectedPointsCoordinates->clear();
   d->TableWidget_ProjectedPointsCoordinates->setRowCount(0);
-  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList() << tr("Original label") << tr("R") << tr("A") << tr("S") \
+  d->TableWidget_ProjectedPointsCoordinates->setHorizontalHeaderLabels( QStringList()
+    << tr("Original label")
+    //: right
+    << tr("R")
+    //: anterior
+    << tr("A")
+    //: superior
+    << tr("S")
     << tr("Width") << tr("Height") << tr("Column") << tr("Row") << tr("Status") );
   d->PushButton_ProjectControlPoints->setEnabled(true);
   d->PushButton_ClearProjectedTableWidget->setEnabled(false);

--- a/DvhComparison/DvhComparison.py
+++ b/DvhComparison/DvhComparison.py
@@ -4,6 +4,8 @@ import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 
+from slicer.i18n import tr as _
+
 #
 # ------------------------------------------------------------------------------
 # DvhComparison
@@ -12,11 +14,11 @@ from slicer.ScriptedLoadableModule import *
 class DvhComparison(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "DVH Comparison"
-    self.parent.categories = ["Radiotherapy"]
+    self.parent.title = _("DVH Comparison")
+    self.parent.categories = [_("Radiotherapy")]
     self.parent.dependencies = ["DoseVolumeHistogram"]
     self.parent.contributors = ["Kyle Sunderland (Queen's University), Csaba Pinter (Queen's University)"]
-    self.parent.helpText = """This module compares two Dose Volume Histograms from corresponding Table nodes."""
+    self.parent.helpText = _("""This module compares two Dose Volume Histograms from corresponding Table nodes.""")
     self.parent.acknowledgementText = """ """
     iconPath = os.path.join(os.path.dirname(self.parent.path), 'Resources/Icons', self.moduleName+'.png')
     parent.icon = qt.QIcon(iconPath)
@@ -46,7 +48,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     # Parameter Combobox
     #
     self.parameterSelector = slicer.qMRMLNodeComboBox()
-    self.parameterLabel = qt.QLabel("  Parameter set: ")
+    self.parameterLabel = qt.QLabel(_("Parameter set: "))
     self.parameterSelector.nodeTypes = ["vtkMRMLScriptedModuleNode"]
     self.parameterSelector.removeEnabled = False
     self.parameterSelector.showHidden = True
@@ -60,7 +62,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     # Input Area
     #
     inputCollapsibleButton = ctk.ctkCollapsibleButton()
-    inputCollapsibleButton.text = "Input"
+    inputCollapsibleButton.text = _("Input")
     self.layout.addWidget(inputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -74,7 +76,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     self.dvh1Selector.addAttribute("vtkMRMLTableNode", "DoseVolumeHistogram.DVH")
     self.dvh1Selector.removeEnabled = False
     self.dvh1Selector.setMRMLScene( slicer.mrmlScene )
-    inputFormLayout.addRow("DVH 1: ", self.dvh1Selector)
+    inputFormLayout.addRow(_("DVH 1: "), self.dvh1Selector)
 
     #
     # Input second DVH selector
@@ -84,7 +86,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     self.dvh1Selector.addAttribute("vtkMRMLTableNode", "DoseVolumeHistogram.DVH")
     self.dvh2Selector.removeEnabled = False
     self.dvh2Selector.setMRMLScene( slicer.mrmlScene )
-    inputFormLayout.addRow("DVH 2: ", self.dvh2Selector)
+    inputFormLayout.addRow(_("DVH 2: "), self.dvh2Selector)
 
     #
     # Input the dose volume
@@ -94,12 +96,12 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     self.doseVolumeSelector.addAttribute("vtkMRMLScalarVolumeNode", "DicomRtImport.DoseVolume")
     self.doseVolumeSelector.removeEnabled = False
     self.doseVolumeSelector.setMRMLScene( slicer.mrmlScene )
-    inputFormLayout.addRow("Dose Volume: ", self.doseVolumeSelector)
+    inputFormLayout.addRow(_("Dose Volume: "), self.doseVolumeSelector)
 
     #
     # Dose volume only check box
     #
-    self.showDoseVolumeOnlyCheckbox = qt.QCheckBox("Show dose volume only")
+    self.showDoseVolumeOnlyCheckbox = qt.QCheckBox(_("Show dose volume only"))
     self.showDoseVolumeOnlyCheckbox.setChecked(2)
     inputFormLayout.addWidget(self.showDoseVolumeOnlyCheckbox)
 
@@ -110,7 +112,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     self.volumeDifferenceSpinbox.setValue(1.0)
     self.volumeDifferenceSpinbox.setDecimals(1)
     self.volumeDifferenceSpinbox.setSingleStep(0.1)
-    inputFormLayout.addRow("Volume difference criterion: ", self.volumeDifferenceSpinbox)
+    inputFormLayout.addRow(_("Volume difference criterion: "), self.volumeDifferenceSpinbox)
 
     #
     # Dose to agreement criterion spin box
@@ -119,12 +121,12 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     self.doseToAgreementSpinbox.setValue(1.0)
     self.doseToAgreementSpinbox.setDecimals(1)
     self.doseToAgreementSpinbox.setSingleStep(0.1)
-    inputFormLayout.addRow("Dose to agreement criterion: ", self.doseToAgreementSpinbox)
+    inputFormLayout.addRow(_("Dose to agreement criterion: "), self.doseToAgreementSpinbox)
 
     #
     # Compute button
     #
-    self.computeButton = qt.QPushButton("Compute")
+    self.computeButton = qt.QPushButton(_("Compute"))
     self.computeButtonLayout = qt.QVBoxLayout()
     self.computeButtonLayout.addStrut(100)
     self.computeButtonLayout.setAlignment(2)
@@ -138,7 +140,7 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
     # Output Area
     #
     outputCollapsibleButton = ctk.ctkCollapsibleButton()
-    outputCollapsibleButton.text = "Output"
+    outputCollapsibleButton.text = _("Output")
     self.layout.addWidget(outputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -146,13 +148,13 @@ class DvhComparisonWidget(ScriptedLoadableModuleWidget):
 
     self.agreementAcceptanceOutput = qt.QLineEdit()
     self.agreementAcceptanceOutput.setReadOnly(True)
-    outputFormLayout.addRow("Agreement acceptance %: ", self.agreementAcceptanceOutput)
+    outputFormLayout.addRow(_("Agreement acceptance %: "), self.agreementAcceptanceOutput)
 
     #
     # Visualize Area
     #
     visualizeCollapsibleButton = ctk.ctkCollapsibleButton()
-    visualizeCollapsibleButton.text = "Visualize"
+    visualizeCollapsibleButton.text = _("Visualize")
     sizePolicy = qt.QSizePolicy()
     sizePolicy.setHorizontalPolicy(qt.QSizePolicy.Preferred)
     sizePolicy.setVerticalPolicy(qt.QSizePolicy.Expanding)

--- a/ExternalBeamPlanning/Logic/vtkSlicerExternalBeamPlanningModuleLogic.cxx
+++ b/ExternalBeamPlanning/Logic/vtkSlicerExternalBeamPlanningModuleLogic.cxx
@@ -29,6 +29,7 @@
 // MRML includes
 //#include <vtkMRMLMarkupsFiducialNode.h> //TODO: Includes commented out due to obsolete methods, see below
 //#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLScalarVolumeNode.h>
 //#include <vtkMRMLScalarVolumeDisplayNode.h>
 //#include <vtkMRMLDoubleArrayNode.h>
@@ -369,7 +370,7 @@ std::string vtkSlicerExternalBeamPlanningModuleLogic::ComputeDoseByMatlab(vtkMRM
 {
   if ( !this->GetMRMLScene() || !planNode )
   {
-    std::string errorMessage("Invalid MRML scene or RT plan node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerExternalBeamPlanningModuleLogic", "Invalid MRML scene or RT plan node");
     vtkErrorMacro("ComputeDoseByMatlab: " << errorMessage);
     return errorMessage;
   }
@@ -403,7 +404,7 @@ std::string vtkSlicerExternalBeamPlanningModuleLogic::ComputeDoseByMatlab(vtkMRM
   this->GetMRMLScene()->RemoveNode(cmdNode);
 #endif
 
-  return "Matlab dose engine unavailable";
+  return vtkMRMLTr("vtkSlicerExternalBeamPlanningModuleLogic", "Matlab dose engine unavailable");
 }
 
 //---------------------------------------------------------------------------

--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -662,16 +662,6 @@
         <property name="toolTip">
          <string>Barrier parameter update strategy: adaptive (recommended) or monotone (mu_strategy).</string>
         </property>
-        <item>
-         <property name="text">
-          <string>adaptive</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>monotone</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item row="6" column="0">
@@ -689,16 +679,6 @@
         <property name="toolTip">
          <string>Hessian approximation method: limited-memory L-BFGS (default) or exact second derivatives (hessian_approximation).</string>
         </property>
-        <item>
-         <property name="text">
-          <string>limited-memory</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>exact</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item row="7" column="0">

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/MockPythonDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/MockPythonDoseEngine.py
@@ -1,4 +1,5 @@
 from DoseEngines import *
+from slicer.i18n import translate
 
 class MockPythonDoseEngine(AbstractScriptedDoseEngine):
   """ Mock python dose engine to test python interface for External Beam Planning
@@ -10,7 +11,7 @@ class MockPythonDoseEngine(AbstractScriptedDoseEngine):
 
   def defineBeamParameters(self):
     self.scriptedEngine.addBeamParameterSpinBox(
-    "Mock python dose", "NoiseRange", "Noise range (% of Rx):", "Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)",
+    translate("DoseEngines.MockPythonDoseEngine", "Mock python dose"), "NoiseRange", translate("DoseEngines.MockPythonDoseEngine", "Noise range (% of Rx):"), translate("DoseEngines.MockPythonDoseEngine", "Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)"),
     0.0, 99.99, 10.0, 1.0, 2 )
 
   def calculateDoseUsingEngine(self, beamNode, resultDoseVolumeNode):

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/OrthovoltageDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/OrthovoltageDoseEngine.py
@@ -7,6 +7,8 @@ from DoseEngines import OrthovoltageDoseEngineUtil
 from DoseEngines import EGSnrcUtil
 from SegmentEditorEffects import SegmentEditorMaskVolumeEffect
 
+from slicer.i18n import translate
+
 #------------------------------------------------------------------------------
 #
 # OrthovoltageDoseEngine
@@ -57,32 +59,32 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     ##########################################
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "CtcreateExecFilePath", "Ctcreate executable file path:",
-    "Enter file path of the ctcreate executable", ctcreateExecFilePath)
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "CtcreateExecFilePath", translate("DoseEngines.OrthovoltageDoseEngine", "Ctcreate executable file path:"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path of the ctcreate executable"), ctcreateExecFilePath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "CtcreateOutputPath", "Ctcreate output file path:",
-    "Enter file path to store ctcreate phantom and related files", ctcreateOutputPath)
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "CtcreateOutputPath", translate("DoseEngines.OrthovoltageDoseEngine", "Ctcreate output file path:"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path to store ctcreate phantom and related files"), ctcreateOutputPath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "ROIName", "ROI node name for cropping image (optional):",
-    "Enter name of ROI, if you wish to crop CT image which will be converted to ctcreate phantom format. \
-    If no ROI entered, will use image bounds from original CT image volume", "")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "ROIName", translate("DoseEngines.OrthovoltageDoseEngine", "ROI node name for cropping image (optional):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter name of ROI, if you wish to crop CT image which will be converted to ctcreate phantom format. \
+    If no ROI entered, will use image bounds from original CT image volume"), "")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "SliceThicknessX", "Slice thickness (mm) in X direction (optional):",
-    "Enter desired slice thickness in X direction for output ctcreate phantom. If not x,y,z slice \
-    thickness not provided, will use same thickness from original CT image volume", "")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "SliceThicknessX", translate("DoseEngines.OrthovoltageDoseEngine", "Slice thickness (mm) in X direction (optional):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter desired slice thickness in X direction for output ctcreate phantom. If not x,y,z slice \
+    thickness not provided, will use same thickness from original CT image volume"), "")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "SliceThicknessY", "Slice thickness (mm) in Y direction (optional):",
-    "Enter desired slice thickness in Y direction for output ctcreate phantom. If not x,y,z slice \
-    thickness not provided, will use same thickness from original CT image volume", "")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "SliceThicknessY", translate("DoseEngines.OrthovoltageDoseEngine", "Slice thickness (mm) in Y direction (optional):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter desired slice thickness in Y direction for output ctcreate phantom. If not x,y,z slice \
+    thickness not provided, will use same thickness from original CT image volume"), "")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Generate ctcreate phantom", "SliceThicknessZ", "Slice thickness (mm) in Z direction (optional):",
-    "Enter desired slice thickness in Z direction for output ctcreate phantom. If not x,y,z slice \
-    thickness not provided, will use same thickness from original CT image volume", "")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "SliceThicknessZ", translate("DoseEngines.OrthovoltageDoseEngine", "Slice thickness (mm) in Z direction (optional):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter desired slice thickness in Z direction for output ctcreate phantom. If not x,y,z slice \
+    thickness not provided, will use same thickness from original CT image volume"), "")
 
     defaultMaterials = [
       {
@@ -95,138 +97,138 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
       }
     ]
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Generate ctcreate phantom", "Materials", "Materials:",
-      "JSON string containing all of the material names and ramp values.", json.dumps(defaultMaterials))
+      translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "Materials", translate("DoseEngines.OrthovoltageDoseEngine", "Materials:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "JSON string containing all of the material names and ramp values."), json.dumps(defaultMaterials))
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Generate ctcreate phantom", "LowerBound", "Lower bound:",
-      "Lower CT number for the first medium in the ramp.", "-1024")
+      translate("DoseEngines.OrthovoltageDoseEngine", "Generate ctcreate phantom"), "LowerBound", translate("DoseEngines.OrthovoltageDoseEngine", "Lower bound:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Lower CT number for the first medium in the ramp."), "-1024")
 
     ##########################################
     # Orthovoltage dose parameters tab
     ##########################################
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "SimulationTitle", "Simulation title:",
-    "Enter a title for the DOSXYZNrc simulation", "DOSXYZnrc simulation")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "SimulationTitle", translate("DoseEngines.OrthovoltageDoseEngine", "Simulation title:"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter a title for the DOSXYZNrc simulation"), "DOSXYZnrc simulation")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "PhaseSpaceFilePath", "Phase space file path:",
-    "Enter full path to phase space file", phaseSpaceFilePath)
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "PhaseSpaceFilePath", translate("DoseEngines.OrthovoltageDoseEngine", "Phase space file path:"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter full path to phase space file"), phaseSpaceFilePath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "ECut", "Global electron cutoff energy - ECUT (MeV):",
-    "Select global electron cutoff energy (MeV)", "0.512")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "ECut", translate("DoseEngines.OrthovoltageDoseEngine", "Global electron cutoff energy - ECUT (MeV):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Select global electron cutoff energy (MeV)"), "0.512")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "PCut", "Global photon cutoff energy - PCUT (MeV):",
-    "Select global electron cutoff energy (MeV)", "0.001")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "PCut", translate("DoseEngines.OrthovoltageDoseEngine", "Global photon cutoff energy - PCUT (MeV):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Select global electron cutoff energy (MeV)"), "0.001")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "IncidentBeamSize", "Incident beam size (cm):",
-    "SBEAM SIZE is the side of a square field in cm. The default value for \
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "IncidentBeamSize", translate("DoseEngines.OrthovoltageDoseEngine", "Incident beam size (cm):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "SBEAM SIZE is the side of a square field in cm. The default value for \
     BEAM SIZE is 100 cm. When phase-space particles are read from a data file \
     or reconstructed by a multiple-source model, DOSXYZnrcwill check their \
     positions and discard those that fall outside of the specified field. \
-    Use with caution.", "100.0")
+    Use with caution."), "100.0")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-    "Orthovoltage dose", "DistanceSourceToIsocenter", "Distance from source to isocenter (cm):",
-    "Enter absolute distance from source to isocenter (cm):", "0")
+    translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "DistanceSourceToIsocenter", translate("DoseEngines.OrthovoltageDoseEngine", "Distance from source to isocenter (cm):"),
+    translate("DoseEngines.OrthovoltageDoseEngine", "Enter absolute distance from source to isocenter (cm):"), "0")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "MedSur", "Surrounding medium:",
-      "Medium number for the region outside the phantom. Default = 0 (vacuum)", "0")
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "MedSur", translate("DoseEngines.OrthovoltageDoseEngine", "Surrounding medium:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Medium number for the region outside the phantom. Default = 0 (vacuum)"), "0")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "NumHistories", "Number of histories:",
-      "Number of histories to use for simulation", "129796480")
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "NumHistories", translate("DoseEngines.OrthovoltageDoseEngine", "Number of histories:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Number of histories to use for simulation"), "129796480")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "Inseed1", "Random number generator seed 1:",
-      "The random number generator used requires 2 seeds between 1 and \
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "Inseed1", translate("DoseEngines.OrthovoltageDoseEngine", "Random number generator seed 1:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "The random number generator used requires 2 seeds between 1 and \
       31328 and 1 and 30081 respectively.  For each different pair of \
       seeds, an independent random number sequence is generated.  Once \
       the seeds are used to establish the state of the generator, the \
-      \"seeds\" output in log files etc. are really just pointers between 1 and 98.",
+      \"seeds\" output in log files etc. are really just pointers between 1 and 98."),
       "33")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "Inseed2", "Random number generator seed 2:",
-      "The random number generator used requires 2 seeds between 1 and \
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "Inseed2", translate("DoseEngines.OrthovoltageDoseEngine", "Random number generator seed 2:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "The random number generator used requires 2 seeds between 1 and \
       31328 and 1 and 30081 respectively.  For each different pair of \
       seeds, an independent random number sequence is generated.  Once \
       the seeds are used to establish the state of the generator, the \
-      \"seeds\" output in log files etc. are really just pointers between 1 and 98.",
+      \"seeds\" output in log files etc. are really just pointers between 1 and 98."),
       "97")
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "DosxyznrcFolderPath", "Dosxyznrc folder path:",
-      "Enter file path to dosxyznrc folder", dosxyznrcFolderPath)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "DosxyznrcFolderPath", translate("DoseEngines.OrthovoltageDoseEngine", "Dosxyznrc folder path:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path to dosxyznrc folder"), dosxyznrcFolderPath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "DosxyznrcExecFilePath", "Dosxyznrc executable file path:",
-      "Enter file path to dosxyznrc executable", dosxyznrcExecFilePath)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "DosxyznrcExecFilePath", translate("DoseEngines.OrthovoltageDoseEngine", "Dosxyznrc executable file path:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path to dosxyznrc executable"), dosxyznrcExecFilePath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "PegsFilePath", "Path to pegs4 data file:",
-      "Enter file path to .pegs5dat file", pegsFilePath)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "PegsFilePath", translate("DoseEngines.OrthovoltageDoseEngine", "Path to pegs4 data file:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path to .pegs5dat file"), pegsFilePath)
 
     self.runCTCreateAndDoseXYZnrcIndex = 0
     self.runCTCreateOnlyIndex = 1
     self.runDOSXYZnrcOnlyIndex = 2
     self.scriptedEngine.addBeamParameterComboBox(
-      "Orthovoltage dose", "RunCTCreateDOSXYZnrc", "Run ctcreate and DOSXYZnrc",
-      "Choose if only one, or both ctcreate and DOSXYZnrc should be run", ["ctcreate and DOSXYZnrc", "ctcreate only", "DOSXYZnrc only"], self.runCTCreateAndDoseXYZnrcIndex)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "RunCTCreateDOSXYZnrc", translate("DoseEngines.OrthovoltageDoseEngine", "Run ctcreate and DOSXYZnrc"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Choose if only one, or both ctcreate and DOSXYZnrc should be run"), [translate("DoseEngines.OrthovoltageDoseEngine", "ctcreate and DOSXYZnrc"), translate("DoseEngines.OrthovoltageDoseEngine", "ctcreate only"), translate("DoseEngines.OrthovoltageDoseEngine", "DOSXYZnrc only")], self.runCTCreateAndDoseXYZnrcIndex)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "ExistingCtcreatePath", "Existing ctcreate file path (DOSXYZnrc only):",
-      "Enter file path for existing ctcreate phantom and related files. Required if only running DOSXYZnrc.", "")
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "ExistingCtcreatePath", translate("DoseEngines.OrthovoltageDoseEngine", "Existing ctcreate file path (DOSXYZnrc only):"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Enter file path for existing ctcreate phantom and related files. Required if only running DOSXYZnrc."), "")
 
     self.scriptedEngine.addBeamParameterCheckBox(
-      "Orthovoltage dose", "ZeroAirDose", "Enable dose in air:",
-      "If checked, sets dose in air to zero", True)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "ZeroAirDose", translate("DoseEngines.OrthovoltageDoseEngine", "Enable dose in air:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "If checked, sets dose in air to zero"), True)
 
     self.scriptedEngine.addBeamParameterCheckBox(
-      "Orthovoltage dose", "IReject", "Enable electron range rejection:",
-      "If checked, enables electron range reject, which speeds up the simulation\
-      Use ESAVE_GLOBAL threshold for cutoff particle energy cutoff", False)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "IReject", translate("DoseEngines.OrthovoltageDoseEngine", "Enable electron range rejection:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "If checked, enables electron range reject, which speeds up the simulation\
+      Use ESAVE_GLOBAL threshold for cutoff particle energy cutoff"), False)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "ESaveGlobal", "E save global (MeV):",
-      "Energy (MeV) below which charged particle will be considered for range rejection", 0)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "ESaveGlobal", translate("DoseEngines.OrthovoltageDoseEngine", "E save global (MeV):"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Energy (MeV) below which charged particle will be considered for range rejection"), 0)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "NRcycl", "Number of times to recycle each particle:",
-      "Number of times to recycle each particle.\n\
-      Each particle in the phase space file is used a total of NRCYCL+1 times before going on to the next particle.", 0)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "NRcycl", translate("DoseEngines.OrthovoltageDoseEngine", "Number of times to recycle each particle:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "Number of times to recycle each particle.\n\
+      Each particle in the phase space file is used a total of NRCYCL+1 times before going on to the next particle."), 0)
 
     self.scriptedEngine.addBeamParameterCheckBox(
-      "Orthovoltage dose", "IHowFarLess", "Enable HOWFARLESS algorithm:",
-      "If checked, enables 'HOWFARLESS' algorithm for transport in a homogeneous phantom.", False)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "IHowFarLess", translate("DoseEngines.OrthovoltageDoseEngine", "Enable HOWFARLESS algorithm:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "If checked, enables 'HOWFARLESS' algorithm for transport in a homogeneous phantom."), False)
 
     self.scriptedEngine.addBeamParameterCheckBox(
-      "Orthovoltage dose", "IDBS", "Enable directional bremsstrahlung splitting:",
-      "If checked, enables directional bremsstrahlung splitting (DBS).", True)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "IDBS", translate("DoseEngines.OrthovoltageDoseEngine", "Enable directional bremsstrahlung splitting:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "If checked, enables directional bremsstrahlung splitting (DBS)."), True)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "RDBS", "DBS splitting radius (cm):",
-      "DBS splitting radius used in BEAMnrc simulation (cm).\n\
-      Set to 0 to disable this option. Only needed if DBS is enabled.", 10)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "RDBS", translate("DoseEngines.OrthovoltageDoseEngine", "DBS splitting radius (cm):"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "DBS splitting radius used in BEAMnrc simulation (cm).\n\
+      Set to 0 to disable this option. Only needed if DBS is enabled."), 10)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "SSDDBS", "DBS SSD (cm):",
-      "SSD at which r_dbs is defined in the BEAM sim. (cm).\n\
-      Only needed if DBS is enabled.", 20)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "SSDDBS", translate("DoseEngines.OrthovoltageDoseEngine", "DBS SSD (cm):"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "SSD at which r_dbs is defined in the BEAM sim. (cm).\n\
+      Only needed if DBS is enabled."), 20)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "ZDBS", "DBS Z (cm):",
-       "Z in the BEAMnrc run where the phase space source was scored (cm).\n\
-      Only needed if DBS is enabled.", 20)
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "ZDBS", translate("DoseEngines.OrthovoltageDoseEngine", "DBS Z (cm):"),
+       translate("DoseEngines.OrthovoltageDoseEngine", "Z in the BEAMnrc run where the phase space source was scored (cm).\n\
+      Only needed if DBS is enabled."), 20)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      "Orthovoltage dose", "EraseOutsideSegment", "Erase outside segment:",
-      "If specified, causes the dose volume to be erased outside of the segment with the specified name.", "")
+      translate("DoseEngines.OrthovoltageDoseEngine", "Orthovoltage dose"), "EraseOutsideSegment", translate("DoseEngines.OrthovoltageDoseEngine", "Erase outside segment:"),
+      translate("DoseEngines.OrthovoltageDoseEngine", "If specified, causes the dose volume to be erased outside of the segment with the specified name."), "")
 
   #------------------------------------------------------------------------------
   #TODO: Add a path parameter type using the CTK path selector that saves the selections to Application Settings
@@ -484,7 +486,7 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     logging.info("DOSXYZ output (last paragraph): \n" + outStr[outStr.rfind('\n\n')+2:])
     if err is not None and str(err) != '':
       logging.error("DOSXYZ error: \n" + str(err))
-      return "DOSXYZ error! Please check the log"
+      return translate("DoseEngines.OrthovoltageDoseEngine", "DOSXYZ error! Please check the log")
 
     # Read output 3ddose file into result dose volume
     dosXyznrcOutputFileName = dosXyznrcSessionFilePrefix + ".3ddose"
@@ -492,7 +494,7 @@ class OrthovoltageDoseEngine(AbstractScriptedDoseEngine):
     loadedVolumeNode = slicer.util.loadNodeFromFile(dosXyznrcOutputFilePath, 'DosxyzNrc3dDoseFile', {})
     if loadedVolumeNode is None:
       logging.error("Failed to load result dose file {} for session using DOSXYZnrc input file {}".format(dosXyznrcOutputFilePath, dosXyznrcInputFileName))
-      return "Failed to load result dose file! Please check the log"
+      return translate("DoseEngines.OrthovoltageDoseEngine", "Failed to load result dose file! Please check the log")
 
     resultDoseVolumeNode.CopyOrientation(loadedVolumeNode)
     doseImageDataCopy = vtk.vtkImageData()

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/TopasDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/TopasDoseEngine.py
@@ -5,6 +5,8 @@ from DoseEngines import AbstractScriptedDoseEngine
 from Python.TopasDoseEngineUtil import TopasDoseEngineUtil
 import logging
 
+from slicer.i18n import translate
+
 #------------------------------------------------------------------------------
 #
 # TopasDoseEngine
@@ -40,69 +42,69 @@ class TopasDoseEngine(AbstractScriptedDoseEngine):
   #------------------------------------------------------------------------------
   def defineBeamParameters(self):
     """Define beam parameters that can be configured"""
-    tabName = "Topas parameters"
+    tabName = translate("DoseEngines.TopasDoseEngine", "Topas parameters")
 
     # Radiation mode (beam particle)
     self.scriptedEngine.addBeamParameterComboBox(
-      tabName, 'radiationMode', 'Radiation mode',
-      'Particle type used for the simulation',
+      tabName, 'radiationMode', translate("DoseEngines.TopasDoseEngine", "Radiation mode"),
+      translate("DoseEngines.TopasDoseEngine", "Particle type used for the simulation"),
       ['proton', 'neutron', 'gamma', 'e-', 'e+'], 0)
 
     # Energy parameter
     self.scriptedEngine.addBeamParameterSpinBox(
-      tabName, 'energy', 'Beam energy',
-      'Energy of the beam in MeV',
+      tabName, 'energy', translate("DoseEngines.TopasDoseEngine", "Beam energy"),
+      translate("DoseEngines.TopasDoseEngine", "Energy of the beam in MeV"),
       1.0, 250.0, 100.0, 1.0, 1)
 
     # Number of histories parameter
     self.scriptedEngine.addBeamParameterSpinBox(
-      tabName, 'numberOfHistories', 'Number of particles',
-      'Number of particles to simulate (more particles = better statistics but slower)',
+      tabName, 'numberOfHistories', translate("DoseEngines.TopasDoseEngine", "Number of particles"),
+      translate("DoseEngines.TopasDoseEngine", "Number of particles to simulate (more particles = better statistics but slower)"),
       100000, 100000000, 1000000, 500000, 0)
 
     # ParticlesPerHistory: downsampling factor — histories/spot = spot_MU / ParticlesPerHistory
     # Values < 1 increase histories (better statistics); values > 1 decrease them (faster)
     self.scriptedEngine.addBeamParameterSpinBox(
-      tabName, 'particlesPerHistory', 'Particles per history',
-      'Downsampling factor for TsRTIonSource. Values < 1 increase histories per spot for better statistics.',
+      tabName, 'particlesPerHistory', translate("DoseEngines.TopasDoseEngine", "Particles per history"),
+      translate("DoseEngines.TopasDoseEngine", "Downsampling factor for TsRTIonSource. Values < 1 increase histories per spot for better statistics."),
       0.0001, 10000000.0, 1.0, 0.1, 4)
 
     self.scriptedEngine.addBeamParameterSpinBox(
-      tabName, 'numberOfThreads', 'Number of threads',
-      'Number of CPU threads for the TOPAS simulation',
+      tabName, 'numberOfThreads', translate("DoseEngines.TopasDoseEngine", "Number of threads"),
+      translate("DoseEngines.TopasDoseEngine", "Number of CPU threads for the TOPAS simulation"),
       1, 64, os.cpu_count() or 1, 1, 0)
 
     # Path parameters
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'topasDirectory', 'TOPAS directory:',
-      'Path to the TOPAS installation directory', self.topasDirectoryPath)
+      tabName, 'topasDirectory', translate("DoseEngines.TopasDoseEngine", "TOPAS directory:"),
+      translate("DoseEngines.TopasDoseEngine", "Path to the TOPAS installation directory"), self.topasDirectoryPath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'topasBinary', 'TOPAS binary:',
-      'Path to the TOPAS executable', self.topasBinaryPath)
+      tabName, 'topasBinary', translate("DoseEngines.TopasDoseEngine", "TOPAS binary:"),
+      translate("DoseEngines.TopasDoseEngine", "Path to the TOPAS executable"), self.topasBinaryPath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'g4DataDirectory', 'Geant4 data directory:',
-      'Path to the Geant4 data directory (G4DATAFILES)', self.g4dataPath)
+      tabName, 'g4DataDirectory', translate("DoseEngines.TopasDoseEngine", "Geant4 data directory:"),
+      translate("DoseEngines.TopasDoseEngine", "Path to the Geant4 data directory (G4DATAFILES)"), self.g4dataPath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'rtIonPlanFile', 'RT Ion Plan file (optional):',
-      'Path to a DICOM RT Ion Plan file for TsRTIonSource. Leave empty to use the simple beam source.',
+      tabName, 'rtIonPlanFile', translate("DoseEngines.TopasDoseEngine", "RT Ion Plan file (optional):"),
+      translate("DoseEngines.TopasDoseEngine", "Path to a DICOM RT Ion Plan file for TsRTIonSource. Leave empty to use the simple beam source."),
       self.rtIonPlanFilePath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'schneiderMaterialFile', 'Schneider material file (optional):',
-      'Path to a custom HU-to-material Schneider table. Leave empty to use the bundled default '
-      '(a good default, but not the most up to date).',
+      tabName, 'schneiderMaterialFile', translate("DoseEngines.TopasDoseEngine", "Schneider material file (optional):"),
+      translate("DoseEngines.TopasDoseEngine", "Path to a custom HU-to-material Schneider table. Leave empty to use the bundled default "
+      "(a good default, but not the most up to date)."),
       self.schneiderMaterialFilePath)
 
     self.scriptedEngine.addBeamParameterLineEdit(
-      tabName, 'machineDescriptionFile', 'Machine description file (.table, optional):',
-      'Path to a custom TOPAS dicom-interface PBS machine description (.table) file '
-      '(see https://github.com/topasmc/dicom-interface/wiki/using-machine-description-file). '
-      'Overrides the treatment machine read from the RT Ion Plan DICOM. Only generic PBS '
-      '.table files are supported here, not compiled-in machine models. Leave empty to use '
-      'the machine read from DICOM.',
+      tabName, 'machineDescriptionFile', translate("DoseEngines.TopasDoseEngine", "Machine description file (.table, optional):"),
+      translate("DoseEngines.TopasDoseEngine", "Path to a custom TOPAS dicom-interface PBS machine description (.table) file "
+      "(see https://github.com/topasmc/dicom-interface/wiki/using-machine-description-file). "
+      "Overrides the treatment machine read from the RT Ion Plan DICOM. Only generic PBS "
+      ".table files are supported here, not compiled-in machine models. Leave empty to use "
+      "the machine read from DICOM."),
       self.machineDescriptionFilePath)
 
   #------------------------------------------------------------------------------

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/pyRadPlanEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/pyRadPlanEngine.py
@@ -7,6 +7,8 @@ from scipy.sparse import coo_matrix
 from DoseEngines import *
 from Python.PyRadPlanUtils import prepareCt, prepareCst, preparePln
 
+from slicer.i18n import translate
+
 class pyRadPlanEngine(AbstractScriptedDoseEngine):
   """ pyRadPlan dose engine for SlicerRT External Beam Planning Module.
   """
@@ -22,29 +24,29 @@ class pyRadPlanEngine(AbstractScriptedDoseEngine):
   #------------------------------------------------------------------------------
   def defineBeamParameters(self):
     self.scriptedEngine.addBeamParameterSpinBox(
-    "pyRadPlan parameters", "numOfFractions", "number of fractions",
-    "Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)",
+    translate("DoseEngines.pyRadPlanEngine", "pyRadPlan parameters"), "numOfFractions", translate("DoseEngines.pyRadPlanEngine", "number of fractions"),
+    translate("DoseEngines.pyRadPlanEngine", "Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)"),
     0.0, 99.99, 30.0, 1.0, 2 )
 
     self.scriptedEngine.addBeamParameterComboBox(
-    "pyRadPlan parameters", "radiationMode", "radiation mode", "comment",
-    ["photons", "protons", "carbons"], 0)
+    translate("DoseEngines.pyRadPlanEngine", "pyRadPlan parameters"), "radiationMode", translate("DoseEngines.pyRadPlanEngine", "radiation mode"), translate("DoseEngines.pyRadPlanEngine", "comment"),
+    [translate("DoseEngines.pyRadPlanEngine", "photons"), translate("DoseEngines.pyRadPlanEngine", "protons"), translate("DoseEngines.pyRadPlanEngine", "carbons")], 0)
 
     self.scriptedEngine.addBeamParameterComboBox(
-    "pyRadPlan parameters","machine","machine","comment",["generic"],0)      
+    translate("DoseEngines.pyRadPlanEngine", "pyRadPlan parameters"), "machine", translate("DoseEngines.pyRadPlanEngine", "machine"), translate("DoseEngines.pyRadPlanEngine", "comment"), [translate("DoseEngines.pyRadPlanEngine", "generic")], 0)
 
   #------------------------------------------------------------------------------
   def updateBeamParametersForIonPlan(self, isIonPlanActive):
     if isIonPlanActive:
-      availableRadiationModes = ["protons", "carbons"]
-      parameterLabel = "radiation mode (ion)"
+      availableRadiationModes = [translate("DoseEngines.pyRadPlanEngine", "protons"), translate("DoseEngines.pyRadPlanEngine", "carbons")]
+      parameterLabel = translate("DoseEngines.pyRadPlanEngine", "radiation mode (ion)")
     else:
-      availableRadiationModes = ["photons", "protons", "carbons"]
-      parameterLabel = "radiation mode"
+      availableRadiationModes = [translate("DoseEngines.pyRadPlanEngine", "photons"), translate("DoseEngines.pyRadPlanEngine", "protons"), translate("DoseEngines.pyRadPlanEngine", "carbons")]
+      parameterLabel = translate("DoseEngines.pyRadPlanEngine", "radiation mode")
     
     self.scriptedEngine.updateBeamParameterComboBox(
-    "pyRadPlan parameters", "radiationMode", parameterLabel,
-    "comment", availableRadiationModes, 0)
+    translate("DoseEngines.pyRadPlanEngine", "pyRadPlan parameters"), "radiationMode", parameterLabel,
+    translate("DoseEngines.pyRadPlanEngine", "comment"), availableRadiationModes, 0)
 
   #------------------------------------------------------------------------------
   def calculateDoseUsingEngine(self, beamNode, resultDoseVolumeNode):

--- a/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
+++ b/ExternalBeamPlanning/Widgets/qMRMLObjectivesTableWidget.cxx
@@ -35,6 +35,7 @@
 #include <vtkWeakPointer.h>
 
 // Qt includes
+#include <QCoreApplication>
 #include <QDebug>
 #include <QKeyEvent>
 #include <QStringList>
@@ -102,9 +103,20 @@ void qMRMLObjectivesTableWidgetPrivate::init()
   this->ColumnLabels << "Number" << "IsConstraint" << "ObjectiveName" << "Segments" << "OverlapPriority" << "Penalty" << "Parameters";
   this->ObjectivesTable->setColumnCount(this->ColumnLabels.size());
   this->ObjectivesTable->setHorizontalHeaderLabels(
-    QStringList() << "#" << "C" << "Objective" << "Segments" << "OP" << "p" << "Parameters");
+    QStringList()
+      //: number
+      << qMRMLObjectivesTableWidget::tr("#")
+      //: abbreviation for "Constraint"
+      << qMRMLObjectivesTableWidget::tr("C")
+      << qMRMLObjectivesTableWidget::tr("Objective")
+      << qMRMLObjectivesTableWidget::tr("Segments")
+      //: abbreviation for "Overlap Priority"
+      << qMRMLObjectivesTableWidget::tr("OP")
+      //: abbreviation for "Penalty"
+      << qMRMLObjectivesTableWidget::tr("p")
+      << qMRMLObjectivesTableWidget::tr("Parameters"));
   this->ObjectivesTable->horizontalHeaderItem(this->columnIndex("IsConstraint"))
-    ->setToolTip("Constraint (check to show constraints instead of objectives)");
+    ->setToolTip(qMRMLObjectivesTableWidget::tr("Constraint (check to show constraints instead of objectives)"));
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
   this->ObjectivesTable->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
@@ -240,7 +252,7 @@ void qMRMLObjectivesTableWidget::updateObjectivesTable()
   // Check selection validity
   if (!d->PlanNode)
   {
-    d->setMessage("No plan node selected.");
+    d->setMessage(tr("No plan node selected."));
     d->ObjectivesTable->setRowCount(0);
     d->ObjectivesTable->blockSignals(false);
     return;
@@ -248,7 +260,7 @@ void qMRMLObjectivesTableWidget::updateObjectivesTable()
 
   if (!d->PlanNode->GetSegmentationNode())
   {
-    d->setMessage("No segmentation node selected in the plan node.");
+    d->setMessage(tr("No segmentation node selected in the plan node."));
     d->ObjectivesTable->blockSignals(false);
     return;
   }
@@ -256,7 +268,7 @@ void qMRMLObjectivesTableWidget::updateObjectivesTable()
   qSlicerAbstractPlanOptimizer* selectedEngine = qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(d->PlanNode->GetPlanOptimizerName());
   if (!selectedEngine)
   {
-    d->setMessage("No valid plan optimizer selected in the plan node.");
+    d->setMessage(tr("No valid plan optimizer selected in the plan node."));
     d->ObjectivesTable->setRowCount(0);
     d->ObjectivesTable->blockSignals(false);
     return;
@@ -445,7 +457,7 @@ void qMRMLObjectivesTableWidget::onObjectiveAdded()
   QCheckBox* constraintCheckBox = new QCheckBox();
   bool hasConstraints = std::any_of(availableObjectives.begin(), availableObjectives.end(),
     [](const qSlicerAbstractPlanOptimizer::ObjectiveStruct& o) { return o.isConstraint; });
-  constraintCheckBox->setToolTip("Check to show constraints instead of objectives");
+  constraintCheckBox->setToolTip(tr("Check to show constraints instead of objectives"));
   d->ObjectivesTable->setCellWidget(row, d->columnIndex("IsConstraint"), constraintCheckBox);
   d->ObjectivesTable->setColumnHidden(d->columnIndex("IsConstraint"), !hasConstraints);
 

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
@@ -182,14 +182,14 @@ QString qSlicerAbstractDoseEngine::calculateDose(vtkMRMLRTBeamNode* beamNode)
 {
   if (!beamNode)
   {
-    QString errorMessage("Invalid beam node");
+    QString errorMessage(tr("Invalid beam node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();
   if (!parentPlanNode)
   {
-    QString errorMessage = QString("Unable to access parent node for beam %1").arg(beamNode->GetName());
+    QString errorMessage = tr("Unable to access parent node for beam %1").arg(beamNode->GetName());
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -198,14 +198,14 @@ QString qSlicerAbstractDoseEngine::calculateDose(vtkMRMLRTBeamNode* beamNode)
   vtkMRMLScalarVolumeNode* referenceVolumeNode = parentPlanNode->GetReferenceVolumeNode();
   if (!referenceVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(beamNode->GetScene());
   if (!shNode)
   {
-    QString errorMessage("Failed to access subject hierarchy node");
+    QString errorMessage(tr("Failed to access subject hierarchy node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -253,21 +253,21 @@ QString qSlicerAbstractDoseEngine::calculateDoseInfluenceMatrix(vtkMRMLRTBeamNod
 {
   if (!this->isInverse())
   {
-    QString errorMessage("Dose engine lacks functionality for calculating a dose influence matrix for inverse planning");
+    QString errorMessage(tr("Dose engine lacks functionality for calculating a dose influence matrix for inverse planning"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
-    
+
   if (!beamNode)
   {
-    QString errorMessage("Invalid beam node");
+    QString errorMessage(tr("Invalid beam node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();
   if (!parentPlanNode)
   {
-    QString errorMessage = QString("Unable to access parent node for beam %1").arg(beamNode->GetName());
+    QString errorMessage = tr("Unable to access parent node for beam %1").arg(beamNode->GetName());
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -276,14 +276,14 @@ QString qSlicerAbstractDoseEngine::calculateDoseInfluenceMatrix(vtkMRMLRTBeamNod
   vtkMRMLScalarVolumeNode* referenceVolumeNode = parentPlanNode->GetReferenceVolumeNode();
   if (!referenceVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(beamNode->GetScene());
   if (!shNode)
   {
-    QString errorMessage("Failed to access subject hierarchy node");
+    QString errorMessage(tr("Failed to access subject hierarchy node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractPlanOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractPlanOptimizer.cxx
@@ -104,7 +104,7 @@ QString qSlicerAbstractPlanOptimizer::optimizePlan(vtkMRMLRTPlanNode* planNode)
 {
   if (!planNode)
   {
-    QString errorMessage = QString("Invalid Plan Node");
+    QString errorMessage = tr("Invalid Plan Node");
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -113,14 +113,14 @@ QString qSlicerAbstractPlanOptimizer::optimizePlan(vtkMRMLRTPlanNode* planNode)
   vtkMRMLScalarVolumeNode* referenceVolumeNode = planNode->GetReferenceVolumeNode();
   if (!referenceVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(planNode->GetScene());
   if (!shNode)
   {
-    QString errorMessage("Failed to access subject hierarchy node");
+    QString errorMessage(tr("Failed to access subject hierarchy node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }

--- a/ExternalBeamPlanning/Widgets/qSlicerDoseEngineLogic.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerDoseEngineLogic.cxx
@@ -160,7 +160,7 @@ void qSlicerDoseEngineLogic::applyDoseEngineInPlan(vtkObject* nodeObject)
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
   }
@@ -189,7 +189,7 @@ QString qSlicerDoseEngineLogic::calculateDose(vtkMRMLRTPlanNode* planNode)
   QString errorMessage("");
   if (!planNode || !planNode->GetScene())
   {
-    errorMessage = QString("Invalid MRML scene or RT plan node");
+    errorMessage = tr("Invalid MRML scene or RT plan node");
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -199,7 +199,7 @@ QString qSlicerDoseEngineLogic::calculateDose(vtkMRMLRTPlanNode* planNode)
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return errorMessage;
   }
@@ -229,7 +229,7 @@ QString qSlicerDoseEngineLogic::calculateDose(vtkMRMLRTPlanNode* planNode)
     }
     else
     {
-      errorMessage = QString("Invalid beam!");
+      errorMessage = tr("Invalid beam");
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       return errorMessage;
     }
@@ -258,7 +258,7 @@ QString qSlicerDoseEngineLogic::calculateDoseInfluenceMatrix(vtkMRMLRTPlanNode* 
   QString errorMessage("");
   if (!planNode || !planNode->GetScene())
   {
-      errorMessage = QString("Invalid MRML scene or RT plan node");
+      errorMessage = tr("Invalid MRML scene or RT plan node");
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       return errorMessage;
   }
@@ -268,7 +268,7 @@ QString qSlicerDoseEngineLogic::calculateDoseInfluenceMatrix(vtkMRMLRTPlanNode* 
       qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-      QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+      QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
       qCritical() << Q_FUNC_INFO << ": " << errorString;
       return errorMessage;
   }
@@ -298,7 +298,7 @@ QString qSlicerDoseEngineLogic::calculateDoseInfluenceMatrix(vtkMRMLRTPlanNode* 
     }
     else
     {
-      errorMessage = QString("Invalid beam!");
+      errorMessage = tr("Invalid beam");
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       return errorMessage;
     }
@@ -315,7 +315,7 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
 {
   if (!planNode || !planNode->GetScene())
   {
-    QString errorMessage("Invalid MRML scene or RT plan node");
+    QString errorMessage(tr("Invalid MRML scene or RT plan node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -323,7 +323,7 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
   vtkMRMLScalarVolumeNode* referenceVolumeNode = planNode->GetReferenceVolumeNode();
   if (!referenceVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -331,14 +331,14 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
   vtkMRMLScalarVolumeNode* totalDoseVolumeNode = planNode->GetOutputTotalDoseVolumeNode();
   if (!totalDoseVolumeNode)
   {
-    QString errorMessage("Unable to access output dose volume");
+    QString errorMessage(tr("Unable to access output dose volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(planNode->GetScene());
   if (!shNode)
   {
-    QString errorMessage("Failed to access subject hierarchy node");
+    QString errorMessage(tr("Failed to access subject hierarchy node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -348,7 +348,7 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorMessage = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorMessage = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -370,7 +370,7 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
     vtkMRMLRTBeamNode* beamNode = (*beamIt);
     if (!beamNode)
     {
-      QString errorMessage("Beam not found");
+      QString errorMessage(tr("Beam not found"));
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       continue;
     }
@@ -379,7 +379,7 @@ QString qSlicerDoseEngineLogic::createAccumulatedDose(vtkMRMLRTPlanNode* planNod
     vtkMRMLScalarVolumeNode* perBeamDoseVolume = selectedEngine->getResultDoseForBeam(beamNode);
     if (!perBeamDoseVolume)
     {
-      QString errorMessage = QString("No calculated dose found for beam %1").arg(beamNode->GetName());
+      QString errorMessage = tr("No calculated dose found for beam %1").arg(beamNode->GetName());
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       continue;
     }
@@ -489,7 +489,7 @@ void qSlicerDoseEngineLogic::removeIntermediateResults(vtkMRMLRTPlanNode* planNo
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
   }
@@ -537,7 +537,7 @@ vtkMRMLRTBeamNode* qSlicerDoseEngineLogic::createBeamInPlan(vtkMRMLRTPlanNode* p
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return nullptr;
   }

--- a/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerIpoptOptimizer.cxx
@@ -743,7 +743,7 @@ qSlicerIpoptOptimizer::Result qSlicerIpoptOptimizer::solveProblem(const Array& x
 
   // Emit completion signal
   emit optimizationCompleted(result.success,
-    result.success ? "Optimization completed successfully" : "Optimization failed");
+    result.success ? tr("Optimization completed successfully") : tr("Optimization failed"));
 
   return result;
 }
@@ -959,20 +959,20 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
   vtkMRMLScalarVolumeNode* resultOptimizationVolumeNode)
 {
   if (!planNode || !resultOptimizationVolumeNode)
-    return "Invalid plan or result volume node";
+    return tr("Invalid plan or result volume node");
   if (objectives.empty())
-    return "No objectives defined";
+    return tr("No objectives defined");
 
   vtkMRMLScalarVolumeNode* refVol = planNode->GetReferenceVolumeNode();
   if (!refVol)
-    return "No reference volume on plan";
+    return tr("No reference volume on plan");
 
   // ── Step 1: collect beams and build combined D (numVoxels × totalBixels) ──
 
   std::vector<vtkMRMLRTBeamNode*> beams;
   planNode->GetBeams(beams);
   if (beams.empty())
-    return "No beams in plan";
+    return tr("No beams in plan");
 
   // Use dose grid from first beam; fall back to reference volume if not set.
   int doseGridDim[3] = {0, 0, 0};
@@ -1027,7 +1027,7 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
   {
     const SparseD& Di = beam->GetDoseInfluenceMatrix();
     if (Di.rows() == 0 || Di.cols() == 0)
-      return QString("Dose influence matrix empty for beam '%1'. "
+      return tr("Dose influence matrix empty for beam '%1'. "
                      "Run dose calculation first.").arg(beam->GetName());
     for (int k = 0; k < Di.outerSize(); ++k)
       for (SparseD::InnerIterator it(Di, k); it; ++it)
@@ -1097,7 +1097,7 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
   scene->RemoveNode(doseGridVolNode);
 
   if (structObjs.empty() && structConstraints.empty())
-    return "No valid objectives or constraints could be configured";
+    return tr("No valid objectives or constraints could be configured");
 
   // ── Step 3: wire IPOPT objective and gradient as lambdas ──
   // f(w) = Σ_i penalty_i * f_i( D[struct_i, :] * w )
@@ -1226,14 +1226,14 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
   }
 
   // ── Step 4: solve ──
-  emit progressInfoUpdated("Starting IPOPT optimization...");
+  emit progressInfoUpdated(tr("Starting IPOPT optimization..."));
 
   // Scale initial weights so the mean dose in the most demanding MinDose
   Array w0(totalBixels, 1.0 / totalBixels);
 
   Result result = solveProblem(w0);
   if (!result.success)
-    return QString("IPOPT solver did not converge (status %1)").arg(result.status);
+    return tr("IPOPT solver did not converge (status %1)").arg(result.status);
 
   // ── Step 5: compute and store result dose volume ──
   Eigen::VectorXd wOpt = Eigen::Map<Eigen::VectorXd>(
@@ -1252,6 +1252,6 @@ QString qSlicerIpoptOptimizer::optimizePlanUsingOptimizer(
   resultOptimizationVolumeNode->SetName(
     (std::string(planNode->GetName()) + "_IpoptOptimizedDose").c_str());
 
-  emit progressInfoUpdated("IPOPT optimization complete.");
+  emit progressInfoUpdated(tr("IPOPT optimization complete."));
   return QString(); // empty = success
 }

--- a/ExternalBeamPlanning/Widgets/qSlicerMockDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMockDoseEngine.cxx
@@ -61,7 +61,7 @@ void qSlicerMockDoseEngine::defineBeamParameters()
 {
   // Noise level parameter
   this->addBeamParameterSpinBox(
-    "Mock dose", "NoiseRange", "Noise range (% of Rx):", "Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)",
+    tr("Mock dose"), "NoiseRange", tr("Noise range (% of Rx):"), tr("Range of noise added to the prescription dose (+- half of the percentage of the Rx dose)"),
     0.0, 99.99, 10.0, 1.0, 2 );
 }
 
@@ -70,7 +70,7 @@ QString qSlicerMockDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamN
 {
   if (!beamNode)
   {
-    QString errorMessage("Invalid beam node");
+    QString errorMessage(tr("Invalid beam node"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -78,7 +78,7 @@ QString qSlicerMockDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamN
   vtkMRMLScalarVolumeNode* referenceVolumeNode = parentPlanNode->GetReferenceVolumeNode();
   if (!parentPlanNode || !referenceVolumeNode || !resultDoseVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -101,7 +101,7 @@ QString qSlicerMockDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamN
 
   if (!beamImageData)
   {
-    QString errorMessage("Unable to create beam image!");
+    QString errorMessage(tr("Unable to create beam image!"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -115,7 +115,7 @@ QString qSlicerMockDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* beamN
   if ( beamImageData->GetNumberOfPoints() != protonDoseImageData->GetNumberOfPoints()
     || beamImageData->GetScalarType() != VTK_UNSIGNED_CHAR )
   {
-    QString errorMessage("Geometrical discrepancy between beam and dose");
+    QString errorMessage(tr("Geometrical discrepancy between beam and dose"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }

--- a/ExternalBeamPlanning/Widgets/qSlicerMockPlanOptimizer.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerMockPlanOptimizer.cxx
@@ -58,7 +58,7 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
   vtkMRMLScalarVolumeNode* referenceVolumeNode = planNode->GetReferenceVolumeNode();  
   if (!planNode || !referenceVolumeNode || !resultOptimizationVolumeNode)  
   {  
-    QString errorMessage("Unable to access reference volume");  
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;  
     return errorMessage;  
   }  
@@ -86,20 +86,20 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
   for (int i = 0; i < planNode->GetNumberOfBeams(); i++)  
   {  
     // Update progress
-    QString info = "Beam " + QString::number(i+1) + "/" + QString::number(planNode->GetNumberOfBeams());
+    QString info = tr("Beam %1/%2").arg(i+1).arg(planNode->GetNumberOfBeams());
     this->progressInfoUpdated(info);
     
     vtkMRMLRTBeamNode* beamNode = planNode->GetBeamByName(beamNames[i]);  
     if (!beamNode)
     {
-      QString errorMessage("Invalid beam node");
+      QString errorMessage(tr("Invalid beam node"));
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       return errorMessage;
     }
-    vtkMRMLRTBeamNode::DoseInfluenceMatrixType doseInfluenceMatrix = beamNode->GetDoseInfluenceMatrix();  
-    if (doseInfluenceMatrix.rows() == 0 || doseInfluenceMatrix.cols() == 0)  
-    {  
-      QString errorMessage("Dose influence matrix is empty");  
+    vtkMRMLRTBeamNode::DoseInfluenceMatrixType doseInfluenceMatrix = beamNode->GetDoseInfluenceMatrix();
+    if (doseInfluenceMatrix.rows() == 0 || doseInfluenceMatrix.cols() == 0)
+    {
+      QString errorMessage(tr("Dose influence matrix is empty"));
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;  
       return errorMessage;  
     }  
@@ -175,13 +175,13 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
       resampledDoseImageData->DeepCopy(resliceFilter->GetOutput());
       if (!resampledDoseImageData || resampledDoseImageData->GetNumberOfPoints() == 0)
       {
-        QString errorMessage("Dose resampling failed or resulted in empty data");
+        QString errorMessage(tr("Dose resampling failed or resulted in empty data"));
         qCritical() << Q_FUNC_INFO << ": " << errorMessage;
         return errorMessage;
       }
       if (resampledDoseImageData->GetNumberOfPoints() != totalDoseImageData->GetNumberOfPoints())
       {
-        QString errorMessage("Number of points in resampled dose and total dose don't match! (Should match referenceVolume.)");
+        QString errorMessage(tr("Number of points in resampled dose and total dose don't match! (Should match referenceVolume.)"));
         qCritical() << Q_FUNC_INFO << ": " << errorMessage;
         return errorMessage;
       }
@@ -190,7 +190,7 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
       float* dosePtr = static_cast<float*>(resampledDoseImageData->GetScalarPointer());
       if (!totalDosePtr || !dosePtr)
       {
-        QString errorMessage("Invalid pointer in total or resampled beam dose data!");
+        QString errorMessage(tr("Invalid pointer in total or resampled beam dose data!"));
         qCritical() << Q_FUNC_INFO << ": " << errorMessage;
         return errorMessage;
       }
@@ -204,7 +204,7 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
       // No resampling needed, use original dose image data
       if (doseImageData->GetNumberOfPoints() != totalDoseImageData->GetNumberOfPoints())
       {
-        QString errorMessage("Number of points in dose and total dose don't match! (Should match referenceVolume.)");
+        QString errorMessage(tr("Number of points in dose and total dose don't match! (Should match referenceVolume.)"));
         qCritical() << Q_FUNC_INFO << ": " << errorMessage;
         return errorMessage;
       }
@@ -213,7 +213,7 @@ QString qSlicerMockPlanOptimizer::optimizePlanUsingOptimizer(vtkMRMLRTPlanNode* 
       float* dosePtr = static_cast<float*>(doseImageData->GetScalarPointer());
       if (!totalDosePtr || !dosePtr)
       {
-        QString errorMessage("Invalid pointer in total dose or beam dose data!");
+        QString errorMessage(tr("Invalid pointer in total dose or beam dose data!"));
         qCritical() << Q_FUNC_INFO << ": " << errorMessage;
         return errorMessage;
       }

--- a/ExternalBeamPlanning/Widgets/qSlicerPlanOptimizerLogic.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerPlanOptimizerLogic.cxx
@@ -77,7 +77,7 @@ QString qSlicerPlanOptimizerLogic::optimizePlan(vtkMRMLRTPlanNode* planNode)
   QString errorMessage("");
   if (!planNode || !planNode->GetScene())
   {
-    errorMessage = QString("Invalid MRML scene or RT plan node");
+    errorMessage = tr("Invalid MRML scene or RT plan node");
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -87,14 +87,14 @@ QString qSlicerPlanOptimizerLogic::optimizePlan(vtkMRMLRTPlanNode* planNode)
     qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(planNode->GetPlanOptimizerName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
+    QString errorString = tr("Unable to access optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return errorMessage;
   }
 
   connect(selectedEngine, SIGNAL(progressInfoUpdated(QString)), this, SIGNAL(progressInfoUpdated(QString)));
 
-  emit progressInfoUpdated("starting");
+  emit progressInfoUpdated(tr("starting"));
 
   errorMessage = selectedEngine->optimizePlan(planNode);
   if (!errorMessage.isEmpty())
@@ -169,7 +169,7 @@ void qSlicerPlanOptimizerLogic::applyPlanOptimizerInPlan(vtkObject* nodeObject)
     qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(planNode->GetPlanOptimizerName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access plan optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
+    QString errorString = tr("Unable to access plan optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
   }

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModule.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModule.cxx
@@ -64,21 +64,21 @@ qSlicerExternalBeamPlanningModule::~qSlicerExternalBeamPlanningModule() = defaul
 //-----------------------------------------------------------------------------
 QString qSlicerExternalBeamPlanningModule::helpText()const
 {
-  return QString("The External Beam Planning module facilitates basic EBRT planning. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/ExternalBeamPlanning\">%1/Documentation/%2.%3/Modules/ExternalBeamPlanning</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("The External Beam Planning module facilitates basic EBRT planning. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/ExternalBeamPlanning.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerExternalBeamPlanningModule::acknowledgementText()const
 {
-  return "This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.";
+  return tr("This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.");
 }
 
 //-----------------------------------------------------------------------------
 QStringList qSlicerExternalBeamPlanningModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -387,8 +387,8 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
   connect(d->lineEdit_Ipopt_tol,                   SIGNAL(editingFinished()),           this, SLOT(ipoptTolChanged()));
   connect(d->lineEdit_Ipopt_acceptable_tol,        SIGNAL(editingFinished()),           this, SLOT(ipoptAcceptableTolChanged()));
   connect(d->spinBox_Ipopt_acceptable_iter,        SIGNAL(valueChanged(int)),           this, SLOT(ipoptAcceptableIterChanged(int)));
-  connect(d->comboBox_Ipopt_mu_strategy,           SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptMuStrategyChanged(QString)));
-  connect(d->comboBox_Ipopt_hessian_approximation, SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptHessianApproximationChanged(QString)));
+  connect(d->comboBox_Ipopt_mu_strategy,           SIGNAL(currentIndexChanged(int)),    this, SLOT(ipoptMuStrategyChanged(int)));
+  connect(d->comboBox_Ipopt_hessian_approximation, SIGNAL(currentIndexChanged(int)),    this, SLOT(ipoptHessianApproximationChanged(int)));
   connect(d->spinBox_Ipopt_lbfgs_history,          SIGNAL(valueChanged(int)),           this, SLOT(ipoptLbfgsHistoryChanged(int)));
   connect(d->spinBox_Ipopt_print_level,            SIGNAL(valueChanged(int)),           this, SLOT(ipoptPrintLevelChanged(int)));
   connect(d->comboBox_Ipopt_linear_solver,         SIGNAL(currentTextChanged(QString)), this, SLOT(ipoptLinearSolverChanged(QString)));
@@ -414,6 +414,25 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
     if (cb->count() == 0)                         cb->addItem("mumps"); // fallback
     cb->blockSignals(false);
   }
+
+  {
+    // Populate with translatable display text; the literal IPOPT option value is stored
+    // as item data and read back via currentData() in the slots below (see currentIndexChanged
+    // connections above), so the UI language cannot affect what gets passed to IPOPT.
+    QComboBox* muCb = d->comboBox_Ipopt_mu_strategy;
+    muCb->blockSignals(true);
+    muCb->clear();
+    muCb->addItem(tr("adaptive"), QString("adaptive"));
+    muCb->addItem(tr("monotone"), QString("monotone"));
+    muCb->blockSignals(false);
+
+    QComboBox* hessianCb = d->comboBox_Ipopt_hessian_approximation;
+    hessianCb->blockSignals(true);
+    hessianCb->clear();
+    hessianCb->addItem(tr("limited-memory"), QString("limited-memory"));
+    hessianCb->addItem(tr("exact"), QString("exact"));
+    hessianCb->blockSignals(false);
+  }
 #endif
 
   // Objective Table
@@ -429,7 +448,7 @@ void qSlicerExternalBeamPlanningModuleWidget::setup()
   d->MRMLNodeComboBox_DoseROI->setVisible(false);
 
   // Set status text to initial instruction
-  d->label_CalculateDoseStatus->setText("Add plan and beam to start planning");
+  d->label_CalculateDoseStatus->setText(tr("Add plan and beam to start planning"));
 
   // Handle scene change event if occurs
   qvtkConnect( d->logic(), vtkCommand::ModifiedEvent, this, SLOT( onLogicModified() ) );
@@ -1152,7 +1171,7 @@ void qSlicerExternalBeamPlanningModuleWidget::updateDoseEngines()
   if (d->comboBox_DoseEngine->count() == 0)
   {
       //qCritical() << Q_FUNC_INFO << ": No dose engines available";
-      d->comboBox_DoseEngine->addItem("No dose engines available");
+      d->comboBox_DoseEngine->addItem(tr("No dose engines available"));
       d->comboBox_DoseEngine->setCurrentIndex(0);
       d->comboBox_DoseEngine->setDisabled(true);
       return;
@@ -1217,7 +1236,7 @@ void qSlicerExternalBeamPlanningModuleWidget::updatePlanOptimizers()
   if (d->comboBox_PlanOptimizer->count() == 0)
   {
     //qCritical() << Q_FUNC_INFO << ": No dose engines available";
-    d->comboBox_PlanOptimizer->addItem("No optimizers available");
+    d->comboBox_PlanOptimizer->addItem(tr("No optimizers available"));
     d->comboBox_PlanOptimizer->setCurrentIndex(0);
     d->comboBox_PlanOptimizer->setDisabled(true);
     return;
@@ -1382,7 +1401,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateDoseClicked()
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
-  d->label_CalculateDoseStatus->setText("Starting dose calculation...");
+  d->label_CalculateDoseStatus->setText(tr("Starting dose calculation..."));
 
   if (!this->mrmlScene())
   {
@@ -1399,7 +1418,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateDoseClicked()
   vtkMRMLRTPlanNode* planNode = vtkMRMLRTPlanNode::SafeDownCast(d->MRMLNodeComboBox_RtPlan->currentNode());
   if (!planNode)
   {
-    QString errorString("No RT plan node selected");
+    QString errorString(tr("No RT plan node selected"));
     d->label_CalculateDoseStatus->setText(errorString);
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
@@ -1442,7 +1461,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateDoseClicked()
     qSlicerDoseEnginePluginHandler::instance()->doseEngineByName(planNode->GetDoseEngineName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Unable to access dose engine with name %1").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     d->label_CalculateDoseStatus->setText(errorString);
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
@@ -1451,7 +1470,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateDoseClicked()
   // If inverse planning is selected, we do a sanity check for the dose engine capabilities
   if (d->checkBox_InversePlanning->isChecked() && !selectedEngine->isInverse())
   {
-    QString errorString = QString("Selected Dose Engine %1 can't do dose influence matrix calculation!").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
+    QString errorString = tr("Selected Dose Engine %1 can't do dose influence matrix calculation!").arg(planNode->GetDoseEngineName() ? planNode->GetDoseEngineName() : "nullptr");
     d->label_CalculateDoseStatus->setText(errorString);
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
@@ -1461,26 +1480,26 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateDoseClicked()
   QString errorMessage;
   if (d->checkBox_InversePlanning->isChecked())
   {
-    QString message = QString("Starting dose influence matrix calculation...");
+    QString message = tr("Starting dose influence matrix calculation...");
     qDebug() << Q_FUNC_INFO << ": " << message;
     errorMessage = d->DoseEngineLogic->calculateDoseInfluenceMatrix(planNode);
   }
   else
   {
-    QString message = QString("Starting forward dose calculation...");
+    QString message = tr("Starting forward dose calculation...");
     qDebug() << Q_FUNC_INFO << ": " << message;
     errorMessage = d->DoseEngineLogic->calculateDose(planNode);
   }
 
   if (errorMessage.isEmpty())
   {
-    QString message = QString("Dose calculated successfully in %1 s").arg(time.elapsed()/1000.0);
+    QString message = tr("Dose calculated successfully in %1 s").arg(time.elapsed()/1000.0);
     qDebug() << Q_FUNC_INFO << ": " << message;
     d->label_CalculateDoseStatus->setText(message);
   }
   else
   {
-    QString message = QString("ERROR: %1").arg(errorMessage);
+    QString message = tr("ERROR: %1").arg(errorMessage);
     qCritical() << Q_FUNC_INFO << ": " << message;
     d->label_CalculateDoseStatus->setText(message);
   }
@@ -1493,7 +1512,7 @@ void qSlicerExternalBeamPlanningModuleWidget::optimizePlanClicked()
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
-  d->label_OptimizationStatus->setText("Starting optimization...");
+  d->label_OptimizationStatus->setText(tr("Starting optimization..."));
 
   if (!this->mrmlScene())
   {
@@ -1510,7 +1529,7 @@ void qSlicerExternalBeamPlanningModuleWidget::optimizePlanClicked()
   vtkMRMLRTPlanNode* planNode = vtkMRMLRTPlanNode::SafeDownCast(d->MRMLNodeComboBox_RtPlan->currentNode());
   if (!planNode)
   {
-    QString errorString("No RT plan node selected");
+    QString errorString(tr("No RT plan node selected"));
     d->label_OptimizationStatus->setText(errorString);
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
@@ -1527,7 +1546,7 @@ void qSlicerExternalBeamPlanningModuleWidget::optimizePlanClicked()
     qSlicerPlanOptimizerPluginHandler::instance()->PlanOptimizerByName(planNode->GetPlanOptimizerName());
   if (!selectedEngine)
   {
-    QString errorString = QString("Unable to access plan optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
+    QString errorString = tr("Unable to access plan optimizer with name %1").arg(planNode->GetPlanOptimizerName() ? planNode->GetPlanOptimizerName() : "nullptr");
     d->label_OptimizationStatus->setText(errorString);
     qCritical() << Q_FUNC_INFO << ": " << errorString;
     return;
@@ -1538,20 +1557,20 @@ void qSlicerExternalBeamPlanningModuleWidget::optimizePlanClicked()
 
   if (d->checkBox_InversePlanning->isChecked())
   {
-    QString message = QString("Starting optimization...");
+    QString message = tr("Starting optimization...");
     qDebug() << Q_FUNC_INFO << ": " << message;
     errorMessage = d->PlanOptimizerLogic->optimizePlan(planNode);
   }
 
   if (errorMessage.isEmpty())
   {
-    QString message = QString("Optimization calculated successfully in %1 s").arg(time.elapsed() / 1000.0);
+    QString message = tr("Optimization calculated successfully in %1 s").arg(time.elapsed() / 1000.0);
     qDebug() << Q_FUNC_INFO << ": " << message;
     d->label_OptimizationStatus->setText(message);
   }
   else
   {
-    QString message = QString("ERROR: %1").arg(errorMessage);
+    QString message = tr("ERROR: %1").arg(errorMessage);
     qCritical() << Q_FUNC_INFO << ": " << message;
     d->label_OptimizationStatus->setText(message);
   }
@@ -1606,9 +1625,9 @@ void qSlicerExternalBeamPlanningModuleWidget::onProgressUpdated(double progress)
   int progressPercent = (int)(progress * 100.0);
   QString progressMessage;
   if (d->checkBox_InversePlanning->isChecked())
-    progressMessage = QString("Dose influence matrix calculation in progress: %1 %").arg(progressPercent);
+    progressMessage = tr("Dose influence matrix calculation in progress: %1 %").arg(progressPercent);
   else
-    progressMessage = QString("Dose calculation in progress: %1 %").arg(progressPercent);
+    progressMessage = tr("Dose calculation in progress: %1 %").arg(progressPercent);
   d->label_CalculateDoseStatus->setText(progressMessage);
   QApplication::processEvents();
 }
@@ -1628,7 +1647,7 @@ void qSlicerExternalBeamPlanningModuleWidget::onOptimizerProgressInfoUpdated(QSt
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
   QString progressMessage;
-  progressMessage = QString("Optimization in progress: ") + info;
+  progressMessage = tr("Optimization in progress: ") + info;
   d->label_OptimizationStatus->setText(progressMessage);
   QApplication::processEvents();
 }
@@ -1638,7 +1657,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateWEDClicked()
 {
   Q_D(qSlicerExternalBeamPlanningModuleWidget);
 
-  d->label_CalculateDoseStatus->setText("Starting WED calculation...");
+  d->label_CalculateDoseStatus->setText(tr("Starting WED calculation..."));
 
   if (!this->mrmlScene())
   {
@@ -1659,7 +1678,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateWEDClicked()
   vtkMRMLScalarVolumeNode* referenceVolume = planNode->GetReferenceVolumeNode();
   if (!referenceVolume)
   {
-    d->label_CalculateDoseStatus->setText("No reference image");
+    d->label_CalculateDoseStatus->setText(tr("No reference image"));
     return;
   }
 
@@ -1673,7 +1692,7 @@ void qSlicerExternalBeamPlanningModuleWidget::calculateWEDClicked()
   // Do the actual computation in the logic object
   d->logic()->ComputeWED();
 
-  d->label_CalculateDoseStatus->setText("WED calculation done.");
+  d->label_CalculateDoseStatus->setText(tr("WED calculation done."));
   QApplication::restoreOverrideCursor();
 #endif
 }
@@ -1786,15 +1805,21 @@ void qSlicerExternalBeamPlanningModuleWidget::ipoptAcceptableIterChanged(int val
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerExternalBeamPlanningModuleWidget::ipoptMuStrategyChanged(const QString& value)
+void qSlicerExternalBeamPlanningModuleWidget::ipoptMuStrategyChanged(int index)
 {
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  Q_UNUSED(index);
+  QString value = d->comboBox_Ipopt_mu_strategy->currentData().toString();
   if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
     opt->setOption("mu_strategy", value);
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerExternalBeamPlanningModuleWidget::ipoptHessianApproximationChanged(const QString& value)
+void qSlicerExternalBeamPlanningModuleWidget::ipoptHessianApproximationChanged(int index)
 {
+  Q_D(qSlicerExternalBeamPlanningModuleWidget);
+  Q_UNUSED(index);
+  QString value = d->comboBox_Ipopt_hessian_approximation->currentData().toString();
   if (qSlicerIpoptOptimizer* opt = getIpoptOptimizer())
     opt->setOption("hessian_approximation", value);
 }

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.h
@@ -127,8 +127,8 @@ protected slots:
   void ipoptTolChanged();
   void ipoptAcceptableTolChanged();
   void ipoptAcceptableIterChanged(int value);
-  void ipoptMuStrategyChanged(const QString& value);
-  void ipoptHessianApproximationChanged(const QString& value);
+  void ipoptMuStrategyChanged(int index);
+  void ipoptHessianApproximationChanged(int index);
   void ipoptLbfgsHistoryChanged(int value);
   void ipoptPrintLevelChanged(int value);
   void ipoptLinearSolverChanged(const QString& value);

--- a/Isodose/Logic/vtkSlicerIsodoseModuleLogic.cxx
+++ b/Isodose/Logic/vtkSlicerIsodoseModuleLogic.cxx
@@ -36,6 +36,7 @@
 
 // MRML includes
 #include <vtkMRMLColorTableNode.h>
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLColorLegendDisplayNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLModelNode.h>
@@ -977,14 +978,14 @@ void vtkSlicerIsodoseModuleLogic::SetColorLegendDefaults(vtkMRMLIsodoseNode* par
   // Check that range is valid for dose and relative dose
   // Set dose unit name
   std::string doseUnits = "Gy";
-  std::string title = "Isolevels, ";
+  std::string title = vtkMRMLTr("vtkSlicerIsodoseModuleLogic", "Isolevels, ");
   switch (parameterNode->GetDoseUnits())
   {
   case vtkMRMLIsodoseNode::Gy:
     break;
   case vtkMRMLIsodoseNode::Relative:
     doseUnits = "%";
-    title = "Relative isolevels, ";
+    title = vtkMRMLTr("vtkSlicerIsodoseModuleLogic", "Relative isolevels, ");
     break;
   case vtkMRMLIsodoseNode::Unknown:
   default:
@@ -996,7 +997,7 @@ void vtkSlicerIsodoseModuleLogic::SetColorLegendDefaults(vtkMRMLIsodoseNode* par
   if (parameterNode->GetRelativeRepresentationFlag())
   {
     doseUnits = "%";
-    title = "Relative isolevels, ";
+    title = vtkMRMLTr("vtkSlicerIsodoseModuleLogic", "Relative isolevels, ");
   }
   title += doseUnits;
 

--- a/Isodose/SubjectHierarchyPlugins/qSlicerSubjectHierarchyIsodosePlugin.cxx
+++ b/Isodose/SubjectHierarchyPlugins/qSlicerSubjectHierarchyIsodosePlugin.cxx
@@ -125,7 +125,7 @@ double qSlicerSubjectHierarchyIsodosePlugin::canOwnSubjectHierarchyItem(vtkIdTyp
 //---------------------------------------------------------------------------
 const QString qSlicerSubjectHierarchyIsodosePlugin::roleForPlugin()const
 {
-  return "Isodose surface";
+  return /*no tr*/ "Isodose surface";
 }
 
 //---------------------------------------------------------------------------

--- a/Isodose/qSlicerIsodoseModule.cxx
+++ b/Isodose/qSlicerIsodoseModule.cxx
@@ -20,7 +20,6 @@
 ==============================================================================*/
 
 // SlicerQt includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // SubjectHierarchy Plugins includes
@@ -73,7 +72,7 @@ qSlicerIsodoseModule::qSlicerIsodoseModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 QStringList qSlicerIsodoseModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------
@@ -82,15 +81,15 @@ qSlicerIsodoseModule::~qSlicerIsodoseModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerIsodoseModule::helpText()const
 {
-  return QString("This module generates iso dose surface models using user defined dose levels. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Isodose\">%1/Documentation/%2.%3/Modules/Isodose</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module generates iso dose surface models using user defined dose levels. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/Isodose.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerIsodoseModule::acknowledgementText()const
 {
-  return "This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.";
+  return tr("This work was funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO), and CANARIE.");
 }
 
 //-----------------------------------------------------------------------------

--- a/Isodose/qSlicerIsodoseModuleWidget.cxx
+++ b/Isodose/qSlicerIsodoseModuleWidget.cxx
@@ -620,9 +620,7 @@ void qSlicerIsodoseModuleWidget::setReferenceDoseValue(double value)
 //-----------------------------------------------------------------------------
 QString qSlicerIsodoseModuleWidget::generateNewIsodoseLevel() const
 {
-  QString newIsodoseLevelBase("New level");
-  QString newIsodoseLevel(newIsodoseLevelBase);
-  return newIsodoseLevel;
+  return tr("New level");
 }
 
 //------------------------------------------------------------------------------
@@ -798,7 +796,7 @@ void qSlicerIsodoseModuleWidget::updateScalarBarsFromSelectedColorTable()
   bool relativeRepresentation = d->IsodoseNode->GetRelativeRepresentationFlag();
 
   // Get dose unit name and assemble scalar bar title
-  std::string scalarBarTitle("Isolevels");
+  std::string scalarBarTitle(tr("Isolevels").toStdString());
   switch (doseUnits)
   {
   case vtkMRMLIsodoseNode::Gy:

--- a/PinnacleDvfReader/qSlicerPinnacleDvfReaderModule.cxx
+++ b/PinnacleDvfReader/qSlicerPinnacleDvfReaderModule.cxx
@@ -67,7 +67,7 @@ qSlicerPinnacleDvfReaderModule::~qSlicerPinnacleDvfReaderModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerPinnacleDvfReaderModule::helpText()const
 {
-  QString help = QString(
+  QString help = tr(
     "The PinnacleDvfReader module enables importing and loading .DVF files into Slicer.<br>"
     "The PinnacleDvfReader module is hidden and therefore does not require an application.<br>");
   return help;
@@ -76,7 +76,7 @@ QString qSlicerPinnacleDvfReaderModule::helpText()const
 //-----------------------------------------------------------------------------
 QString qSlicerPinnacleDvfReaderModule::acknowledgementText()const
 {
-  QString acknowledgement = QString(
+  QString acknowledgement = tr(
     "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
   return acknowledgement;
 }
@@ -108,7 +108,7 @@ void qSlicerPinnacleDvfReaderModule::setup()
     qSlicerCoreApplication::application()->coreIOManager();
   ioManager->registerIO(new qSlicerPinnacleDvfReaderPlugin(PinnacleDvfReaderLogic,this));
   ioManager->registerIO(new qSlicerNodeWriter(
-    "Dvf", QString("Pinnacle DVF"),
+    "Dvf", QString("PinnacleDVF") /*no tr*/,
     QStringList() << "vtkMRMLGridTransformNode", true, this));
 }
 

--- a/PinnacleDvfReader/qSlicerPinnacleDvfReaderPlugin.cxx
+++ b/PinnacleDvfReader/qSlicerPinnacleDvfReaderPlugin.cxx
@@ -72,7 +72,7 @@ vtkSlicerPinnacleDvfReaderLogic* qSlicerPinnacleDvfReaderPlugin::logic()const
 //-----------------------------------------------------------------------------
 QString qSlicerPinnacleDvfReaderPlugin::description()const
 {
-  return "Dvf";
+  return tr("Dvf");
 }
 
 //-----------------------------------------------------------------------------
@@ -84,7 +84,7 @@ qSlicerIO::IOFileType qSlicerPinnacleDvfReaderPlugin::fileType()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerPinnacleDvfReaderPlugin::extensions()const
 {
-  return QStringList() << "Dvf (*.dvf)";
+  return QStringList() << tr("Dvf (*.dvf)");
 }
 
 //-----------------------------------------------------------------------------

--- a/PlanarImage/Logic/vtkSlicerPlanarImageModuleLogic.cxx
+++ b/PlanarImage/Logic/vtkSlicerPlanarImageModuleLogic.cxx
@@ -26,6 +26,7 @@
 #include "vtkSlicerRtCommon.h"
 
 // MRML includes
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLModelDisplayNode.h>
 #include <vtkMRMLScene.h>
@@ -356,7 +357,7 @@ void vtkSlicerPlanarImageModuleLogic::CreateModelForPlanarImage(vtkMRMLPlanarIma
     vtkErrorMacro("CreateModelForPlanarImage: Missing displayed model reference in parameter set node for planar image '" << planarImageVolume->GetName() << "'!");
     return;
   }
-  displayedModelNode->SetDescription("Model displaying a planar image");
+  displayedModelNode->SetDescription(vtkMRMLTr("vtkSlicerPlanarImageModuleLogic", "Model displaying a planar image").c_str());
 
   // Create display node for the model
   vtkMRMLModelDisplayNode* displayedModelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayedModelNode->GetDisplayNode());

--- a/PlanarImage/qSlicerPlanarImageModule.cxx
+++ b/PlanarImage/qSlicerPlanarImageModule.cxx
@@ -19,7 +19,6 @@
 ==============================================================================*/
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // PlanarImage Logic includes
@@ -62,7 +61,7 @@ qSlicerPlanarImageModule::qSlicerPlanarImageModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 QStringList qSlicerPlanarImageModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------
@@ -71,15 +70,13 @@ qSlicerPlanarImageModule::~qSlicerPlanarImageModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerPlanarImageModule::helpText()const
 {
-  return QString("This module displays and handles planar images (single-slice volumes) as textured models. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/PlanarImage\">%1/Documentation/%2.%3/Modules/PlanarImage</a><br>").arg(
-    qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module displays and handles planar images (single-slice volumes) as textured models.");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerPlanarImageModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------

--- a/PlastimatchPy/qSlicerPlastimatchPyModule.cxx
+++ b/PlastimatchPy/qSlicerPlastimatchPyModule.cxx
@@ -61,13 +61,13 @@ qSlicerPlastimatchPyModule::~qSlicerPlastimatchPyModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerPlastimatchPyModule::helpText()const
 {
-  return "This module facilitates python access of numerous Plastimatch functions.";
+  return tr("This module facilitates python access of numerous Plastimatch functions.");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerPlastimatchPyModule::acknowledgementText()const
 {
-  return "This work was was partially funded by NIH grant 3P41RR013218-12S1";
+  return tr("This work was was partially funded by NIH grant 3P41RR013218-12S1");
 }
 
 //-----------------------------------------------------------------------------
@@ -82,7 +82,7 @@ QStringList qSlicerPlastimatchPyModule::contributors()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerPlastimatchPyModule::categories() const
 {
-  return QStringList() << "Plastimatch.Utilities";
+  return QStringList() << tr("Plastimatch.Utilities");
 }
 
 //-----------------------------------------------------------------------------

--- a/PlmMismatchError/PlmMismatchError.py
+++ b/PlmMismatchError/PlmMismatchError.py
@@ -3,6 +3,8 @@ import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 
+from slicer.i18n import tr as _
+
 #
 # PlmMismatchError
 #
@@ -10,16 +12,16 @@ from slicer.ScriptedLoadableModule import *
 class PlmMismatchError(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "Landmark Mismatch Error"
-    self.parent.categories = ["Plastimatch.DIR Validation"]
+    self.parent.title = _("Landmark Mismatch Error")
+    self.parent.categories = [_("Plastimatch.DIR Validation")]
     self.parent.dependencies = []
     self.parent.contributors = ["Gregory Sharp (MGH)"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
     This is an example of scripted loadable module bundled in an extension.
-    """
-    self.parent.acknowledgementText = """
+    """)
+    self.parent.acknowledgementText = _("""
     This file was originally developed by Greg Sharp, Massachusetts General Hospital, and was partially funded by NIH grant 2-U54-EB005149.
-    """ # replace with organization, grant and thanks.
+    """) # replace with organization, grant and thanks.
 
 class PlmMismatchErrorWidgetLogicIO: 
   def __init__(self):
@@ -61,7 +63,7 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
 
     ### Parameters Area
     inputCollapsibleButton = ctk.ctkCollapsibleButton()
-    inputCollapsibleButton.text = "Input"
+    inputCollapsibleButton.text = _("Input")
     self.layout.addWidget(inputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -77,8 +79,8 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
     self.fixedLandmarks.showHidden = False
     self.fixedLandmarks.renameEnabled = True
     self.fixedLandmarks.setMRMLScene( slicer.mrmlScene )
-    self.fixedLandmarks.setToolTip( "Landmarks on fixed image." )
-    inputFormLayout.addRow("Fixed landmarks: ", self.fixedLandmarks)
+    self.fixedLandmarks.setToolTip( _("Landmarks on fixed image.") )
+    inputFormLayout.addRow(_("Fixed landmarks: "), self.fixedLandmarks)
 
     # fixed landmarks (directory input)
     self.fixedLandmarksDirectory = ctk.ctkDirectoryButton()
@@ -95,8 +97,8 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
     self.movingLandmarks.showHidden = False
     self.movingLandmarks.showChildNodeTypes = False
     self.movingLandmarks.setMRMLScene( slicer.mrmlScene )
-    self.movingLandmarks.setToolTip( "Landmarks on moving image." )
-    inputFormLayout.addRow("Moving landmarks: ", self.movingLandmarks)
+    self.movingLandmarks.setToolTip( _("Landmarks on moving image.") )
+    inputFormLayout.addRow(_("Moving landmarks: "), self.movingLandmarks)
 
     self.view = qt.QTableView()
     self.view.sortingEnabled = True
@@ -108,14 +110,14 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
     inputFormLayout.addRow("", self.movingLandmarksDirectory) 
 
     # Apply Button
-    self.applyButton = qt.QPushButton("Apply")
-    self.applyButton.toolTip = "Run the algorithm."
+    self.applyButton = qt.QPushButton(_("Apply"))
+    self.applyButton.toolTip = _("Run the algorithm.")
     self.applyButton.enabled = True
     self.layout.addWidget(self.applyButton)
 
     ### Output Area
     outputCollapsibleButton = ctk.ctkCollapsibleButton()
-    outputCollapsibleButton.text = "Output statistics"
+    outputCollapsibleButton.text = _("Output statistics")
     self.layout.addWidget(outputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -125,23 +127,23 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
     buttonLayout = qt.QHBoxLayout()
     self.averageError = qt.QLineEdit()
     self.averageErrorValue = 1
-    self.averageError.setToolTip( "Average landmark separation" )
+    self.averageError.setToolTip( _("Average landmark separation") )
     buttonLayout.addWidget(self.averageError)
-    outputFormLayout.addRow("Average error:", buttonLayout)
-     
+    outputFormLayout.addRow(_("Average error:"), buttonLayout)
+
     buttonLayout = qt.QHBoxLayout()
     self.Variance = qt.QLineEdit()
     self.VarianceValue = 1
-    self.Variance.setToolTip( "Variance" )
+    self.Variance.setToolTip( _("Variance") )
     buttonLayout.addWidget(self.Variance)
-    outputFormLayout.addRow("Variance:", buttonLayout)
+    outputFormLayout.addRow(_("Variance:"), buttonLayout)
 
     buttonLayout = qt.QHBoxLayout()
     self.stDev = qt.QLineEdit()
     self.stDevValue = 1
-    self.stDev.setToolTip( "Standard deviation" )
+    self.stDev.setToolTip( _("Standard deviation") )
     buttonLayout.addWidget(self.stDev)
-    outputFormLayout.addRow("Standard deviation:", buttonLayout)
+    outputFormLayout.addRow(_("Standard deviation:"), buttonLayout)
 
     # model and view for stats table
     self.view = qt.QTableView()
@@ -198,8 +200,8 @@ class PlmMismatchErrorWidget(ScriptedLoadableModuleWidget):
       row += 1
     #done!
     #self.view.setColumnWidth(0,30)
-    self.model.setHeaderData(0,1,"Landmark")
-    self.model.setHeaderData(1,1,"dist, mm")
+    self.model.setHeaderData(0,1,_("Landmark"))
+    self.model.setHeaderData(1,1,_("dist, mm"))
 
   def populateDistances(self):
     if not self.logic:

--- a/PlmProtonDoseEngine/DoseEngines/qSlicerPlmProtonDoseEngine.cxx
+++ b/PlmProtonDoseEngine/DoseEngines/qSlicerPlmProtonDoseEngine.cxx
@@ -75,16 +75,16 @@ void qSlicerPlmProtonDoseEngine::defineBeamParameters()
   // Energy tab
 
   this->addBeamParameterSpinBox(
-    "Energy", "ProximalMargin", "Proximal margin (mm):", "",
+    tr("Energy"), "ProximalMargin", tr("Proximal margin (mm):"), "",
     0.0, 50.0, 5.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Energy", "DistalMargin", "Distal margin (mm):", "",
+    tr("Energy"), "DistalMargin", tr("Distal margin (mm):"), "",
     0.0, 50.0, 5.0, 1.0, 2 );
 
   QStringList beamLineTypeOptions;
-  beamLineTypeOptions << "Active scanning" << "Passive scattering";
+  beamLineTypeOptions << tr("Active scanning") << tr("Passive scattering");
   this->addBeamParameterComboBox(
-    "Energy", "BeamLineTypeActive", "Beam line type:", "",
+    tr("Energy"), "BeamLineTypeActive", tr("Beam line type:"), "",
     beamLineTypeOptions, 0 );
 
   //TODO: Attribute name not consistent with label (ManualEnergyLimits vs Energy prescription)
@@ -92,51 +92,51 @@ void qSlicerPlmProtonDoseEngine::defineBeamParameters()
   QStringList dependentParameters;
   dependentParameters << "MinimumEnergy" << "MaximumEnergy";
   this->addBeamParameterCheckBox(
-    "Energy", "ManualEnergyLimits", "Energy prescription:", "", false, dependentParameters);
+    tr("Energy"), "ManualEnergyLimits", tr("Energy prescription:"), "", false, dependentParameters);
 
   this->addBeamParameterSpinBox(
-    "Energy", "MinimumEnergy", "Minimum energy (MeV):", "",
+    tr("Energy"), "MinimumEnergy", tr("Minimum energy (MeV):"), "",
     0.0, 99.99, 0.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Energy", "MaximumEnergy", "Maximum energy (MeV):", "",
+    tr("Energy"), "MaximumEnergy", tr("Maximum energy (MeV):"), "",
     0.0, 99.99, 0.0, 1.0, 2 );
 
   // Beam model tab
 
   //TODO: Attribute name not consistent with label (ApertureOffset vs Aperture distance)
   this->addBeamParameterSpinBox(
-    "Beam model", "ApertureOffset", "Aperture distance (mm):", "",
+    tr("Beam model"), "ApertureOffset", tr("Aperture distance (mm):"), "",
     1.0, 10000.0, 1500.0, 100.0, 2 );
 
   QStringList algorithmOptions;
-  algorithmOptions << "Ray tracer" << "Pencil beam";
+  algorithmOptions << tr("Ray tracer") << tr("Pencil beam");
   this->addBeamParameterComboBox(
-    "Beam model", "Algorithm", "Dose calculation algorithm:", "",
+    tr("Beam model"), "Algorithm", tr("Dose calculation algorithm:"), "",
     algorithmOptions, 0 );
 
   this->addBeamParameterSpinBox(
-    "Beam model", "PencilBeamResolution", "Pencil beam spacing at isocenter (mm):", "",
+    tr("Beam model"), "PencilBeamResolution", tr("Pencil beam spacing at isocenter (mm):"), "",
     0.1, 99.99, 2.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Beam model", "RangeCompensatorSmearingRadius", "Smearing radius (mm):", "",
+    tr("Beam model"), "RangeCompensatorSmearingRadius", tr("Smearing radius (mm):"), "",
     0.0, 99.99, 5.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Beam model", "SourceSize", "Source size (mm):", "",
+    tr("Beam model"), "SourceSize", tr("Source size (mm):"), "",
     0.0, 50.0, 0.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Beam model", "EnergyResolution", "Energy resolution (MeV):", "",
+    tr("Beam model"), "EnergyResolution", tr("Energy resolution (MeV):"), "",
     1.0, 5.0, 5.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Beam model", "EnergySpread", "Energy spread (MeV):", "",
+    tr("Beam model"), "EnergySpread", tr("Energy spread (MeV):"), "",
     0.0, 99.99, 1.0, 1.0, 2 );
   this->addBeamParameterSpinBox(
-    "Beam model", "StepLength", "Step length:", "",
+    tr("Beam model"), "StepLength", tr("Step length:"), "",
     0.0, 99.99, 2.0, 1.0, 2 );
 
   this->addBeamParameterCheckBox(
-    "Beam model", "KanematsuGottschalk", "Kanematsu-Gottschalk patient scattering:", "", false);
+    tr("Beam model"), "KanematsuGottschalk", tr("Kanematsu-Gottschalk patient scattering:"), "", false);
   this->addBeamParameterCheckBox(
-    "Beam model", "RangeCompensatorHighland", "Highland model for range compensator:", "", false);
+    tr("Beam model"), "RangeCompensatorHighland", tr("Highland model for range compensator:"), "", false);
 }
 
 //---------------------------------------------------------------------------
@@ -145,20 +145,20 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
   vtkMRMLRTPlanNode* parentPlanNode = beamNode->GetParentPlanNode();
   if (!parentPlanNode)
   {
-    QString errorMessage = QString("Unable to access parent node for beam %1").arg(beamNode->GetName());
+    QString errorMessage = tr("Unable to access parent node for beam %1").arg(beamNode->GetName());
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   vtkMRMLScalarVolumeNode* referenceVolumeNode = parentPlanNode->GetReferenceVolumeNode();
   if (!referenceVolumeNode)
   {
-    QString errorMessage("Unable to access reference volume");
+    QString errorMessage(tr("Unable to access reference volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   if (!resultDoseVolumeNode)
   {
-    QString errorMessage("Invalid result dose volume");
+    QString errorMessage(tr("Invalid result dose volume"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -169,14 +169,14 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
   vtkSmartPointer<vtkOrientedImageData> targetLabelmap = parentPlanNode->GetTargetOrientedImageData();
   if (targetLabelmap.GetPointer() == nullptr)
   {
-    QString errorMessage("Failed to access target labelmap");
+    QString errorMessage(tr("Failed to access target labelmap"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
   Plm_image::Pointer targetPlmVolume = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(targetLabelmap);
   if (!targetPlmVolume)
   {
-    QString errorMessage("Failed to convert segment labelmap");
+    QString errorMessage(tr("Failed to convert segment labelmap"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -197,7 +197,7 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
   double isocenter[3] = {0.0, 0.0, 0.0};
   if (!beamNode->GetPlanIsocenterPosition(isocenter))
   {
-    QString errorMessage("Failed to get isocenter position");
+    QString errorMessage(tr("Failed to get isocenter position"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage;
     return errorMessage;
   }
@@ -330,7 +330,7 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
     double apertureOffset = this->doubleParameter(beamNode, "ApertureOffset");
     if (beamNode->GetSAD() < 0 || beamNode->GetSAD() < apertureOffset)
     {
-      QString errorMessage = QString("SAD (=%1) must be positive and greater than aperture offset (%2)").arg(beamNode->GetSAD()).arg(apertureOffset);
+      QString errorMessage = tr("SAD (=%1) must be positive and greater than aperture offset (%2)").arg(beamNode->GetSAD()).arg(apertureOffset);
       qCritical() << Q_FUNC_INFO << ": " << errorMessage;
       return errorMessage;
     }
@@ -423,7 +423,7 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
   }
   catch (std::exception& ex)
   {
-    QString errorMessage("Plastimatch exception happened! See log for details");
+    QString errorMessage(tr("Plastimatch exception happened! See log for details"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage << ": " << ex.what();
     return errorMessage;
   }
@@ -435,7 +435,7 @@ QString qSlicerPlmProtonDoseEngine::calculateDoseUsingEngine(vtkMRMLRTBeamNode* 
   }
   catch (std::exception& ex)
   {
-    QString errorMessage("Plastimatch exception happened! See log for details");
+    QString errorMessage(tr("Plastimatch exception happened! See log for details"));
     qCritical() << Q_FUNC_INFO << ": " << errorMessage << ": " << ex.what();
     return errorMessage;
   }

--- a/PlmProtonDoseEngine/qSlicerPlmProtonDoseEngineModule.cxx
+++ b/PlmProtonDoseEngine/qSlicerPlmProtonDoseEngineModule.cxx
@@ -51,13 +51,13 @@ qSlicerPlmProtonDoseEngineModule::~qSlicerPlmProtonDoseEngineModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerPlmProtonDoseEngineModule::helpText() const
 {
-  return "This is a hidden module providing the Plastimatch proton dose engine";
+  return tr("This is a hidden module providing the Plastimatch proton dose engine");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerPlmProtonDoseEngineModule::acknowledgementText() const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------
@@ -74,7 +74,7 @@ QStringList qSlicerPlmProtonDoseEngineModule::contributors() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerPlmProtonDoseEngineModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/PlmRegister/PlmRegister.py
+++ b/PlmRegister/PlmRegister.py
@@ -4,6 +4,8 @@ from slicer.ScriptedLoadableModule import *
 import RegistrationLib
 import logging
 
+from slicer.i18n import tr as _
+
 #########################################################
 #
 #
@@ -27,16 +29,16 @@ comment = """
 class PlmRegister(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "Plastimatch"
-    self.parent.categories = ["Plastimatch"]
+    self.parent.title = _("Plastimatch")
+    self.parent.categories = [_("Plastimatch")]
     self.parent.dependencies = []
     self.parent.contributors = ["Gregory Sharp (MGH)"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
     This is an example of scripted loadable module bundled in an extension.
-    """
-    self.parent.acknowledgementText = """
+    """)
+    self.parent.acknowledgementText = _("""
     This file was originally developed by Greg Sharp, Nadya Shusharina, and Paolo Zaffino and was partially funded by NIH grant 2-U54-EB005149.
-    """ # replace with organization, grant and thanks.
+    """) # replace with organization, grant and thanks.
     self.hidden = True
 
 
@@ -61,8 +63,8 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
   # generic settings that can (should) be overridden by the subclass
 
   # displayed for the user to select the registration
-  name = "Plastimatch"
-  tooltip = "B-spline deformable registration with landmark and regularization"
+  name = _("Plastimatch")
+  tooltip = _("B-spline deformable registration with landmark and regularization")
 
   stages = ["","","","",""] # transaltion gridsearch, translation, bspline1, bspline2, bspline3
 
@@ -104,7 +106,7 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
 
     # Main collapsible bar
     self.collapsibleButton = ctk.ctkCollapsibleButton()
-    self.collapsibleButton.text = "Plastimatch Registration"
+    self.collapsibleButton.text = _("Plastimatch Registration")
     plmRegisterFormLayout = qt.QFormLayout()
     self.collapsibleButton.setLayout(plmRegisterFormLayout)
     self.widgets.append(self.collapsibleButton)
@@ -116,20 +118,21 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
     for cost in self.costFunctions:
       self.costFunctionButtons[cost] = qt.QRadioButton()
       self.costFunctionButtons[cost].text = cost
-      self.costFunctionButtons[cost].setToolTip("Register using %s cost function." % cost)
+      self.costFunctionButtons[cost].setToolTip(_("Register using %s cost function.") % cost)
       buttonLayout.addWidget(self.costFunctionButtons[cost])
     self.costFunctionButtons[self.costFunction].checked = True
-    plmRegisterFormLayout.addRow("Cost function:", buttonLayout)
+    plmRegisterFormLayout.addRow(_("Cost function:"), buttonLayout)
 
     # Pre-alignment
     buttonLayout = qt.QHBoxLayout()
     self.prealignmentComboBox = qt.QComboBox()
+    # no tr (currentText is compared against these literal values in runOneIteration)
     self.prealignmentComboBox.insertItem (1, "None")
     self.prealignmentComboBox.insertItem (2, "Local")
     self.prealignmentComboBox.insertItem (3, "Global")
-    self.prealignmentComboBox.setToolTip("Pre-alignment method\nEither none, global, or local")
+    self.prealignmentComboBox.setToolTip(_("Pre-alignment method\nEither none, global, or local"))
     buttonLayout.addWidget(self.prealignmentComboBox)
-    plmRegisterFormLayout.addRow("Pre-alignment:", buttonLayout)
+    plmRegisterFormLayout.addRow(_("Pre-alignment:"), buttonLayout)
 
     # Number of stages
     buttonLayout = qt.QHBoxLayout()
@@ -137,9 +140,9 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
     self.numstagesComboBox.insertItem (1, "1")
     self.numstagesComboBox.insertItem (2, "2")
     self.numstagesComboBox.insertItem (3, "3")
-    self.numstagesComboBox.setToolTip("Choose number of stages\nUse more stages for slower, more precise registration.")
+    self.numstagesComboBox.setToolTip(_("Choose number of stages\nUse more stages for slower, more precise registration."))
     buttonLayout.addWidget(self.numstagesComboBox)
-    plmRegisterFormLayout.addRow("B-Spline stages:", buttonLayout)
+    plmRegisterFormLayout.addRow(_("B-Spline stages:"), buttonLayout)
 
     # Output transform
     self.outputTransformComboBox = slicer.qMRMLNodeComboBox()
@@ -151,17 +154,17 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
     self.outputTransformComboBox.showHidden = False
     self.outputTransformComboBox.showChildNodeTypes = False
     self.outputTransformComboBox.setMRMLScene( slicer.mrmlScene )
-    plmRegisterFormLayout.addRow("Output transform:",
+    plmRegisterFormLayout.addRow(_("Output transform:"),
                                  self.outputTransformComboBox)
 
     # Apply button
-    self.applyButton = qt.QPushButton("Click to start registration!")
+    self.applyButton = qt.QPushButton(_("Click to start registration!"))
     self.applyButton.setStyleSheet("background-color: #FFFF99")
     self.applyButton.connect('clicked(bool)', self.onApply)
     plmRegisterFormLayout.addWidget(self.applyButton)
 
     # Stop button
-    self.stopButton = qt.QPushButton("Click to stop registration!")
+    self.stopButton = qt.QPushButton(_("Click to stop registration!"))
     self.stopButton.setStyleSheet("background-color: #FF3232")
     self.stopButton.connect('clicked(bool)', self.onStop)
     plmRegisterFormLayout.addWidget(self.stopButton)
@@ -171,155 +174,155 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
     plmRegisterFormLayout.addWidget(self.statusLabel)
 
     # Stage 1
-    self.stage1Box = qt.QGroupBox("Stage 1")
+    self.stage1Box = qt.QGroupBox(_("Stage 1"))
     self.stage1Box.setLayout(qt.QFormLayout())
 
     # Iterations
     buttonLayout = qt.QHBoxLayout()
     self.stage1_iterationsLineEdit = qt.QLineEdit()
     self.stage1_iterationsLineEdit.setText('40')
-    self.stage1_iterationsLineEdit.setToolTip( "Maximum number of iterations" )
+    self.stage1_iterationsLineEdit.setToolTip( _("Maximum number of iterations") )
     self.stage1_iterationsLineEdit.connect('textChanged(QString)', self.parameterStage1IsChanged)
     buttonLayout.addWidget(self.stage1_iterationsLineEdit)
-    self.stage1Box.layout().addRow("Iterations:", buttonLayout)
+    self.stage1Box.layout().addRow(_("Iterations:"), buttonLayout)
 
     # Subsampling rate
     buttonLayout = qt.QHBoxLayout()
     self.stage1_subsamplingLineEdit = qt.QLineEdit()
     self.stage1_subsamplingLineEdit.setText('4 4 2')
-    self.stage1_subsamplingLineEdit.setToolTip( "Subsampling rate" )
+    self.stage1_subsamplingLineEdit.setToolTip( _("Subsampling rate") )
     self.stage1_subsamplingLineEdit.connect('textChanged(QString)', self.parameterStage1IsChanged)
     buttonLayout.addWidget(self.stage1_subsamplingLineEdit)
-    self.stage1Box.layout().addRow("Subsampling rate (vox):", buttonLayout)
+    self.stage1Box.layout().addRow(_("Subsampling rate (vox):"), buttonLayout)
 
     # Grid spacing
     buttonLayout = qt.QHBoxLayout()
     self.stage1_gridSpacingLineEdit = qt.QLineEdit()
     self.stage1_gridSpacingLineEdit.setText('100')
-    self.stage1_gridSpacingLineEdit.setToolTip( "Set B-spline grid spacing" )
+    self.stage1_gridSpacingLineEdit.setToolTip( _("Set B-spline grid spacing") )
     self.stage1_gridSpacingLineEdit.connect('textChanged(QString)', self.parameterStage1IsChanged)
     buttonLayout.addWidget(self.stage1_gridSpacingLineEdit)
-    self.stage1Box.layout().addRow("Grid size (mm):", buttonLayout)
+    self.stage1Box.layout().addRow(_("Grid size (mm):"), buttonLayout)
 
     # Regularization
     buttonLayout = qt.QHBoxLayout()
     self.stage1_regularizationLineEdit = qt.QLineEdit()
     self.stage1_regularizationLineEdit.setText('0.1')
-    self.stage1_regularizationLineEdit.setToolTip("Set Regularization penalty term")
+    self.stage1_regularizationLineEdit.setToolTip(_("Set Regularization penalty term"))
     self.stage1_regularizationLineEdit.connect('textChanged(QString)', self.parameterStage1IsChanged)
     buttonLayout.addWidget(self.stage1_regularizationLineEdit)
-    self.stage1Box.layout().addRow("Regularization:", buttonLayout)
+    self.stage1Box.layout().addRow(_("Regularization:"), buttonLayout)
 
     # Landmark penalty
     buttonLayout = qt.QHBoxLayout()
     self.stage1_landmarkPenaltyLineEdit = qt.QLineEdit()
     self.stage1_landmarkPenaltyLineEdit.setText('10')
-    self.stage1_landmarkPenaltyLineEdit.setToolTip("Set landmark distance penalty term")
+    self.stage1_landmarkPenaltyLineEdit.setToolTip(_("Set landmark distance penalty term"))
     self.stage1_landmarkPenaltyLineEdit.connect('textChanged(QString)', self.parameterStage1IsChanged)
     buttonLayout.addWidget(self.stage1_landmarkPenaltyLineEdit)
-    self.stage1Box.layout().addRow("Landmark penalty:", buttonLayout)
+    self.stage1Box.layout().addRow(_("Landmark penalty:"), buttonLayout)
 
     plmRegisterFormLayout.addRow(self.stage1Box)
 
     # Stage 2
-    self.stage2Box = qt.QGroupBox("Stage 2")
+    self.stage2Box = qt.QGroupBox(_("Stage 2"))
     self.stage2Box.setLayout(qt.QFormLayout())
 
     # Iterations
     buttonLayout = qt.QHBoxLayout()
     self.stage2_iterationsLineEdit = qt.QLineEdit()
     self.stage2_iterationsLineEdit.setText('20')
-    self.stage2_iterationsLineEdit.setToolTip( "Maximum number of iterations" )
+    self.stage2_iterationsLineEdit.setToolTip( _("Maximum number of iterations") )
     self.stage2_iterationsLineEdit.connect('textChanged(QString)', self.parameterStage2IsChanged)
     buttonLayout.addWidget(self.stage2_iterationsLineEdit)
-    self.stage2Box.layout().addRow("Iterations:", buttonLayout)
+    self.stage2Box.layout().addRow(_("Iterations:"), buttonLayout)
 
     # Subsampling rate
     buttonLayout = qt.QHBoxLayout()
     self.stage2_subsamplingLineEdit = qt.QLineEdit()
     self.stage2_subsamplingLineEdit.setText('2 2 1')
-    self.stage2_subsamplingLineEdit.setToolTip( "Subsampling rate" )
+    self.stage2_subsamplingLineEdit.setToolTip( _("Subsampling rate") )
     self.stage2_subsamplingLineEdit.connect('textChanged(QString)', self.parameterStage2IsChanged)
     buttonLayout.addWidget(self.stage2_subsamplingLineEdit)
-    self.stage2Box.layout().addRow("Subsampling rate (vox):", buttonLayout)
+    self.stage2Box.layout().addRow(_("Subsampling rate (vox):"), buttonLayout)
 
     # Grid spacing
     buttonLayout = qt.QHBoxLayout()
     self.stage2_gridSpacingLineEdit = qt.QLineEdit()
     self.stage2_gridSpacingLineEdit.setText('50')
-    self.stage2_gridSpacingLineEdit.setToolTip( "Set B-spline grid spacing" )
+    self.stage2_gridSpacingLineEdit.setToolTip( _("Set B-spline grid spacing") )
     self.stage2_gridSpacingLineEdit.connect('textChanged(QString)', self.parameterStage2IsChanged)
     buttonLayout.addWidget(self.stage2_gridSpacingLineEdit)
-    self.stage2Box.layout().addRow("Grid size (mm):", buttonLayout)
+    self.stage2Box.layout().addRow(_("Grid size (mm):"), buttonLayout)
 
     # Regularization
     buttonLayout = qt.QHBoxLayout()
     self.stage2_regularizationLineEdit = qt.QLineEdit()
     self.stage2_regularizationLineEdit.setText('0.1')
-    self.stage2_regularizationLineEdit.setToolTip("Set Regularization penalty term")
+    self.stage2_regularizationLineEdit.setToolTip(_("Set Regularization penalty term"))
     self.stage2_regularizationLineEdit.connect('textChanged(QString)', self.parameterStage2IsChanged)
     buttonLayout.addWidget(self.stage2_regularizationLineEdit)
-    self.stage2Box.layout().addRow("Regularization:", buttonLayout)
+    self.stage2Box.layout().addRow(_("Regularization:"), buttonLayout)
 
     # Landmark penalty
     buttonLayout = qt.QHBoxLayout()
     self.stage2_landmarkPenaltyLineEdit = qt.QLineEdit()
     self.stage2_landmarkPenaltyLineEdit.setText('10')
-    self.stage2_landmarkPenaltyLineEdit.setToolTip("Set landmark distance penalty term")
+    self.stage2_landmarkPenaltyLineEdit.setToolTip(_("Set landmark distance penalty term"))
     self.stage2_landmarkPenaltyLineEdit.connect('textChanged(QString)', self.parameterStage2IsChanged)
     buttonLayout.addWidget(self.stage2_landmarkPenaltyLineEdit)
-    self.stage2Box.layout().addRow("Landmark penalty:", buttonLayout)
+    self.stage2Box.layout().addRow(_("Landmark penalty:"), buttonLayout)
 
     plmRegisterFormLayout.addRow(self.stage2Box)
 
     # Stage 3
-    self.stage3Box = qt.QGroupBox("Stage 3")
+    self.stage3Box = qt.QGroupBox(_("Stage 3"))
     self.stage3Box.setLayout(qt.QFormLayout())
 
     # Iterations
     buttonLayout = qt.QHBoxLayout()
     self.stage3_iterationsLineEdit = qt.QLineEdit()
     self.stage3_iterationsLineEdit.setText('10')
-    self.stage3_iterationsLineEdit.setToolTip( "Maximum number of iterations" )
+    self.stage3_iterationsLineEdit.setToolTip( _("Maximum number of iterations") )
     self.stage3_iterationsLineEdit.connect('textChanged(QString)', self.parameterStage3IsChanged)
     buttonLayout.addWidget(self.stage3_iterationsLineEdit)
-    self.stage3Box.layout().addRow("Iterations:", buttonLayout)
+    self.stage3Box.layout().addRow(_("Iterations:"), buttonLayout)
 
     # Subsampling rate
     buttonLayout = qt.QHBoxLayout()
     self.stage3_subsamplingLineEdit = qt.QLineEdit()
     self.stage3_subsamplingLineEdit.setText('1 1 1')
-    self.stage3_subsamplingLineEdit.setToolTip( "Subsampling rate" )
+    self.stage3_subsamplingLineEdit.setToolTip( _("Subsampling rate") )
     self.stage3_subsamplingLineEdit.connect('textChanged(QString)', self.parameterStage3IsChanged)
     buttonLayout.addWidget(self.stage3_subsamplingLineEdit)
-    self.stage3Box.layout().addRow("Subsampling rate (vox):", buttonLayout)
+    self.stage3Box.layout().addRow(_("Subsampling rate (vox):"), buttonLayout)
 
     # Grid spacing
     buttonLayout = qt.QHBoxLayout()
     self.stage3_gridSpacingLineEdit = qt.QLineEdit()
     self.stage3_gridSpacingLineEdit.setText('30')
-    self.stage3_gridSpacingLineEdit.setToolTip( "Set B-spline grid spacing" )
+    self.stage3_gridSpacingLineEdit.setToolTip( _("Set B-spline grid spacing") )
     self.stage3_gridSpacingLineEdit.connect('textChanged(QString)', self.parameterStage3IsChanged)
     buttonLayout.addWidget(self.stage3_gridSpacingLineEdit)
-    self.stage3Box.layout().addRow("Grid size (mm):", buttonLayout)
+    self.stage3Box.layout().addRow(_("Grid size (mm):"), buttonLayout)
 
     # Regularization
     buttonLayout = qt.QHBoxLayout()
     self.stage3_regularizationLineEdit = qt.QLineEdit()
     self.stage3_regularizationLineEdit.setText('0.1')
-    self.stage3_regularizationLineEdit.setToolTip("Set Regularization penalty term")
+    self.stage3_regularizationLineEdit.setToolTip(_("Set Regularization penalty term"))
     self.stage3_regularizationLineEdit.connect('textChanged(QString)', self.parameterStage3IsChanged)
     buttonLayout.addWidget(self.stage3_regularizationLineEdit)
-    self.stage3Box.layout().addRow("Regularization:", buttonLayout)
+    self.stage3Box.layout().addRow(_("Regularization:"), buttonLayout)
 
     # Landmark penalty
     buttonLayout = qt.QHBoxLayout()
     self.stage3_landmarkPenaltyLineEdit = qt.QLineEdit()
     self.stage3_landmarkPenaltyLineEdit.setText('10')
-    self.stage3_landmarkPenaltyLineEdit.setToolTip("Set landmark distance penalty term")
+    self.stage3_landmarkPenaltyLineEdit.setToolTip(_("Set landmark distance penalty term"))
     self.stage3_landmarkPenaltyLineEdit.connect('textChanged(QString)', self.parameterStage3IsChanged)
     buttonLayout.addWidget(self.stage3_landmarkPenaltyLineEdit)
-    self.stage3Box.layout().addRow("Landmark penalty:", buttonLayout)
+    self.stage3Box.layout().addRow(_("Landmark penalty:"), buttonLayout)
 
     plmRegisterFormLayout.addRow(self.stage3Box)
 
@@ -458,7 +461,7 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
   def InitializeRegistration(self):
     import os, sys, vtk
 
-    self.statusLabel.setText("Working...")
+    self.statusLabel.setText(_("Working..."))
     self.statusLabel.repaint()
     self.statusLabel.repaint()
 
@@ -513,7 +516,7 @@ class PlmRegisterPlugin(RegistrationLib.RegistrationPlugin):
     # later.  But for now, let's wait for it to complete.
     #self.reg.StartRegistration ()
     self.reg.RunRegistration ()
-    self.statusLabel.setText("Done.")
+    self.statusLabel.setText(_("Done."))
 
     #TODO: WHY DOESN'T THIS WORK?
     # Here we want to send the B-Spline transform to Slicer.

--- a/PlmVectorFieldAnalysis/PlmVectorFieldAnalysis.py
+++ b/PlmVectorFieldAnalysis/PlmVectorFieldAnalysis.py
@@ -3,6 +3,8 @@ import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 
+from slicer.i18n import tr as _
+
 #
 # PlmVectorFieldAnalysis
 #
@@ -10,16 +12,16 @@ from slicer.ScriptedLoadableModule import *
 class PlmVectorFieldAnalysis(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "Vector Field Analysis"
-    self.parent.categories = ["Plastimatch.DIR Validation"]
+    self.parent.title = _("Vector Field Analysis")
+    self.parent.categories = [_("Plastimatch.DIR Validation")]
     self.parent.dependencies = []
     self.parent.contributors = ["Gregory Sharp (MGH)"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
     This is an example of scripted loadable module bundled in an extension.
-    """
-    self.parent.acknowledgementText = """
+    """)
+    self.parent.acknowledgementText = _("""
     This file was originally developed by Greg Sharp, Massachusetts General Hospital, and was partially funded by NIH grant 2-U54-EB005149.
-    """ # replace with organization, grant and thanks.
+    """) # replace with organization, grant and thanks.
 
 #
 # Class for bidirectional data transfer between Widget (GUI) and Logic
@@ -56,7 +58,7 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
 
     ### Input Area
     inputCollapsibleButton = ctk.ctkCollapsibleButton()
-    inputCollapsibleButton.text = "Input"
+    inputCollapsibleButton.text = _("Input")
     self.layout.addWidget(inputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -71,8 +73,8 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
     self.vfMRMLSelector.noneEnabled = True
     self.vfMRMLSelector.showHidden = False
     self.vfMRMLSelector.setMRMLScene( slicer.mrmlScene )
-    self.vfMRMLSelector.setToolTip( "Pick the input to the algorithm." )
-    inputFormLayout.addRow("Vector Field image: ", self.vfMRMLSelector)
+    self.vfMRMLSelector.setToolTip( _("Pick the input to the algorithm.") )
+    inputFormLayout.addRow(_("Vector Field image: "), self.vfMRMLSelector)
 
     # variables
     self.minJacobianValue = 1
@@ -81,7 +83,7 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
     # vf image (directory input)
     self.vfInputDirectory = ctk.ctkDirectoryButton()
     self.vfInputDirectory.directory = qt.QDir.homePath()
-    inputFormLayout.addRow("Input Directory:", self.vfInputDirectory)
+    inputFormLayout.addRow(_("Input Directory:"), self.vfInputDirectory)
 
     # Fixed image (for geometry info)
     self.fixedImage = slicer.qMRMLNodeComboBox()
@@ -91,18 +93,18 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
     self.fixedImage.addEnabled = False
     self.fixedImage.renameEnabled = True
     self.fixedImage.noneEnabled = True
-    self.fixedImage.setToolTip( "Output image of Jacobian matrix.vtkSlicerPlastimatchModuleLogicPython" )
-    inputFormLayout.addRow("Fixed image (for geometry info): ", self.fixedImage)
+    self.fixedImage.setToolTip( _("Output image of Jacobian matrix.vtkSlicerPlastimatchModuleLogicPython") )
+    inputFormLayout.addRow(_("Fixed image (for geometry info): "), self.fixedImage)
 
     # Apply Button
-    self.applyButton = qt.QPushButton("Apply")
-    self.applyButton.toolTip = "Run the algorithm."
+    self.applyButton = qt.QPushButton(_("Apply"))
+    self.applyButton.toolTip = _("Run the algorithm.")
     self.applyButton.enabled = True
     self.layout.addWidget(self.applyButton)
     
     ### Output Area
     outputCollapsibleButton = ctk.ctkCollapsibleButton()
-    outputCollapsibleButton.text = "Output"
+    outputCollapsibleButton.text = _("Output")
     self.layout.addWidget(outputCollapsibleButton)
 
     # Layout within the dummy collapsible button
@@ -115,8 +117,8 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
     self.outputJacobian.addEnabled = True
     self.outputJacobian.renameEnabled = True
     #self.outputJacobian.layout().addWidget(self.outputSelector)
-    self.outputJacobian.setToolTip( "Output image of Jacobian matrix.vtkSlicerPlastimatchModuleLogicPython" )
-    outputFormLayout.addRow("Jacobian image: ", self.outputJacobian)
+    self.outputJacobian.setToolTip( _("Output image of Jacobian matrix.vtkSlicerPlastimatchModuleLogicPython") )
+    outputFormLayout.addRow(_("Jacobian image: "), self.outputJacobian)
 
     # output directory selector
 #    self.outputDirectory = ctk.ctkDirectoryButton()
@@ -126,15 +128,15 @@ class PlmVectorFieldAnalysisWidget(ScriptedLoadableModuleWidget):
     # output statistics
     buttonLayout = qt.QHBoxLayout()
     self.minJacobian = qt.QLineEdit()
-    self.minJacobian.setToolTip( "Minimum value of Jacobian matrix" ) 
+    self.minJacobian.setToolTip( _("Minimum value of Jacobian matrix") )
     buttonLayout.addWidget(self.minJacobian)
-    outputFormLayout.addRow("Minimum Jacobian:", buttonLayout)
+    outputFormLayout.addRow(_("Minimum Jacobian:"), buttonLayout)
 
     buttonLayout = qt.QHBoxLayout()
     self.maxJacobian = qt.QLineEdit()
-    self.maxJacobian.setToolTip( "Maximum value of Jacobian matrix" ) 
+    self.maxJacobian.setToolTip( _("Maximum value of Jacobian matrix") )
     buttonLayout.addWidget(self.maxJacobian)
-    outputFormLayout.addRow("Maximum Jacobian:", buttonLayout)    
+    outputFormLayout.addRow(_("Maximum Jacobian:"), buttonLayout)
 
     # connections
     self.applyButton.connect('clicked(bool)', self.onJacobianApply)

--- a/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
+++ b/RoomsEyeView/Logic/vtkSlicerRoomsEyeViewModuleLogic.cxx
@@ -33,6 +33,7 @@
 
 // MRML includes
 #include <vtkMRMLDisplayNode.h>
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLModelNode.h>
@@ -1572,7 +1573,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
   if (!parameterNode)
   {
     vtkErrorMacro("CheckForCollisions: Invalid parameter set node");
-    return "Invalid parameters";
+    return vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Invalid parameters");
   }
   if (!parameterNode->GetCollisionDetectionEnabled())
   {
@@ -1594,7 +1595,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
   if ( !gantryToFixedReferenceTransformNode || !patientSupportToPatientSupportRotationTransformNode
     || !collimatorToGantryTransformNode || !tableTopToTableTopEccentricRotationTransformNode )
   {
-    statusString = "Failed to access IEC transforms";
+    statusString = vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Failed to access IEC transforms");
     vtkErrorMacro("CheckForCollisions: " + statusString);
     return statusString;
   }
@@ -1621,7 +1622,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
     || !vtkMRMLTransformNode::IsGeneralTransformLinear(collimatorToRasGeneralTransform, collimatorToRasTransform)
     || !vtkMRMLTransformNode::IsGeneralTransformLinear(tableTopToRasGeneralTransform, tableTopToRasTransform) )
   {
-    statusString = "Non-linear transform detected";
+    statusString = vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Non-linear transform detected");
     vtkErrorMacro("CheckForCollisions: " + statusString);
     return statusString;
   }
@@ -1641,7 +1642,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
     this->GantryTableTopCollisionDetection->Update();
     if (this->GantryTableTopCollisionDetection->GetNumberOfContacts() > 0)
     {
-      statusString = statusString + "Collision between gantry and table top\n";
+      statusString = statusString + vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Collision between gantry and table top\n");
     }
   }
 
@@ -1652,7 +1653,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
     this->GantryPatientSupportCollisionDetection->Update();
     if (this->GantryPatientSupportCollisionDetection->GetNumberOfContacts() > 0)
     {
-      statusString = statusString + "Collision between gantry and patient support\n";
+      statusString = statusString + vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Collision between gantry and patient support\n");
     }
   }
 
@@ -1663,7 +1664,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
     this->CollimatorTableTopCollisionDetection->Update();
     if (this->CollimatorTableTopCollisionDetection->GetNumberOfContacts() > 0)
     {
-      statusString = statusString + "Collision between collimator and table top\n";
+      statusString = statusString + vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Collision between collimator and table top\n");
     }
   }
 
@@ -1678,7 +1679,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
       this->GantryPatientCollisionDetection->Update();
       if (this->GantryPatientCollisionDetection->GetNumberOfContacts() > 0)
       {
-        statusString = statusString + "Collision between gantry and patient\n";
+        statusString = statusString + vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Collision between gantry and patient\n");
       }
     }
 
@@ -1689,7 +1690,7 @@ std::string vtkSlicerRoomsEyeViewModuleLogic::CheckForCollisions(vtkMRMLRoomsEye
       this->CollimatorPatientCollisionDetection->Update();
       if (this->CollimatorPatientCollisionDetection->GetNumberOfContacts() > 0)
       {
-        statusString = statusString + "Collision between collimator and patient\n";
+        statusString = statusString + vtkMRMLTr("vtkSlicerRoomsEyeViewModuleLogic", "Collision between collimator and patient\n");
       }
     }
   }

--- a/RoomsEyeView/qSlicerRoomsEyeViewModule.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModule.cxx
@@ -26,7 +26,6 @@
 #include <QtPlugin>
 
 // Slicer includes
-#include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
 // RoomsEyeView includes
@@ -67,7 +66,7 @@ qSlicerRoomsEyeViewModule::qSlicerRoomsEyeViewModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 QStringList qSlicerRoomsEyeViewModule::categories()const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------
@@ -82,15 +81,13 @@ QStringList qSlicerRoomsEyeViewModule::dependencies()const
 //-----------------------------------------------------------------------------
 QString qSlicerRoomsEyeViewModule::helpText()const
 {
-  return QString("This module loads and visualizes treatment machines, and calculates collisions between its parts and the patient."
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/RoomsEyeView\">%1/Documentation/%2.%3/Modules/RoomsEyeView</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module loads and visualizes treatment machines, and calculates collisions between its parts and the patient.");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerRoomsEyeViewModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).\n\nThe collision detection module was partly supported by Conselleria de Educación, Investigación, Cultura y Deporte (Generalitat Valenciana), Spain under grant number CDEIGENT/2019/011.";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).\n\nThe collision detection module was partly supported by Conselleria de Educación, Investigación, Cultura y Deporte (Generalitat Valenciana), Spain under grant number CDEIGENT/2019/011.");
 }
 
 //-----------------------------------------------------------------------------

--- a/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
+++ b/RoomsEyeView/qSlicerRoomsEyeViewModuleWidget.cxx
@@ -402,9 +402,9 @@ void qSlicerRoomsEyeViewModuleWidget::setup()
   ioManager->registerDialog(new qSlicerSaveDataDialog(this));
 
   // Add treatment machine options
-  d->TreatmentMachineComboBox->addItem("Varian TrueBeam STx", "VarianTrueBeamSTx");
-  d->TreatmentMachineComboBox->addItem("Siemens Artiste", "SiemensArtiste");
-  d->TreatmentMachineComboBox->addItem("From file...", "FromFile");
+  d->TreatmentMachineComboBox->addItem(tr("Varian TrueBeam STx"), "VarianTrueBeamSTx");
+  d->TreatmentMachineComboBox->addItem(tr("Siemens Artiste"), "SiemensArtiste");
+  d->TreatmentMachineComboBox->addItem(tr("From file..."), "FromFile");
 
   //
   // Make connections
@@ -660,8 +660,8 @@ void qSlicerRoomsEyeViewModuleWidget::onLoadTreatmentMachineButtonClicked()
   if (!treatmentMachineType.compare("FromFile"))
   {
     // Ask user for descriptor JSON file if load from file option is selected
-    descriptorFilePath = QFileDialog::getOpenFileName( this, "Select treatment machine descriptor JSON file...",
-      QString(), "Json files (*.json);; All files (*)" );
+    descriptorFilePath = QFileDialog::getOpenFileName( this, tr("Select treatment machine descriptor JSON file..."),
+      QString(), tr("Json files (*.json);; All files (*)") );
   }
   else //TODO: Currently support two default types in addition to loading file. Need to rethink the module
   {
@@ -756,17 +756,17 @@ void qSlicerRoomsEyeViewModuleWidget::loadTreatmentMachineFromFile(QString descr
   bool collisionDetectionDisabled = false;
   if (d->logic()->GetGantryTableTopCollisionDetection()->GetInputData(0) == nullptr)
   {
-    disabledCollisionDetectionMessage.append("Gantry-TableTop\n");
+    disabledCollisionDetectionMessage.append(tr("Gantry-TableTop\n"));
     collisionDetectionDisabled = true;
   }
   if (d->logic()->GetGantryPatientSupportCollisionDetection()->GetInputData(0) == nullptr)
   {
-    disabledCollisionDetectionMessage.append("Gantry-PatientSupport\n");
+    disabledCollisionDetectionMessage.append(tr("Gantry-PatientSupport\n"));
     collisionDetectionDisabled = true;
   }
   if (d->logic()->GetCollimatorTableTopCollisionDetection()->GetInputData(0) == nullptr)
   {
-    disabledCollisionDetectionMessage.append("Collimator-TableTop\n");
+    disabledCollisionDetectionMessage.append(tr("Collimator-TableTop\n"));
     collisionDetectionDisabled = true;
   }
   disabledCollisionDetectionMessage.append(tr("\nWhat would you like to do?"));
@@ -1246,7 +1246,7 @@ void qSlicerRoomsEyeViewModuleWidget::checkForCollisions()
     return;
   }
 
-  d->CollisionDetectionStatusLabel->setText(QString::fromStdString("Calculating collisions..."));
+  d->CollisionDetectionStatusLabel->setText(tr("Calculating collisions..."));
   d->CollisionDetectionStatusLabel->setStyleSheet("color: black");
   QApplication::processEvents();
 

--- a/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
+++ b/SegmentComparison/Logic/vtkSlicerSegmentComparisonModuleLogic.cxx
@@ -41,6 +41,7 @@
 #endif
 
 // MRML includes
+#include <vtkMRMLI18N.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLTableNode.h>
 #include <vtkMRMLScene.h>
@@ -104,7 +105,7 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
 {
   if (!parameterNode || !this->Logic->GetMRMLScene())
   {
-    std::string errorMessage("Invalid MRML scene or parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Invalid MRML scene or parameter set node");
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -117,13 +118,13 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
 
   if (!referenceSegmentationNode || !referenceSegmentID)
   {
-    std::string errorMessage("Invalid reference segment selection");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Invalid reference segment selection");
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
   if (!compareSegmentationNode || !compareSegmentID)
   {
-    std::string errorMessage("Invalid compare segment selection");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Invalid compare segment selection");
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -133,7 +134,7 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
   vtkSmartPointer<vtkOrientedImageData> referenceSegmentLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
   if (!referenceSegmentationNode->GetBinaryLabelmapRepresentation(referenceSegmentID, referenceSegmentLabelmap))
   {
-    std::string errorMessage("Failed to get binary labelmap from reference segment: " + std::string(referenceSegmentID));
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to get binary labelmap from reference segment: ") + std::string(referenceSegmentID);
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -141,7 +142,7 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
   vtkSmartPointer<vtkOrientedImageData> compareSegmentLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
   if (!compareSegmentationNode->GetBinaryLabelmapRepresentation(compareSegmentID, compareSegmentLabelmap))
   {
-    std::string errorMessage("Failed to get binary labelmap from reference segment: " + std::string(compareSegmentID));
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to get binary labelmap from reference segment: ") + std::string(compareSegmentID);
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -152,13 +153,13 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
   {
     if (!vtkSlicerSegmentationsModuleLogic::ApplyParentTransformToOrientedImageData(referenceSegmentationNode, referenceSegmentLabelmap))
     {
-      std::string errorMessage("Failed to apply parent transformation to compare segment!");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to apply parent transformation to compare segment!");
       vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
       return errorMessage;
     }
     if (!vtkSlicerSegmentationsModuleLogic::ApplyParentTransformToOrientedImageData(compareSegmentationNode, compareSegmentLabelmap))
     {
-      std::string errorMessage("Failed to apply parent transformation to reference segment!");
+      std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to apply parent transformation to reference segment!");
       vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
       return errorMessage;
     }
@@ -171,7 +172,7 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
   plmRefSegmentLabelmap = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(referenceSegmentLabelmap);
   if (!plmRefSegmentLabelmap)
   {
-    std::string errorMessage("Failed to convert reference segment labelmap into Plm_image");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to convert reference segment labelmap into Plm_image");
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -179,7 +180,7 @@ std::string vtkSlicerSegmentComparisonModuleLogicPrivate::GetInputSegmentsAsPlmV
   plmCmpSegmentLabelmap = PlmCommon::ConvertVtkOrientedImageDataToPlmImage(compareSegmentLabelmap);
   if (!plmCmpSegmentLabelmap)
   {
-    std::string errorMessage("Failed to convert compare segment labelmap into Plm_image");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogicPrivate", "Failed to convert compare segment labelmap into Plm_image");
     vtkErrorMacro("GetInputSegmentsAsPlmVolumes: " << errorMessage);
     return errorMessage;
   }
@@ -305,13 +306,13 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeDiceStatistics(vtkMRML
 
   if (!parameterNode || !this->GetMRMLScene())
   {
-    std::string errorMessage("Invalid MRML scene or parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Invalid MRML scene or parameter set node");
     vtkErrorMacro("ComputeDiceStatistics: " << errorMessage);
     return errorMessage;
   }
   if (!parameterNode->GetReferenceSegmentationNode() || !parameterNode->GetCompareSegmentationNode())
   {
-    std::string errorMessage("Invalid input segment selection");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Invalid input segment selection");
     vtkErrorMacro("ComputeDiceStatistics: " << errorMessage);
     return errorMessage;
   }
@@ -327,7 +328,7 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeDiceStatistics(vtkMRML
   std::string inputToPlmResult = this->LogicPrivate->GetInputSegmentsAsPlmVolumes(parameterNode, plmRefSegmentLabelmap, plmCmpSegmentLabelmap, checkpointItkConvertStart);
   if (!inputToPlmResult.empty())
   {
-    std::string errorMessage("Error occurred during ITK conversion");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Error occurred during ITK conversion");
     vtkErrorMacro("ComputeDiceStatistics: " << errorMessage);
     return errorMessage;
   }
@@ -381,25 +382,26 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeDiceStatistics(vtkMRML
     tableNode->SetUseColumnTitleAsColumnHeader(true);
     tableNode->RemoveAllColumns();
     vtkStringArray* header = vtkStringArray::SafeDownCast(tableNode->AddColumn());
-    header->SetName("Metric name");
+    // no tr (these strings are written into the exported file and may be parsed by other tools)
+    header->SetName(/*no tr*/ "Metric name");
     // Add input information to the table so that they appear in the exported file
-    header->InsertNextValue("Reference segmentation");
-    header->InsertNextValue("Reference segment");
-    header->InsertNextValue("Compare segmentation");
-    header->InsertNextValue("Compare segment");
+    header->InsertNextValue(/*no tr*/ "Reference segmentation");
+    header->InsertNextValue(/*no tr*/ "Reference segment");
+    header->InsertNextValue(/*no tr*/ "Compare segmentation");
+    header->InsertNextValue(/*no tr*/ "Compare segment");
     // Dice results
-    header->InsertNextValue("Dice coefficient");
-    header->InsertNextValue("True positives (%)");
-    header->InsertNextValue("True negatives (%)");
-    header->InsertNextValue("False positives (%)");
-    header->InsertNextValue("False negatives (%)");
-    header->InsertNextValue("Reference center");
-    header->InsertNextValue("Compare center");
-    header->InsertNextValue("Reference volume (cc)");
-    header->InsertNextValue("Compare volume (cc)");
+    header->InsertNextValue(/*no tr*/ "Dice coefficient");
+    header->InsertNextValue(/*no tr*/ "True positives (%)");
+    header->InsertNextValue(/*no tr*/ "True negatives (%)");
+    header->InsertNextValue(/*no tr*/ "False positives (%)");
+    header->InsertNextValue(/*no tr*/ "False negatives (%)");
+    header->InsertNextValue(/*no tr*/ "Reference center");
+    header->InsertNextValue(/*no tr*/ "Compare center");
+    header->InsertNextValue(/*no tr*/ "Reference volume (cc)");
+    header->InsertNextValue(/*no tr*/ "Compare volume (cc)");
 
     vtkStringArray* column = vtkStringArray::SafeDownCast(tableNode->AddColumn());
-    column->SetName("Metric value");
+    column->SetName(/*no tr*/ "Metric value");
 
     int row = 0;
     vtkMRMLSegmentationNode* referenceSegmentationNode = parameterNode->GetReferenceSegmentationNode();
@@ -449,13 +451,13 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeHausdorffDistances(vtk
 
   if (!parameterNode || !this->GetMRMLScene())
   {
-    std::string errorMessage("Invalid MRML scene or parameter set node");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Invalid MRML scene or parameter set node");
     vtkErrorMacro("ComputeHausdorffDistances: " << errorMessage);
     return errorMessage;
   }
   if (!parameterNode->GetReferenceSegmentationNode() || !parameterNode->GetCompareSegmentationNode())
   {
-    std::string errorMessage("Invalid input segment selection");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Invalid input segment selection");
     vtkErrorMacro("ComputeHausdorffDistances: " << errorMessage);
     return errorMessage;
   }
@@ -471,7 +473,7 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeHausdorffDistances(vtk
   std::string inputToPlmResult = this->LogicPrivate->GetInputSegmentsAsPlmVolumes(parameterNode, plmRefSegmentLabelmap, plmCmpSegmentLabelmap, checkpointItkConvertStart);
   if (!inputToPlmResult.empty())
   {
-    std::string errorMessage("Error occurred during ITK conversion");
+    std::string errorMessage = vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Error occurred during ITK conversion");
     vtkErrorMacro("ComputeHausdorffDistances: " << errorMessage);
     return errorMessage;
   }
@@ -503,19 +505,19 @@ std::string vtkSlicerSegmentComparisonModuleLogic::ComputeHausdorffDistances(vtk
     tableNode->SetUseColumnTitleAsColumnHeader(true);
     tableNode->RemoveAllColumns();
     vtkStringArray* header = vtkStringArray::SafeDownCast(tableNode->AddColumn());
-    header->SetName("Metric name");
+    header->SetName(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Metric name").c_str());
     // Add input information to the table so that they appear in the exported file
-    header->InsertNextValue("Reference segmentation");
-    header->InsertNextValue("Reference segment");
-    header->InsertNextValue("Compare segmentation");
-    header->InsertNextValue("Compare segment");
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Reference segmentation"));
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Reference segment"));
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Compare segmentation"));
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Compare segment"));
     // Hausdorff results
-    header->InsertNextValue("Maximum (mm)");
-    header->InsertNextValue("Average (mm)");
-    header->InsertNextValue("95% (mm)");
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Maximum (mm)"));
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Average (mm)"));
+    header->InsertNextValue(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "95% (mm)"));
 
     vtkStringArray* column = vtkStringArray::SafeDownCast(tableNode->AddColumn());
-    column->SetName("Metric value");
+    column->SetName(vtkMRMLTr("vtkSlicerSegmentComparisonModuleLogic", "Metric value").c_str());
 
     int row = 0;
     vtkMRMLSegmentationNode* referenceSegmentationNode = parameterNode->GetReferenceSegmentationNode();

--- a/SegmentComparison/qSlicerSegmentComparisonModule.cxx
+++ b/SegmentComparison/qSlicerSegmentComparisonModule.cxx
@@ -18,9 +18,6 @@
 
 ==============================================================================*/
 
-// Slicer includes
-#include <qSlicerCoreApplication.h>
-
 // SegmentComparison Logic includes
 #include <vtkSlicerSegmentComparisonModuleLogic.h>
 
@@ -64,21 +61,21 @@ qSlicerSegmentComparisonModule::~qSlicerSegmentComparisonModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerSegmentComparisonModule::helpText()const
 {
-  return QString("This module computes segment similarity metrics. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/SegmentComparison\">%1/Documentation/%2.%3/Modules/SegmentComparison</a><br>").arg(
-    this->slicerWikiUrl()).arg(qSlicerCoreApplication::application()->majorVersion()).arg(qSlicerCoreApplication::application()->minorVersion());
+  return tr("This module computes segment similarity metrics. "
+    "For more information see <a href=\"%1\">%1</a><br>").arg(
+    "https://github.com/SlicerRt/SlicerRT/blob/master/Docs/user_guide/modules/SegmentComparison.md");
 }
 
 //-----------------------------------------------------------------------------
 QString qSlicerSegmentComparisonModule::acknowledgementText()const
 {
-  return "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).";
+  return tr("This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
 }
 
 //-----------------------------------------------------------------------------
 QStringList qSlicerSegmentComparisonModule::categories() const
 {
-  return QStringList() << "Radiotherapy";
+  return QStringList() << tr("Radiotherapy");
 }
 
 //-----------------------------------------------------------------------------

--- a/VffFileReader/qSlicerVffFileReaderModule.cxx
+++ b/VffFileReader/qSlicerVffFileReaderModule.cxx
@@ -64,7 +64,7 @@ qSlicerVffFileReaderModule::~qSlicerVffFileReaderModule() = default;
 //-----------------------------------------------------------------------------
 QString qSlicerVffFileReaderModule::helpText()const
 {
-  QString help = QString(
+  QString help = tr(
     "The VffFileReader module enables importing and loading VFF files into Slicer.<br>"
     "The VffFileReader module is hidden and therefore does not require an application.<br>");
   return help;
@@ -73,7 +73,7 @@ QString qSlicerVffFileReaderModule::helpText()const
 //-----------------------------------------------------------------------------
 QString qSlicerVffFileReaderModule::acknowledgementText()const
 {
-  QString acknowledgement = QString(
+  QString acknowledgement = tr(
     "This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).");
   return acknowledgement;
 }

--- a/VffFileReader/qSlicerVffFileReaderPlugin.cxx
+++ b/VffFileReader/qSlicerVffFileReaderPlugin.cxx
@@ -72,7 +72,7 @@ vtkSlicerVffFileReaderLogic* qSlicerVffFileReaderPlugin::logic()const
 //-----------------------------------------------------------------------------
 QString qSlicerVffFileReaderPlugin::description()const
 {
-  return "Vff";
+  return tr("Vff");
 }
 
 //-----------------------------------------------------------------------------
@@ -84,7 +84,7 @@ qSlicerIO::IOFileType qSlicerVffFileReaderPlugin::fileType()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerVffFileReaderPlugin::extensions()const
 {
-  return QStringList() << "Vff (*.vff)";
+  return QStringList() << tr("Vff (*.vff)");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Add `tr()` (C++/Widgets) and `_()` (Python) calls to every module's UI strings, module titles, categories, help text, and error/status messages: Beams, DVH, DVH Comparison, DICOM RT/SRO Import-Export, Dose Accumulation/Comparison, External Beam Planning, Isodose, the Dosxyz/DRR/Pinnacle/VFF file readers, the Plastimatch modules, Rooms Eye View, and Segment Comparison.

This completes the internationalization support needed to generate the translated `.ts` files.