### PR TITLE
BUG: Fix multi leaf collimator workflow in beam parameters

### DIFF
--- a/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
+++ b/Beams/Logic/vtkSlicerMLCPositionLogic.cxx
@@ -91,6 +91,8 @@ namespace
 
 const char* MLCX_BOUNDARYANDPOSITION = "MLCX_BoundaryAndPosition";
 const char* MLCY_BOUNDARYANDPOSITION = "MLCY_BoundaryAndPosition";
+// Position given to both leaves of a pair that is shut, as used for a newly generated table
+const double MLC_LEAF_CLOSED_POSITION = -20.0;
 
 } // namespace
 
@@ -248,12 +250,21 @@ vtkMRMLMarkupsCurveNode* vtkSlicerMLCPositionLogic::CalculatePositionConvexHullC
     }
 
     delete [] xyCoordinates;
+
+    // The curve is a by-product of the leaf position calculation rather than something to
+    // look at or edit, so it is created hidden. It stays under the beam in the subject
+    // hierarchy, where it can be switched visible to inspect the computed opening.
+    curveNode->CreateDefaultDisplayNodes();
+    curveNode->SetDisplayVisibility(0);
+
     return curveNode.GetPointer();
   }
   else
   {
+    // Taking the node out of the scene releases the reference the scene held. The one held
+    // here is released on the way out of this function, so it must not be released by hand
+    // as well, which would free the node twice.
     this->GetMRMLScene()->RemoveNode(curveNode);
-    curveNode->Delete();
     return nullptr;
   }
 }
@@ -446,15 +457,11 @@ bool vtkSlicerMLCPositionLogic::CalculateMultiLeafCollimatorPosition( vtkMRMLTab
     return false;
   }
 
-  size_t nofLeafPairs = 0;
-  if (mlcTableNode)
-  {
-    nofLeafPairs = mlcTableNode->GetNumberOfRows() - 1;
-    if (nofLeafPairs <= 0)
-    {
-      nofLeafPairs = 0;
-    }
-  }
+  // A table holds one boundary value more than it has leaf pairs. Subtracting that one before
+  // checking the count would turn an empty table into a huge number of pairs rather than none,
+  // since the count is kept in a value that cannot go negative.
+  vtkIdType nofRows = mlcTableNode->GetNumberOfRows();
+  size_t nofLeafPairs = (nofRows > 1) ? static_cast<size_t>(nofRows - 1) : 0;
 
   double curveBounds[4] = {};
   if (!nofLeafPairs || !CalculateCurveBoundary(curveNode, curveBounds))
@@ -464,6 +471,16 @@ bool vtkSlicerMLCPositionLogic::CalculateMultiLeafCollimatorPosition( vtkMRMLTab
   }
 
   vtkTable* mlcTable = mlcTableNode->GetTable();
+
+  // Close every leaf pair before opening the ones the new outline calls for. Only the pairs
+  // covering the outline are given positions below, so pairs opened for an outline calculated
+  // earlier would otherwise stay open and the opening would end up covering the old target
+  // and the new one together instead of just the target currently selected.
+  for (size_t leafPair = 0; leafPair < nofLeafPairs; ++leafPair)
+  {
+    mlcTable->SetValue(leafPair, 1, MLC_LEAF_CLOSED_POSITION);
+    mlcTable->SetValue(leafPair, 2, MLC_LEAF_CLOSED_POSITION);
+  }
 
   int leafPairStart = -1, leafPairEnd = -1;
   FindLeafPairRangeIndexes(curveBounds, mlcTable, leafPairStart, leafPairEnd);

--- a/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
+++ b/Beams/Widgets/qMRMLBeamParametersTabWidget.cxx
@@ -243,22 +243,22 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
     d->CoordinatesWidget_Isocenter->setEnabled(false);
   }
 
-  // Check for MLC table and enable combo box
-  if (vtkMRMLTableNode* mlcTable = d->BeamNode->GetMultiLeafCollimatorTableNode())
+  // The parameters tab widget is a plain tab container and never gets a scene of its own, so
+  // the leaf collimator table selector has to be handed the beam's scene here. It has to be
+  // filled even when the beam has no table yet, otherwise a table can never be picked for such
+  // a beam. Read the beam's current table before touching the selector: handing it a scene
+  // refills it and makes it report the empty entry as the selected one, which the selection
+  // handler would write straight back into the beam and drop an already assigned table.
+  vtkMRMLTableNode* mlcTable = d->BeamNode->GetMultiLeafCollimatorTableNode();
   {
-    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setMRMLScene(mlcTable->GetScene());
+    const QSignalBlocker blocker(d->MRMLNodeComboBox_MLCBoundaryAndPositionTable);
+    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setMRMLScene(d->BeamNode->GetScene());
     d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setCurrentNode(mlcTable);
-    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setEnabled(true);
-    d->pushButton_UpdateMLCBoundary->setEnabled(true);
-    d->doubleSpinBox_DistanceMLC->setEnabled(true);
   }
