### PR TITLE
BUG: Fix beam-removal crash and follow-up orphaned range shifter issue

### DIFF
--- a/Beams/MRML/vtkMRMLRTBeamNode.cxx
+++ b/Beams/MRML/vtkMRMLRTBeamNode.cxx
@@ -392,6 +392,14 @@ vtkMRMLRTPlanNode* vtkMRMLRTBeamNode::GetParentPlanNode()
     return nullptr;
   }
 
+  // The beam may be transiently absent from the subject hierarchy (e.g. while it is being
+  // removed from the scene and a reentrant GUI refresh queries it in the meantime).
+  // Check silently first so this expected, non-error condition is not logged as one.
+  if (shNode->GetItemByDataNode(this) == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
+  {
+    return nullptr;
+  }
+
   return vtkMRMLRTPlanNode::SafeDownCast(shNode->GetParentDataNode(this));
 }
 

--- a/Beams/MRML/vtkMRMLRTIonRangeShifterNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonRangeShifterNode.cxx
@@ -244,6 +244,14 @@ void vtkMRMLRTIonRangeShifterNode::CreateRangeShifterPolyData(vtkPolyData* range
   if (!ionBeamNode)
   {
     vtkErrorMacro("CreateRangeShifterPolyData: Invalid parent ion beam node");
+    // Clear stale/never-built geometry and hide the model so an orphaned range shifter
+    // (e.g. its parent beam was removed) cannot poison 3D view auto-centering with
+    // leftover or empty-but-visible bounds.
+    rangeShifterModelPolyData->Initialize();
+    if (vtkMRMLDisplayNode* displayNode = this->GetDisplayNode())
+    {
+      displayNode->VisibilityOff();
+    }
     return;
   }
   double isoToRsDistance = ionBeamNode->GetIsocenterToRangeShifterDistance();

--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -22,6 +22,8 @@
 // Beams includes
 #include "vtkMRMLRTPlanNode.h"
 #include "vtkMRMLRTBeamNode.h"
+#include "vtkMRMLRTIonBeamNode.h"
+#include "vtkMRMLRTIonRangeShifterNode.h"
 
 // MRML includes
 #include <vtkMRMLModelNode.h>
@@ -728,6 +730,18 @@ void vtkMRMLRTPlanNode::RemoveBeam(vtkMRMLRTBeamNode* beamNode)
 
   // Fire beam added event (do it first so that operations can be performed with beam while exists)
   this->InvokeEvent(vtkMRMLRTPlanNode::BeamRemoved, (void*)beamNode->GetID());
+
+  // Remove range shifter node exclusively owned by an ion beam. Otherwise it is left behind in the
+  // scene with no parent beam, which breaks 3D view auto-centering.
+  vtkMRMLRTIonBeamNode* ionBeamNode = vtkMRMLRTIonBeamNode::SafeDownCast(beamNode);
+  if (ionBeamNode)
+  {
+    vtkMRMLRTIonRangeShifterNode* rangeShifterNode = ionBeamNode->GetRangeShifterNode();
+    if (rangeShifterNode)
+    {
+      this->GetScene()->RemoveNode(rangeShifterNode);
+    }
+  }
 
   // Remove beam node from the scene. The subject hierarchy item will automatically be removed
   this->GetScene()->RemoveNode(beamNode);

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -418,6 +418,10 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
 
   // For inverse plans
   vtkMRMLRTPlanNode* planNode = d->BeamNode->GetParentPlanNode();
+  if (!planNode)
+  {
+    return;
+  }
   bool inversePlan = planNode->GetInversePlanFlag();
 
   d->doubleSpinBox_SAD->setEnabled(!inversePlan);


### PR DESCRIPTION
- Fix a crash when removing a beam that's currently open in the Beams module: a reentrant GUI refresh (triggered by the scene removing the beam's subject hierarchy item mid-removal) queried the beam's parent plan while it was transiently unresolvable and dereferenced the null result.
- Fix a follow-up to the DICOM-import 3D view centering bug: removing a beam (e.g. via the Ion Plan checkbox, which deletes all beams when toggled) left its range shifter behind in the scene with no parent beam to compute geometry from. The orphaned stale range shifter broke the 3D view's automatic centering for the whole scene, the same way that would happen when importing the DICOM before. Beam removal now also removes its range shifter, and a range shifter that loses its parent beam clears its own geometry and hides itself instead of lingering in a broken state.

Re #332, #330
