### PR TITLE
BUG: Fix range shifter placement and 3D centering on ion plan import

### DIFF
--- a/Beams/MRML/vtkMRMLRTIonRangeShifterNode.cxx
+++ b/Beams/MRML/vtkMRMLRTIonRangeShifterNode.cxx
@@ -257,15 +257,18 @@ void vtkMRMLRTIonRangeShifterNode::CreateRangeShifterPolyData(vtkPolyData* range
   double isoToRsDistance = ionBeamNode->GetIsocenterToRangeShifterDistance();
   double wet = ionBeamNode->GetRangeShifterWET();
   const char* setting = ionBeamNode->GetRangeShifterSetting();
-  double beamAxisOffset = 0.; // in/out beam offset
-  if (setting && (!std::strcmp(setting, "OUT") || !std::strcmp(setting, "0")))
+
+  // Reflect the range shifter setting through transparency rather than by shifting the model
+  // sideways off the beam axis. The previous sideways shift pushed a retracted range shifter
+  // outside the field of view and skewed the 3D view automatic centering. The model now always
+  // stays on the beam axis; when the range shifter is retracted it is drawn nearly transparent,
+  // and when it is inserted it keeps its normal semi-transparent appearance.
+  bool rangeShifterRetracted = setting && (!std::strcmp(setting, "OUT") || !std::strcmp(setting, "0"));
+  if (vtkMRMLDisplayNode* displayNode = this->GetDisplayNode())
   {
-    beamAxisOffset = -200.; // out of the beam
+    displayNode->SetOpacity(rangeShifterRetracted ? 0.05 : 0.3);
   }
-  else if (setting && (!std::strcmp(setting, "IN") || !std::strcmp(setting, "1")))
-  {
-    beamAxisOffset = 0.; // into the beam
-  }
+
   if (isoToRsDistance <= 0.)
   {
     vtkErrorMacro("CreateRangeShifterPolyData: Invalid isocenter to range shifter distance");
@@ -275,7 +278,7 @@ void vtkMRMLRTIonRangeShifterNode::CreateRangeShifterPolyData(vtkPolyData* range
   if (wet > 0)
   {
     vtkNew< vtkCubeSource > rs;
-    rs->SetBounds( -100., 100., beamAxisOffset + -100., beamAxisOffset + 100., isoToRsDistance, isoToRsDistance + wet);
+    rs->SetBounds( -100., 100., -100., 100., isoToRsDistance, isoToRsDistance + wet);
     rs->Update();
     rangeShifterModelPolyData->DeepCopy(rs->GetOutput());
   }
@@ -284,10 +287,10 @@ void vtkMRMLRTIonRangeShifterNode::CreateRangeShifterPolyData(vtkPolyData* range
     vtkNew<vtkPoints> points;
     vtkNew<vtkCellArray> cellArray;
 
-    points->InsertPoint( 0, -100., beamAxisOffset + -100., isoToRsDistance);
-    points->InsertPoint( 1, -100., beamAxisOffset + 100., isoToRsDistance);
-    points->InsertPoint( 2, 100., beamAxisOffset + 100., isoToRsDistance);
-    points->InsertPoint( 3, 100., beamAxisOffset + -100., isoToRsDistance);
+    points->InsertPoint( 0, -100., -100., isoToRsDistance);
+    points->InsertPoint( 1, -100., 100., isoToRsDistance);
+    points->InsertPoint( 2, 100., 100., isoToRsDistance);
+    points->InsertPoint( 3, 100., -100., isoToRsDistance);
 
     cellArray->InsertNextCell(4);
     cellArray->InsertCellPoint(0);

--- a/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
+++ b/DicomRtImportExport/Logic/vtkSlicerDicomRtImportExportModuleLogic.cxx
@@ -1372,17 +1372,12 @@ bool vtkSlicerDicomRtImportExportModuleLogic::vtkInternal::LoadDynamicBeamSequen
           isocenter = rtReader->GetBeamControlPointIsocenterPositionRas(dicomBeamNumber, 0);
         }
 
-        // Update beam transform without translation to isocenter
+        // Update beam transform. This already places the beam at the isocenter, because the
+        // isocenter translation is applied inside the IEC transform chain. Do not translate
+        // again here, otherwise the beam and its range shifter end up at twice the isocenter
+        // offset, far from the patient.
         beamsLogic->UpdateTransformForBeam(beamSequenceNode->GetSequenceScene(), beamNode, transformNode, isocenter);
 
-        vtkTransform* transform = vtkTransform::SafeDownCast(transformNode->GetTransformToParent());
-        if (isocenter)
-        {
-          // Actual translation to isocenter
-          transform->Translate(isocenter[0], isocenter[1], isocenter[2]);
-          transformNode->Modified();
-        }
-    
         transformSequenceNode->SetDataNodeAtValue(transformNode, std::to_string(controlPointIndex));
       }
     }


### PR DESCRIPTION
Two problems left imported proton plans with their range shifters in the wrong place and the 3D view unable to center on the patient:

First, the dynamic beam sequence import applied the isocenter translation twice: once while updating the beam transform and again explicitly afterward. This placed every imported beam and its range shifter at twice the isocenter offset, more than a metre from the patient. The redundant second translation has been removed so imported beams and range shifters sit at their correct location.

Second, a retracted range shifter was drawn shifted sideways off the beam axis, which pushed it outside the field of view and further skewed the automatic centering. The range shifter model now always stays on the beam axis, and whether it is retracted or inserted is conveyed through its transparency rather than it being moved out of position.

Re #330