-  else
-  {
-    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setCurrentNode(nullptr);
-    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setEnabled(false);
-    d->pushButton_UpdateMLCBoundary->setEnabled(false);
-    d->doubleSpinBox_DistanceMLC->setEnabled(false);
-  }
+  d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setEnabled(true);
+  d->pushButton_UpdateMLCBoundary->setEnabled(mlcTable != nullptr);
+  d->pushButton_CalculateMLCPosition->setEnabled(mlcTable != nullptr);
+  d->doubleSpinBox_DistanceMLC->setEnabled(mlcTable != nullptr);
 
   // Update engine-specific values
   foreach (QWidget* tabWidget, d->BeamParametersTabWidgets)
@@ -357,17 +357,12 @@ void qMRMLBeamParametersTabWidget::updateWidgetFromMRML()
     connect( d->doubleSpinBox_VSADx, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisXDistanceChanged(double)), Qt::UniqueConnection );
     connect( d->doubleSpinBox_VSADy, SIGNAL(valueChanged(double)), this, SLOT(virtualSourceAxisYDistanceChanged(double)), Qt::UniqueConnection );
 
-    // Check for ScanSpot table and enable combo box
-    if (vtkMRMLTableNode* scanspotTable = ionBeamNode->GetScanSpotTableNode())
-    {
-      d->MRMLNodeComboBox_ScanSpotParametersTable->setMRMLScene(scanspotTable->GetScene());
-      d->MRMLNodeComboBox_ScanSpotParametersTable->setCurrentNode(scanspotTable);
-    }
-    else
-    {
-      d->MRMLNodeComboBox_ScanSpotParametersTable->setCurrentNode(nullptr);
-      d->MRMLNodeComboBox_ScanSpotParametersTable->setEnabled(false);
-    }
+    // Same as the MLC table selector above: the scan spot selector needs the beam's scene
+    // before a scan spot table exists, otherwise none can ever be selected. The has-a-table
+    // branch also never enabled the combo box, so it stayed disabled even for imported plans.
+    d->MRMLNodeComboBox_ScanSpotParametersTable->setMRMLScene(ionBeamNode->GetScene());
+    d->MRMLNodeComboBox_ScanSpotParametersTable->setEnabled(true);
+    d->MRMLNodeComboBox_ScanSpotParametersTable->setCurrentNode(ionBeamNode->GetScanSpotTableNode());
 
     // rename some labels
     d->label_DistanceMLC->setText(tr("Isocenter to MLC distance (mm):"));
