### PR TITLE
BUG: Fix ion plan checkbox disabling TOPAS and losing beams

### DIFF
--- a/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
+++ b/ExternalBeamPlanning/Resources/UI/qSlicerExternalBeamPlanningModule.ui
@@ -52,6 +52,9 @@
      </item>
      <item>
       <widget class="QCheckBox" name="checkBox_IonPlanFlag">
+       <property name="toolTip">
+        <string>Indicates that the plan uses the DICOM RT Ion Plan module. This covers both proton beams and other ion beams (e.g. carbon), so it is checked automatically for proton plans as well. Only dose engines that support ion plans (including proton-only engines) are offered below when this is checked.</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::LayoutDirection::LeftToRight</enum>
        </property>

--- a/ExternalBeamPlanning/Widgets/Python/DoseEngines/TopasDoseEngine.py
+++ b/ExternalBeamPlanning/Widgets/Python/DoseEngines/TopasDoseEngine.py
@@ -17,6 +17,7 @@ class TopasDoseEngine(AbstractScriptedDoseEngine):
   #------------------------------------------------------------------------------
   def __init__(self, scriptedEngine):
     scriptedEngine.name = 'Topas'
+    scriptedEngine.canDoIonPlan = True  # TOPAS supports proton beams, which DICOM RT Ion Plan classifies as an ion plan
     AbstractScriptedDoseEngine.__init__(self, scriptedEngine)
 
     # Define initial defaults for parameters that are stored in application settings

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -188,11 +188,12 @@ void qSlicerExternalBeamPlanningModuleWidget::onSceneImportedEvent()
 //-----------------------------------------------------------------------------
 void qSlicerExternalBeamPlanningModuleWidget::enter()
 {
-  this->onEnter();
-  this->Superclass::enter();
-
   //
-  // Register dose engines and optimizers if not already done
+  // Register dose engines and optimizers if not already done.
+  // This needs to happen before onEnter(), which populates the dose engine and plan optimizer
+  // combo boxes from the registered lists; otherwise the first time this module is entered, the
+  // combo boxes are populated before any engine has been registered and appear empty until the
+  // module is entered a second time.
   //
 
   // Inline function for determining if a dose engine is already registered by class name
@@ -258,6 +259,9 @@ void qSlicerExternalBeamPlanningModuleWidget::enter()
     "    exec(\"{0}Instance = optimizers.qSlicerScriptedPlanOptimizer(None); {0}Instance.setPythonSource({0}.__file__.replace('\\\\\\\\','/')); {0}Instance.self().register()\".format(optimizerName)) \n"
     "  except Exception: \n"
     "    logging.error(traceback.format_exc()) \n") );
+
+  this->onEnter();
+  this->Superclass::enter();
 }
 
 //-----------------------------------------------------------------------------
@@ -1060,8 +1064,15 @@ void qSlicerExternalBeamPlanningModuleWidget::ionPlanFlagCheckboxStateChanged(in
     return;
   }
 
-  // delete all beams
-  planNode->RemoveAllBeams();
+  // Only remove the beams if the ion plan flag is actually changing. This handler also runs when
+  // the checkbox is being silently synced to a plan's already-persisted flag (e.g. right after
+  // loading a plan from DICOM), in which case the existing beams must be left alone (see issue #333)
+  bool ionPlanFlagChanged = (planNode->GetIonPlanFlag() != static_cast<bool>(state));
+  if (ionPlanFlagChanged)
+  {
+    // delete all beams
+    planNode->RemoveAllBeams();
+  }
 
   // update beam parameters for ion plan
   qSlicerDoseEnginePluginHandler::DoseEngineListType engines =


### PR DESCRIPTION
- Let the TOPAS dose engine be selected for ion plans, since it already supports proton beams, and add a tooltip to the checkbox explaining that proton plans count as ion plans in DICOM
- Stop the checkbox from deleting all beams when it is merely being synced to reflect a plan that was already an ion plan on import, rather than toggled by the user
- Register dose engines and plan optimizers before refreshing their combo boxes when entering the module, so they are available on the first visit instead of only after re-entering the module

Re #331, #333