### PR TITLE
Fix ion plan checkbox destroying beams and enable proton engine for ion plans

### DIFF
--- a/Beams/MRML/CMakeLists.txt
+++ b/Beams/MRML/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${Slicer_Base_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
   ${vtkSlicerSegmentationsModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerSequencesModuleMRML_INCLUDE_DIRS}
   )
 
 # --------------------------------------------------------------------------
@@ -31,6 +32,7 @@ SET (${KIT}_INCLUDE_DIRS
   ${vtkSlicerSegmentationsModuleLogic_INCLUDE_DIRS}
   ${Slicer_Base_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
+  ${vtkSlicerSequencesModuleMRML_INCLUDE_DIRS}
   CACHE INTERNAL "" FORCE)
 
 # --------------------------------------------------------------------------
@@ -43,6 +45,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicerSegmentationsModuleLogic
   MRMLCore
   vtkSlicerMarkupsModuleMRML
+  vtkSlicerSequencesModuleMRML
   )
 
 SlicerMacroBuildModuleMRML(

--- a/Beams/MRML/vtkMRMLRTPlanNode.cxx
+++ b/Beams/MRML/vtkMRMLRTPlanNode.cxx
@@ -35,6 +35,10 @@
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLTableNode.h>
 
+// Sequences includes
+#include <vtkMRMLSequenceBrowserNode.h>
+#include <vtkMRMLSequenceNode.h>
+
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkDataArray.h>
@@ -731,13 +735,16 @@ void vtkMRMLRTPlanNode::RemoveBeam(vtkMRMLRTBeamNode* beamNode)
   // Fire beam added event (do it first so that operations can be performed with beam while exists)
   this->InvokeEvent(vtkMRMLRTPlanNode::BeamRemoved, (void*)beamNode->GetID());
 
+  // Discard the animation this beam belongs to, if any, before the beam itself goes away
+  this->RemoveSequencesForBeam(beamNode);
+
   // Remove range shifter node exclusively owned by an ion beam. Otherwise it is left behind in the
   // scene with no parent beam, which breaks 3D view auto-centering.
   vtkMRMLRTIonBeamNode* ionBeamNode = vtkMRMLRTIonBeamNode::SafeDownCast(beamNode);
   if (ionBeamNode)
   {
     vtkMRMLRTIonRangeShifterNode* rangeShifterNode = ionBeamNode->GetRangeShifterNode();
-    if (rangeShifterNode)
+    if (rangeShifterNode && this->GetScene()->IsNodePresent(rangeShifterNode))
     {
       this->GetScene()->RemoveNode(rangeShifterNode);
     }
@@ -747,6 +754,66 @@ void vtkMRMLRTPlanNode::RemoveBeam(vtkMRMLRTBeamNode* beamNode)
   this->GetScene()->RemoveNode(beamNode);
 
   this->Modified();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLRTPlanNode::RemoveSequencesForBeam(vtkMRMLRTBeamNode* beamNode)
+{
+  vtkMRMLScene* scene = this->GetScene();
+  if (!scene || !beamNode || !beamNode->GetID())
+  {
+    return;
+  }
+
+  // A beam loaded from a DICOM dynamic beam sequence is the proxy node of a sequence browser, which
+  // also drives the beam transform, the leaf position or scan spot table, and the range shifter.
+  // Removing only the beam leaves the browser behind, and the sequences module then re-creates the
+  // missing proxy at the top level of the scene, outside of any plan, so the beam appears to come
+  // back from the dead as a stray item. Take the whole animation with it instead
+  std::vector<vtkMRMLNode*> candidateBrowserNodes;
+  scene->GetNodesByClass("vtkMRMLSequenceBrowserNode", candidateBrowserNodes);
+
+  vtkSmartPointer<vtkMRMLSequenceBrowserNode> browserNode;
+  for (vtkMRMLNode* node : candidateBrowserNodes)
+  {
+    vtkMRMLSequenceBrowserNode* currentBrowserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(node);
+    if (currentBrowserNode && currentBrowserNode->IsProxyNodeID(beamNode->GetID()))
+    {
+      browserNode = currentBrowserNode;
+      break;
+    }
+  }
+  if (!browserNode)
+  {
+    // Static beam, nothing else to clean up
+    return;
+  }
+
+  std::vector<vtkMRMLNode*> proxyNodes;
+  browserNode->GetAllProxyNodes(proxyNodes);
+  std::vector<vtkMRMLSequenceNode*> sequenceNodes;
+  browserNode->GetSynchronizedSequenceNodes(sequenceNodes, true);
+
+  // Remove the browser first so that it cannot restore any proxy while the rest is being removed
+  scene->RemoveNode(browserNode);
+
+  for (vtkMRMLSequenceNode* sequenceNode : sequenceNodes)
+  {
+    if (sequenceNode)
+    {
+      scene->RemoveNode(sequenceNode);
+    }
+  }
+
+  // The remaining proxies belong to the beam and are meaningless without it. The beam itself is left
+  // for the caller to remove, so that the events it still needs to fire happen in the right order.
+  for (vtkMRMLNode* proxyNode : proxyNodes)
+  {
+    if (proxyNode && proxyNode != beamNode)
+    {
+      scene->RemoveNode(proxyNode);
+    }
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Beams/MRML/vtkMRMLRTPlanNode.h
+++ b/Beams/MRML/vtkMRMLRTPlanNode.h
@@ -249,6 +249,11 @@ protected:
   /// Create default plan POIs markups node
   vtkMRMLMarkupsFiducialNode* CreateMarkupsFiducialNode();
 
+  /// Remove the sequence browser and the sequences that animate the given beam, along with the other
+  /// proxy nodes they drive. Does nothing for a beam that is not part of a sequence. The beam itself
+  /// is not removed. \sa RemoveBeam
+  void RemoveSequencesForBeam(vtkMRMLRTBeamNode* beam);
+
 protected:
   vtkMRMLRTPlanNode();
   ~vtkMRMLRTPlanNode();

--- a/Beams/qSlicerBeamsModule.cxx
+++ b/Beams/qSlicerBeamsModule.cxx
@@ -75,7 +75,7 @@ qSlicerBeamsModule::~qSlicerBeamsModule() = default;
 //-----------------------------------------------------------------------------
 QStringList qSlicerBeamsModule::dependencies()const
 {
-  return QStringList() << "Models" << "Segmentations";
+  return QStringList() << "Models" << "Segmentations" << "Sequences";
 }
 
 //-----------------------------------------------------------------------------

--- a/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
+++ b/ExternalBeamPlanning/Widgets/qSlicerAbstractDoseEngine.cxx
@@ -857,5 +857,8 @@ void qSlicerAbstractDoseEngine::setDoseEngineTypeToBeam(vtkMRMLRTBeamNode* beamN
 //-----------------------------------------------------------------------------
 void  qSlicerAbstractDoseEngine::updateBeamParametersForIonPlan(bool isIonPlanActive)
 {
-  qCritical() << Q_FUNC_INFO << ": updateBeamParamtersForIonPlan not implemented";
+  Q_UNUSED(isIonPlanActive);
+  // Nothing to do by default. Only an engine whose beam parameters differ between ion and
+  // conventional plans needs to react to this, and an engine that offers the same parameters
+  // either way is not doing anything wrong by ignoring it
 }

--- a/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
+++ b/ExternalBeamPlanning/qSlicerExternalBeamPlanningModuleWidget.cxx
@@ -78,6 +78,7 @@
 #include <QTime>
 #include <QItemSelection>
 #include <QMessageBox>
+#include <QSignalBlocker>
 #include <QDir>
 
 // PythonQt includes
@@ -479,8 +480,10 @@ void qSlicerExternalBeamPlanningModuleWidget::updateWidgetFromMRML()
     return;
   }
 
-  // Plan parameters section
-  d->checkBox_IonPlanFlag->setChecked(planNode->GetIonPlanFlag());
+  // Plan parameters section. The check state is assigned rather than the boolean so that the state
+  // the checkbox reports to the outside world stays correct even when this runs while a click on it
+  // is still being handled, which happens whenever changing the flag modifies the plan
+  d->checkBox_IonPlanFlag->setCheckState(planNode->GetIonPlanFlag() ? Qt::Checked : Qt::Unchecked);
 
   // None is enabled for the reference volume and segmentation comboboxes, and invalid selection
   // in plan node is set to GUI so that the user needs to select nodes that are then set to the beams.
@@ -1089,6 +1092,29 @@ void qSlicerExternalBeamPlanningModuleWidget::ionPlanFlagCheckboxStateChanged(in
   bool ionPlanFlagChanged = (planNode->GetIonPlanFlag() != static_cast<bool>(state));
   if (ionPlanFlagChanged)
   {
+    // Deleting every beam in the plan is not something the user can undo, and the checkbox is easy
+    // to hit by accident, so ask for confirmation whenever there is anything to lose
+    if (planNode->GetNumberOfBeams() > 0)
+    {
+      QString message = tr("Ion beams and conventional beams are different types of object that cannot be "
+        "converted into one another, so changing this option deletes every beam currently in plan '%1'.\n\n"
+        "Do you want to continue?").arg(planNode->GetName());
+      QMessageBox::StandardButton answer = QMessageBox::question(
+        this, tr("Delete all beams in the plan?"), message,
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+      if (answer != QMessageBox::Yes)
+      {
+        // Put the checkbox back the way it was without running this handler again. The check state
+        // has to be assigned rather than the boolean, because a checkbox only refreshes the state it
+        // reports to the outside world when it is not in the middle of handling a click. Assigning
+        // the boolean from here would leave it remembering the state the user just tried to set, and
+        // the next click would then look like no change at all and be silently swallowed
+        const QSignalBlocker blocker(d->checkBox_IonPlanFlag);
+        d->checkBox_IonPlanFlag->setCheckState(planNode->GetIonPlanFlag() ? Qt::Checked : Qt::Unchecked);
+        return;
+      }
+    }
+
     // delete all beams
     planNode->RemoveAllBeams();
   }

--- a/PlmProtonDoseEngine/DoseEngines/qSlicerPlmProtonDoseEngine.cxx
+++ b/PlmProtonDoseEngine/DoseEngines/qSlicerPlmProtonDoseEngine.cxx
@@ -62,6 +62,7 @@ qSlicerPlmProtonDoseEngine::qSlicerPlmProtonDoseEngine(QObject* parent)
   : qSlicerAbstractDoseEngine(parent)
 {
   this->m_Name = QString("Plastimatch proton");
+  this->m_CanDoIonPlan = true;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
First, this adds a confirm before the ion plan checkbox deletes beams:

Switching a plan between ion and conventional deletes every beam it contains, because the two kinds of beam are different types of object that cannot be converted into one another. Previously this happened silently and could not be undone, on a checkbox that is easy to hit by accident, and unchecking it on an imported plan scattered stray sequence items across the scene.

- The user is now asked to confirm whenever the change would discard beams. Declining leaves both the plan and the checkbox as they were.
- Removing a beam that was loaded from a DICOM dynamic beam sequence now also removes the sequence browser and sequences that drive it. Before, only the beam was removed, so the sequences module recreated it at the top of the scene, outside of any plan, once per dynamic beam. This covers every way of deleting a beam, not only the checkbox.

Second, keeps the Plastimatch proton engine available for ion plans:

Turning on the ion plan option removed the proton dose engine from the list of choices. It is now offered for ion plans as well.

The hook that lets an engine adjust its beam parameters when the ion plan option changes previously logged an error for any engine that did not implement it; it is now a silent no-op, since only engines with plan-dependent parameters need to react.

Re #331, #333