@@ -892,9 +887,6 @@ void qMRMLBeamParametersTabWidget::mlcBoundaryAndPositionTableNodeChanged(vtkMRM
 {
   Q_D(qMRMLBeamParametersTabWidget);
 
-  d->pushButton_UpdateMLCBoundary->setEnabled(node);
-  d->pushButton_CalculateMLCPosition->setEnabled(node);
-
   if (!d->MLCPositionLogic)
   {
     qCritical() << Q_FUNC_INFO << ": MLC position calculation logic is invalid!";
@@ -915,7 +907,9 @@ void qMRMLBeamParametersTabWidget::mlcBoundaryAndPositionTableNodeChanged(vtkMRM
   {
     d->BeamNode->SetAndObserveMultiLeafCollimatorTableNode(nullptr);
   }
-  d->BeamNode->UpdateGeometry();
+
+  // Assigning the table announces a geometry change on the beam, which rebuilds the beam model
+  // and refreshes this tab, so neither has to be triggered here.
 
   // GCS FIX TODO *** Come back to this later ***
   Q_UNUSED(node);
@@ -963,6 +957,12 @@ void qMRMLBeamParametersTabWidget::generateMLCboundaryClicked()
     return;
   }
 
+  if (!d->BeamNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": No current beam node!";
+    return;
+  }
+
   bool mlcType = d->radioButton_MLCX->isChecked();
   int nofPairs = static_cast<int>(d->SliderWidget_NumberOfLeafPairs->value());
   double leafPairSize = d->SliderWidget_LeafPairBoundarySize->value();
@@ -970,23 +970,31 @@ void qMRMLBeamParametersTabWidget::generateMLCboundaryClicked()
 
   vtkMRMLTableNode* mlcTable = d->MLCPositionLogic->CreateMultiLeafCollimatorTableNodeBoundaryData(
     mlcType, nofPairs, leafPairSize, offset);
-  if (mlcTable)
-  {
-    const char* beamName = d->BeamNode->GetName();
-    const char* mlcName = mlcTable->GetName();
-    std::string newName = std::string(mlcName) + ": " + beamName;
-    mlcTable->SetName(newName.c_str());
-    // enable MRML combobox if it was disabled
-    d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->setEnabled(true);
-  }
-  else
+  if (!mlcTable)
   {
     qCritical() << Q_FUNC_INFO << ": Unable to create MLC boundary data table!";
+    return;
   }
+
+  const char* beamName = d->BeamNode->GetName();
+  const char* mlcName = mlcTable->GetName();
+  std::string newName = std::string(mlcName) + ": " + beamName;
+  mlcTable->SetName(newName.c_str());
+
+  // Project the leaf boundaries onto the isocenter plane before the table is handed to the
+  // beam. The projection writes into the underlying table without announcing a change, so a
+  // beam built beforehand would keep showing the unprojected boundaries.
   if (!d->checkBox_ParallelBeam->isChecked())
   {
     d->MLCPositionLogic->CalculateLeavesProjection( d->BeamNode, mlcTable);
   }
+
+  // Assign the table to the beam directly rather than by driving the selector, which only
+  // works once the selector has a scene and quietly does nothing before that. Assigning it
+  // announces a change on the beam, which rebuilds the beam model and refreshes this tab,
+  // selector and buttons included.
+  d->BeamNode->SetAndObserveMultiLeafCollimatorTableNode(mlcTable);
+  d->MLCPositionLogic->SetParentForMultiLeafCollimatorTableNode(d->BeamNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1007,19 +1015,39 @@ void qMRMLBeamParametersTabWidget::updateMLCboundaryClicked()
 
   vtkMRMLNode* node = d->MRMLNodeComboBox_MLCBoundaryAndPositionTable->currentNode();
   vtkMRMLTableNode* mlcTableNode = vtkMRMLTableNode::SafeDownCast(node);
-  if (mlcTableNode)
-  {
-    d->MLCPositionLogic->UpdateMultiLeafCollimatorTableNodeBoundaryData( mlcTableNode,
-    mlcType, nofPairs, leafPairSize, offset);
-  }
-  else
+  if (!mlcTableNode)
   {
     qCritical() << Q_FUNC_INFO << ": Unable to update MLC boundary data table!";
+    return;
   }
+
+  // Gather the whole edit into a single change announcement. Renaming the node on its own
+  // would otherwise announce the table while the boundaries are still unprojected, rebuilding
+  // the beam twice and once from half-finished data.
+  int wasModifying = mlcTableNode->StartModify();
+
+  d->MLCPositionLogic->UpdateMultiLeafCollimatorTableNodeBoundaryData( mlcTableNode,
+    mlcType, nofPairs, leafPairSize, offset);
+
+  // The update resets the node name to the bare table type, which strips the beam name that
+  // was appended to it when the table was generated. Put it back.
+  if (d->BeamNode)
+  {
+    const char* beamName = d->BeamNode->GetName();
+    const char* mlcName = mlcTableNode->GetName();
+    std::string newName = std::string(mlcName) + ": " + beamName;
+    mlcTableNode->SetName(newName.c_str());
+  }
+
   if (!d->checkBox_ParallelBeam->isChecked())
   {
     d->MLCPositionLogic->CalculateLeavesProjection( d->BeamNode, mlcTableNode);
   }
+
+  // The boundary values are written straight into the underlying table, which does not
+  // announce a change by itself, so the beam would stay built from the old boundaries.
+  mlcTableNode->Modified();
+  mlcTableNode->EndModify(wasModifying);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The table selector was only given a scene when the beam already had a table and was left disabled otherwise, so a beam without one had a selector that could never be used. Generating a table then created it in the scene but could not select it, leaving it unattached to the beam, and the buttons acting on it stayed greyed out. The selector is now filled for every beam, a generated table is attached to the beam directly rather than through the selection, and the buttons follow the table the beam actually carries. Updating the boundaries of an existing table announces the change as one edit, so the beam model is rebuilt from the finished values instead of keeping its old shape. The scan spot selector had the same defect and is fixed the same way.

When the leaf positions were calculated, only the pairs covering the calculated outline were given positions, so pairs opened for a target selected earlier stayed open and the opening covered the old target and the new one together. Every pair is now closed before the ones the new outline needs are opened, and the pair count is derived so a table without rows yields no pairs rather than a huge number.

The closed curve holding the calculated opening is created hidden, being a by-product of the calculation rather than something to look at, and it is no longer released by hand after being taken out of the scene, which freed it twice when the target collapsed to a line or a point.